### PR TITLE
feat(inngest): Phase 2 — migrate all scripts to dynamic imports (#155)

### DIFF
--- a/src/inngest/functions/single-script.ts
+++ b/src/inngest/functions/single-script.ts
@@ -34,26 +34,3 @@ export function createSyncFunction(
     }
   );
 }
-
-/**
- * Factory for scripts not yet migrated to direct imports.
- * Immediately marks the job as FAILED with a helpful message.
- */
-export function createStubFunction(scriptId: string) {
-  return inngest.createFunction(
-    {
-      id: `script/${scriptId}`,
-      retries: 0,
-    },
-    { event: `sync/${scriptId}` },
-    async ({ event }) => {
-      const jobId = event.data.jobId as string | undefined;
-      if (jobId) {
-        await markJobFailed(
-          jobId,
-          `"${scriptId}" pas encore disponible via Inngest. Utiliser la CLI locale.`
-        );
-      }
-    }
-  );
-}

--- a/src/services/sync/birthdates.ts
+++ b/src/services/sync/birthdates.ts
@@ -1,0 +1,113 @@
+/**
+ * Service to enrich politicians with birth/death dates from Wikidata.
+ * Extracted from scripts/sync-birthdates.ts for Inngest compatibility.
+ */
+
+import { WikidataService } from "@/lib/api";
+import { db } from "@/lib/db";
+import { DataSource } from "@/generated/prisma";
+import { WIKIDATA_RATE_LIMIT_MS } from "@/config/rate-limits";
+
+export interface BirthdatesSyncResult {
+  processed: number;
+  birthDatesAdded: number;
+  deathDatesAdded: number;
+  noDateInWikidata: number;
+  errors: string[];
+}
+
+export async function syncBirthdates(options?: { limit?: number }): Promise<BirthdatesSyncResult> {
+  const { limit } = options ?? {};
+  const wikidata = new WikidataService({ rateLimitMs: WIKIDATA_RATE_LIMIT_MS });
+
+  const stats: BirthdatesSyncResult = {
+    processed: 0,
+    birthDatesAdded: 0,
+    deathDatesAdded: 0,
+    noDateInWikidata: 0,
+    errors: [],
+  };
+
+  // Get politicians with Wikidata ID but no birth date
+  console.log("Fetching politicians from database...");
+
+  const politicians = await db.politician.findMany({
+    where: {
+      birthDate: null,
+      externalIds: {
+        some: { source: DataSource.WIKIDATA },
+      },
+    },
+    select: {
+      id: true,
+      fullName: true,
+      deathDate: true,
+      externalIds: {
+        where: { source: DataSource.WIKIDATA },
+        select: { externalId: true },
+      },
+    },
+    take: limit,
+    orderBy: { lastName: "asc" },
+  });
+
+  console.log(`Found ${politicians.length} politicians to process`);
+
+  if (politicians.length === 0) {
+    return stats;
+  }
+
+  // Build map of Wikidata ID -> politician
+  const wikidataIdMap = new Map<string, (typeof politicians)[0]>();
+  const wikidataIds: string[] = [];
+
+  for (const politician of politicians) {
+    const wikidataId = politician.externalIds[0]?.externalId;
+    if (wikidataId) {
+      wikidataIdMap.set(wikidataId, politician);
+      wikidataIds.push(wikidataId);
+    }
+  }
+
+  // Fetch life dates using the unified service (handles batching internally)
+  console.log(`Fetching dates for ${wikidataIds.length} entities...`);
+  const lifeDates = await wikidata.getLifeDates(wikidataIds);
+
+  console.log("Updating database...");
+
+  // Update politicians
+  for (const [wikidataId, dates] of Array.from(lifeDates.entries())) {
+    const politician = wikidataIdMap.get(wikidataId);
+    if (!politician) continue;
+
+    stats.processed++;
+
+    if (!dates.birthDate) {
+      stats.noDateInWikidata++;
+      continue;
+    }
+
+    try {
+      const updateData: { birthDate: Date; deathDate?: Date } = {
+        birthDate: dates.birthDate,
+      };
+      if (dates.deathDate && !politician.deathDate) {
+        updateData.deathDate = dates.deathDate;
+      }
+
+      await db.politician.update({
+        where: { id: politician.id },
+        data: updateData,
+      });
+
+      stats.birthDatesAdded++;
+      if (dates.deathDate && !politician.deathDate) {
+        stats.deathDatesAdded++;
+      }
+    } catch (error) {
+      stats.errors.push(`${politician.fullName}: ${error}`);
+    }
+  }
+
+  return stats;
+}

--- a/src/services/sync/careers.ts
+++ b/src/services/sync/careers.ts
@@ -1,0 +1,525 @@
+/**
+ * Service to enrich politician careers from Wikidata.
+ * 3 phases: P39 positions, P488 chairpersons, P112 founders.
+ * Extracted from scripts/sync-careers.ts for Inngest compatibility.
+ *
+ * NOTE: CheckpointManager and resume logic are CLI-only concerns.
+ */
+
+import { WikidataService } from "@/lib/api";
+import { parseDate } from "@/lib/parsing";
+import { db } from "@/lib/db";
+import { MandateType, DataSource, PartyRole } from "@/generated/prisma";
+import { setCurrentParty, setPartyRole } from "@/services/politician";
+import { WIKIDATA_SPARQL_RATE_LIMIT_MS } from "@/config/rate-limits";
+
+export interface CareersSyncResult {
+  processed: number;
+  mandatesCreated: number;
+  mandatesSkipped: number;
+  partyPresidentsCreated: number;
+  foundersCreated: number;
+  errors: string[];
+}
+
+// Mapping from Wikidata position IDs to our MandateType
+const POSITION_MAPPING: Record<string, { type: MandateType; institution: string }> = {
+  // National level - President & Government
+  Q30461: {
+    type: MandateType.PRESIDENT_REPUBLIQUE,
+    institution: "Présidence de la République",
+  },
+  Q1587677: { type: MandateType.PREMIER_MINISTRE, institution: "Gouvernement" },
+  Q83307: { type: MandateType.MINISTRE, institution: "Gouvernement" },
+  Q814694: { type: MandateType.MINISTRE_DELEGUE, institution: "Gouvernement" },
+  Q26261727: {
+    type: MandateType.SECRETAIRE_ETAT,
+    institution: "Gouvernement",
+  },
+
+  // Deputies
+  Q3044918: { type: MandateType.DEPUTE, institution: "Assemblée nationale" },
+  Q21032547: { type: MandateType.DEPUTE, institution: "Assemblée nationale" },
+  Q18941264: { type: MandateType.DEPUTE, institution: "Assemblée nationale" },
+  Q55648587: { type: MandateType.DEPUTE, institution: "Assemblée nationale" },
+  Q104728949: { type: MandateType.DEPUTE, institution: "Assemblée nationale" },
+
+  // Senators
+  Q3044923: { type: MandateType.SENATEUR, institution: "Sénat" },
+  Q18558628: { type: MandateType.SENATEUR, institution: "Sénat" },
+  Q14828018: { type: MandateType.SENATEUR, institution: "Sénat" },
+
+  // European Parliament
+  Q27169: {
+    type: MandateType.DEPUTE_EUROPEEN,
+    institution: "Parlement européen",
+  },
+  Q2824658: {
+    type: MandateType.DEPUTE_EUROPEEN,
+    institution: "Parlement européen",
+  },
+
+  // Local level
+  Q30185: { type: MandateType.MAIRE, institution: "Mairie" },
+  Q382617: { type: MandateType.ADJOINT_MAIRE, institution: "Mairie" },
+  Q19546: {
+    type: MandateType.PRESIDENT_REGION,
+    institution: "Conseil régional",
+  },
+  Q1805817: {
+    type: MandateType.PRESIDENT_DEPARTEMENT,
+    institution: "Conseil départemental",
+  },
+  Q1162444: {
+    type: MandateType.CONSEILLER_REGIONAL,
+    institution: "Conseil régional",
+  },
+  Q21032554: {
+    type: MandateType.CONSEILLER_DEPARTEMENTAL,
+    institution: "Conseil départemental",
+  },
+  Q3780304: {
+    type: MandateType.CONSEILLER_DEPARTEMENTAL,
+    institution: "Conseil général",
+  },
+  Q17519573: {
+    type: MandateType.CONSEILLER_MUNICIPAL,
+    institution: "Conseil municipal",
+  },
+};
+
+// Role positions (president/VP of chamber) — update role on existing mandate
+const ROLE_POSITIONS: Record<string, { mandateType: MandateType; role: string }> = {
+  Q2824697: {
+    mandateType: MandateType.DEPUTE,
+    role: "Président de l'Assemblée nationale",
+  },
+  Q42512885: {
+    mandateType: MandateType.SENATEUR,
+    role: "Président du Sénat",
+  },
+  Q19600701: {
+    mandateType: MandateType.DEPUTE,
+    role: "Vice-président de l'Assemblée nationale",
+  },
+  Q56055912: {
+    mandateType: MandateType.SENATEUR,
+    role: "Vice-président du Sénat",
+  },
+};
+
+export async function syncCareers(options?: {
+  limit?: number;
+  foundersOnly?: boolean;
+}): Promise<CareersSyncResult> {
+  const { limit, foundersOnly = false } = options ?? {};
+
+  const wikidata = new WikidataService({
+    rateLimitMs: WIKIDATA_SPARQL_RATE_LIMIT_MS,
+  });
+
+  const stats: CareersSyncResult = {
+    processed: 0,
+    mandatesCreated: 0,
+    mandatesSkipped: 0,
+    partyPresidentsCreated: 0,
+    foundersCreated: 0,
+    errors: [],
+  };
+
+  // ========================================
+  // Phase 1: P39 positions
+  // ========================================
+  if (!foundersOnly) {
+    console.log("--- Phase 1: P39 positions ---");
+    console.log("Fetching politicians with Wikidata IDs...");
+
+    const externalIds = await db.externalId.findMany({
+      where: {
+        source: DataSource.WIKIDATA,
+        politicianId: { not: null },
+      },
+      include: {
+        politician: {
+          include: { mandates: true },
+        },
+      },
+      take: limit,
+    });
+
+    console.log(`Found ${externalIds.length} politicians with Wikidata IDs`);
+
+    if (externalIds.length === 0) {
+      return stats;
+    }
+
+    const wikidataIds = externalIds.map((e) => e.externalId).filter(Boolean);
+
+    console.log("Fetching positions from Wikidata...");
+    const positionsMap = await wikidata.getPositions(wikidataIds);
+    console.log(`Fetched positions for ${positionsMap.size} entities`);
+
+    // Collect position IDs for label fetching
+    const labelIds = new Set<string>();
+    positionsMap.forEach((positions) => {
+      for (const pos of positions) {
+        labelIds.add(pos.positionId);
+      }
+    });
+
+    console.log(`Fetching labels for ${labelIds.size} entities...`);
+    const labelsEntities = await wikidata.getEntities(Array.from(labelIds), ["labels"]);
+    const labels = new Map<string, string>();
+    labelsEntities.forEach((entity, id) => {
+      const label = entity.labels.fr || entity.labels.en;
+      if (label) labels.set(id, label);
+    });
+
+    for (const extId of externalIds) {
+      const politician = extId.politician;
+      if (!politician) continue;
+
+      stats.processed++;
+
+      const positions = positionsMap.get(extId.externalId) || [];
+
+      for (const pos of positions) {
+        const startDate = pos.startDate;
+        const endDate = pos.endDate;
+        if (!startDate) continue;
+
+        // Check if this is a ROLE position
+        const roleInfo = ROLE_POSITIONS[pos.positionId];
+        if (roleInfo) {
+          const overlappingMandate = politician.mandates.find((m) => {
+            if (m.type !== roleInfo.mandateType) return false;
+            const mStart = new Date(m.startDate);
+            const mEnd = m.endDate ? new Date(m.endDate) : new Date();
+            const roleEnd = endDate || new Date();
+            return mStart <= roleEnd && mEnd >= startDate;
+          });
+
+          if (overlappingMandate) {
+            try {
+              await db.mandate.update({
+                where: { id: overlappingMandate.id },
+                data: { role: roleInfo.role },
+              });
+            } catch (error) {
+              stats.errors.push(`${politician.fullName} (role update): ${error}`);
+            }
+            stats.mandatesSkipped++;
+          } else {
+            const positionLabel = labels.get(pos.positionId) || pos.positionId;
+            const externalMandateId = `wikidata-${extId.externalId}-${pos.positionId}-${startDate.toISOString().split("T")[0]}`;
+
+            try {
+              await db.mandate.create({
+                data: {
+                  politicianId: politician.id,
+                  type: roleInfo.mandateType,
+                  title: positionLabel,
+                  institution:
+                    roleInfo.mandateType === MandateType.DEPUTE ? "Assemblée nationale" : "Sénat",
+                  role: roleInfo.role,
+                  source: DataSource.WIKIDATA,
+                  startDate,
+                  endDate,
+                  isCurrent: !endDate,
+                  sourceUrl: `https://www.wikidata.org/wiki/${extId.externalId}`,
+                  officialUrl: null,
+                  externalId: externalMandateId,
+                },
+              });
+              stats.mandatesCreated++;
+            } catch (error) {
+              stats.errors.push(`${politician.fullName}: ${error}`);
+            }
+          }
+          continue;
+        }
+
+        // Regular mandate position
+        const mandateInfo = POSITION_MAPPING[pos.positionId];
+        if (!mandateInfo) continue;
+
+        const positionLabel = labels.get(pos.positionId) || pos.positionId;
+
+        // Guard: PRESIDENT_REPUBLIQUE must mention France
+        if (
+          mandateInfo.type === MandateType.PRESIDENT_REPUBLIQUE &&
+          !/r[ée]publique|france/i.test(positionLabel)
+        ) {
+          stats.mandatesSkipped++;
+          continue;
+        }
+
+        // Check if mandate already exists (within 30 days)
+        const existingMandate = politician.mandates.find((m) => {
+          if (m.type !== mandateInfo.type) return false;
+          if (!m.startDate) return false;
+          const existingStart = new Date(m.startDate);
+          const diff = Math.abs(existingStart.getTime() - startDate.getTime());
+          return diff / (1000 * 60 * 60 * 24) < 30;
+        });
+
+        if (existingMandate) {
+          stats.mandatesSkipped++;
+          continue;
+        }
+
+        const externalMandateId = `wikidata-${extId.externalId}-${pos.positionId}-${startDate.toISOString().split("T")[0]}`;
+
+        try {
+          await db.mandate.create({
+            data: {
+              politicianId: politician.id,
+              type: mandateInfo.type,
+              title: positionLabel,
+              institution: mandateInfo.institution,
+              source: DataSource.WIKIDATA,
+              startDate,
+              endDate,
+              isCurrent: !endDate,
+              sourceUrl: `https://www.wikidata.org/wiki/${extId.externalId}`,
+              officialUrl: null,
+              externalId: externalMandateId,
+            },
+          });
+          stats.mandatesCreated++;
+        } catch (error) {
+          stats.errors.push(`${politician.fullName}: ${error}`);
+        }
+      }
+    }
+
+    // ========================================
+    // Phase 2: Party leaders via P488
+    // ========================================
+    console.log("\n--- Phase 2: Party leaders (P488) ---");
+
+    const partyExternalIds = await db.externalId.findMany({
+      where: {
+        source: DataSource.WIKIDATA,
+        partyId: { not: null },
+      },
+      include: { party: true },
+    });
+
+    if (partyExternalIds.length > 0) {
+      const partyWikidataIds = partyExternalIds.map((e) => e.externalId).filter(Boolean);
+      console.log(`Fetching P488 for ${partyWikidataIds.length} parties...`);
+
+      const partyEntities = await wikidata.getEntities(partyWikidataIds, ["claims"]);
+
+      const chairpersonData: Array<{
+        partyName: string;
+        partyId: string;
+        partyWikidataId: string;
+        chairpersonWikidataId: string;
+        startDate: Date | null;
+        partyWebsite: string | null;
+      }> = [];
+
+      for (const ext of partyExternalIds) {
+        if (!ext.party) continue;
+        const entity = partyEntities.get(ext.externalId);
+        if (!entity) continue;
+
+        const chairClaims = entity.claims["P488"];
+        if (!chairClaims) continue;
+
+        for (const claim of chairClaims) {
+          const val = claim.mainsnak?.datavalue?.value;
+          if (!val || typeof val !== "object" || !("id" in val)) continue;
+
+          const endQual = claim.qualifiers?.["P582"];
+          if (endQual && endQual.length > 0) continue;
+
+          let chairStartDate: Date | null = null;
+          const startQual = claim.qualifiers?.["P580"];
+          if (startQual?.[0]?.datavalue?.value) {
+            const timeValue = startQual[0].datavalue.value;
+            if (typeof timeValue === "object" && "time" in timeValue) {
+              const parsed = parseDate((timeValue as { time: string }).time);
+              if (parsed) chairStartDate = parsed;
+            }
+          }
+
+          chairpersonData.push({
+            partyName: ext.party.name,
+            partyId: ext.party.id,
+            partyWikidataId: ext.externalId,
+            chairpersonWikidataId: val.id as string,
+            startDate: chairStartDate,
+            partyWebsite: ext.party.website || null,
+          });
+        }
+      }
+
+      if (chairpersonData.length > 0) {
+        const chairpersonIds = chairpersonData.map((d) => d.chairpersonWikidataId);
+        const chairLabels = await wikidata.getEntities(chairpersonIds, ["labels"]);
+
+        for (const data of chairpersonData) {
+          const chairLabel =
+            chairLabels.get(data.chairpersonWikidataId)?.labels?.fr ||
+            chairLabels.get(data.chairpersonWikidataId)?.labels?.en ||
+            data.chairpersonWikidataId;
+
+          const politicianExt = await db.externalId.findFirst({
+            where: {
+              source: DataSource.WIKIDATA,
+              externalId: data.chairpersonWikidataId,
+              politicianId: { not: null },
+            },
+          });
+
+          if (!politicianExt?.politicianId) continue;
+
+          // Never overwrite manual entries
+          const manualEntry = await db.mandate.findFirst({
+            where: {
+              politicianId: politicianExt.politicianId,
+              type: MandateType.PRESIDENT_PARTI,
+              partyId: data.partyId,
+              source: "MANUAL",
+            },
+          });
+          if (manualEntry) {
+            stats.mandatesSkipped++;
+            continue;
+          }
+
+          const existing = await db.mandate.findFirst({
+            where: {
+              politicianId: politicianExt.politicianId,
+              type: MandateType.PRESIDENT_PARTI,
+              institution: data.partyName,
+              isCurrent: true,
+            },
+          });
+
+          if (existing) {
+            stats.mandatesSkipped++;
+            continue;
+          }
+
+          const externalMandateId = `wikidata-p488-${data.partyWikidataId}-${data.chairpersonWikidataId}`;
+
+          try {
+            const existingByExtId = await db.mandate.findFirst({
+              where: { externalId: externalMandateId },
+            });
+            if (existingByExtId) {
+              stats.mandatesSkipped++;
+              continue;
+            }
+            await db.mandate.create({
+              data: {
+                politicianId: politicianExt.politicianId,
+                type: MandateType.PRESIDENT_PARTI,
+                title: `Dirigeant(e) - ${data.partyName}`,
+                institution: data.partyName,
+                partyId: data.partyId,
+                source: DataSource.WIKIDATA,
+                startDate: data.startDate ?? new Date(),
+                isCurrent: true,
+                sourceUrl: `https://www.wikidata.org/wiki/${data.partyWikidataId}`,
+                officialUrl: data.partyWebsite || null,
+                externalId: externalMandateId,
+              },
+            });
+            await setCurrentParty(politicianExt.politicianId, data.partyId, {
+              startDate: data.startDate ?? new Date(),
+            });
+            stats.mandatesCreated++;
+            stats.partyPresidentsCreated++;
+          } catch (error) {
+            stats.errors.push(`Party leader ${chairLabel} @ ${data.partyName}: ${error}`);
+          }
+        }
+      }
+
+      console.log(`Party leaders: ${stats.partyPresidentsCreated} created`);
+    }
+  }
+
+  // ========================================
+  // Phase 3: Party founders via P112
+  // ========================================
+  console.log("\n--- Phase 3: Party founders (P112) ---");
+
+  const founderPartyExternalIds = await db.externalId.findMany({
+    where: {
+      source: DataSource.WIKIDATA,
+      partyId: { not: null },
+    },
+    include: { party: true },
+  });
+
+  if (founderPartyExternalIds.length > 0) {
+    const founderPartyWikidataIds = founderPartyExternalIds
+      .map((e) => e.externalId)
+      .filter(Boolean);
+    console.log(`Fetching P112 for ${founderPartyWikidataIds.length} parties...`);
+
+    const founderPartyEntities = await wikidata.getEntities(founderPartyWikidataIds, ["claims"]);
+
+    const founderData: Array<{
+      partyName: string;
+      partyId: string;
+      founderWikidataId: string;
+    }> = [];
+
+    for (const ext of founderPartyExternalIds) {
+      if (!ext.party) continue;
+      const entity = founderPartyEntities.get(ext.externalId);
+      if (!entity) continue;
+
+      const founderClaims = entity.claims["P112"];
+      if (!founderClaims) continue;
+
+      for (const claim of founderClaims) {
+        const val = claim.mainsnak?.datavalue?.value;
+        if (!val || typeof val !== "object" || !("id" in val)) continue;
+
+        founderData.push({
+          partyName: ext.party.name,
+          partyId: ext.party.id,
+          founderWikidataId: val.id as string,
+        });
+      }
+    }
+
+    console.log(`Found ${founderData.length} founder claims`);
+
+    if (founderData.length > 0) {
+      for (const data of founderData) {
+        const politicianExt = await db.externalId.findFirst({
+          where: {
+            source: DataSource.WIKIDATA,
+            externalId: data.founderWikidataId,
+            politicianId: { not: null },
+          },
+        });
+
+        if (!politicianExt?.politicianId) continue;
+
+        try {
+          await setPartyRole(politicianExt.politicianId, data.partyId, PartyRole.FOUNDER);
+          stats.foundersCreated++;
+        } catch (error) {
+          stats.errors.push(`Founder @ ${data.partyName}: ${error}`);
+        }
+
+        // Rate limiting
+        await new Promise((r) => setTimeout(r, WIKIDATA_SPARQL_RATE_LIMIT_MS));
+      }
+    }
+
+    console.log(`Founders: ${stats.foundersCreated} created`);
+  }
+
+  return stats;
+}

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -1,0 +1,395 @@
+/**
+ * Service to discover historical judicial affairs from Wikidata and Wikipedia.
+ * Extracted from scripts/discover-affairs.ts for Inngest compatibility.
+ *
+ * Phase 1: Wikidata — P1399 (convicted of) and P1595 (charge)
+ * Phase 2: Wikipedia — Judicial sections + AI extraction
+ * Phase 3: Reconciliation — Dedup + persist
+ */
+
+import { db } from "@/lib/db";
+import { generateSlug } from "@/lib/utils";
+import { WikidataService } from "@/lib/api/wikidata";
+import { WD_PROPS } from "@/config/wikidata";
+import { mapWikidataOffense, getOffenseLabel } from "@/config/wikidata-affairs";
+import { wikipediaService } from "@/lib/api/wikipedia";
+import { extractAffairsFromWikipedia } from "@/services/wikipedia-affair-extraction";
+import { findMatchingAffairs } from "@/services/affairs/matching";
+import type { AffairCategory, AffairStatus, Involvement } from "@/generated/prisma";
+
+interface DiscoveredAffair {
+  politicianId: string;
+  politicianName: string;
+  title: string;
+  description: string;
+  category: AffairCategory;
+  status: AffairStatus;
+  involvement: Involvement;
+  factsDate: Date | null;
+  court: string | null;
+  charges: string[];
+  confidenceScore: number;
+  publicationStatus: "PUBLISHED" | "DRAFT";
+  sources: Array<{
+    url: string;
+    title: string;
+    publisher: string;
+    sourceType: "WIKIDATA" | "WIKIPEDIA" | "PRESSE";
+  }>;
+  phase: "wikidata" | "wikipedia";
+}
+
+export interface DiscoverAffairsResult {
+  politiciansProcessed: number;
+  wikidataAffairsFound: number;
+  wikipediaAffairsFound: number;
+  duplicatesSkipped: number;
+  affairsCreated: number;
+  errors: string[];
+}
+
+function extractPublisherFromUrl(url: string): string {
+  try {
+    const hostname = new URL(url).hostname.replace(/^www\./, "");
+    const PUBLISHER_MAP: Record<string, string> = {
+      "lemonde.fr": "Le Monde",
+      "liberation.fr": "Lib\u00e9ration",
+      "mediapart.fr": "Mediapart",
+      "lefigaro.fr": "Le Figaro",
+      "francetvinfo.fr": "France Info",
+      "bfmtv.com": "BFM TV",
+      "leparisien.fr": "Le Parisien",
+      "20minutes.fr": "20 Minutes",
+      "lexpress.fr": "L'Express",
+      "lepoint.fr": "Le Point",
+      "nouvelobs.com": "L'Obs",
+      "europe1.fr": "Europe 1",
+      "rtl.fr": "RTL",
+      "rfi.fr": "RFI",
+    };
+    return PUBLISHER_MAP[hostname] || hostname;
+  } catch {
+    return "Source inconnue";
+  }
+}
+
+async function generateUniqueAffairSlug(title: string): Promise<string> {
+  const baseSlug = generateSlug(title);
+  let slug = baseSlug;
+  let counter = 2;
+
+  while (await db.affair.findUnique({ where: { slug } })) {
+    const suffix = `-${counter}`;
+    const maxBaseLength = 120 - suffix.length;
+    const truncatedBase = baseSlug.slice(0, maxBaseLength).replace(/-$/, "");
+    slug = `${truncatedBase}${suffix}`;
+    counter++;
+  }
+
+  return slug;
+}
+
+export async function discoverAffairs(options?: {
+  limit?: number;
+  politicianFilter?: string;
+  wikidataOnly?: boolean;
+  wikipediaOnly?: boolean;
+}): Promise<DiscoverAffairsResult> {
+  const { limit, politicianFilter, wikidataOnly = false, wikipediaOnly = false } = options ?? {};
+
+  const stats: DiscoverAffairsResult = {
+    politiciansProcessed: 0,
+    wikidataAffairsFound: 0,
+    wikipediaAffairsFound: 0,
+    duplicatesSkipped: 0,
+    affairsCreated: 0,
+    errors: [],
+  };
+
+  // Fetch politicians
+  const politicians = await db.politician.findMany({
+    where: {
+      publicationStatus: "PUBLISHED",
+      ...(politicianFilter
+        ? {
+            fullName: {
+              contains: politicianFilter,
+              mode: "insensitive" as const,
+            },
+          }
+        : {}),
+    },
+    select: {
+      id: true,
+      fullName: true,
+      externalIds: {
+        where: { source: "WIKIDATA" },
+        select: { externalId: true },
+      },
+    },
+    orderBy: { lastName: "asc" },
+    ...(limit ? { take: limit } : {}),
+  });
+
+  stats.politiciansProcessed = politicians.length;
+  console.log(`${politicians.length} politician(s) found`);
+
+  if (politicians.length === 0) {
+    return stats;
+  }
+
+  // Phase 1: Wikidata
+  let phase1Affairs: DiscoveredAffair[] = [];
+  if (!wikipediaOnly) {
+    phase1Affairs = await runPhase1Wikidata(politicians, stats);
+  }
+
+  // Phase 2: Wikipedia
+  let phase2Affairs: DiscoveredAffair[] = [];
+  if (!wikidataOnly) {
+    phase2Affairs = await runPhase2Wikipedia(politicians, phase1Affairs, stats);
+  }
+
+  // Phase 3: Reconciliation
+  const allAffairs = [...phase1Affairs, ...phase2Affairs];
+
+  if (allAffairs.length > 0) {
+    await runPhase3Reconciliation(allAffairs, stats);
+  }
+
+  return stats;
+}
+
+async function runPhase1Wikidata(
+  politicians: Array<{
+    id: string;
+    fullName: string;
+    externalIds: Array<{ externalId: string }>;
+  }>,
+  stats: DiscoverAffairsResult
+): Promise<DiscoveredAffair[]> {
+  const discovered: DiscoveredAffair[] = [];
+  const wikidataService = new WikidataService();
+
+  const withQid = politicians.filter((p) => p.externalIds.length > 0);
+  if (withQid.length === 0) return discovered;
+
+  console.log(`Phase 1: Wikidata - ${withQid.length} politicians with Q-ID`);
+
+  for (const politician of withQid) {
+    const qid = politician.externalIds[0].externalId;
+
+    try {
+      const entities = await wikidataService.getEntities([qid]);
+      const entity = entities.get(qid);
+      if (!entity) continue;
+
+      const properties: Array<{
+        prop: "P1399" | "P1595";
+        claims: (typeof entity.claims)[string];
+      }> = [
+        { prop: "P1399", claims: entity.claims[WD_PROPS.CONVICTED_OF] },
+        { prop: "P1595", claims: entity.claims[WD_PROPS.CHARGE] },
+      ];
+
+      for (const { prop, claims } of properties) {
+        if (!claims) continue;
+
+        for (const claim of claims) {
+          const value = claim.mainsnak?.datavalue?.value;
+          if (!value || typeof value !== "object" || !("id" in value)) continue;
+
+          const offenseQid = value.id;
+          const { category, status } = mapWikidataOffense(offenseQid, prop);
+          const label = getOffenseLabel(offenseQid);
+
+          const isConviction = prop === "P1399";
+          const publicationStatus = isConviction ? "PUBLISHED" : "DRAFT";
+          const confidence = isConviction ? 95 : 75;
+          const titlePrefix = isConviction ? "" : "[\u00c0 V\u00c9RIFIER] ";
+          const title = `${titlePrefix}${label} \u2014 ${politician.fullName}`;
+
+          discovered.push({
+            politicianId: politician.id,
+            politicianName: politician.fullName,
+            title,
+            description: `${label} (${isConviction ? "condamnation" : "mise en cause"}) \u2014 source Wikidata (${qid}, propri\u00e9t\u00e9 ${prop}).`,
+            category,
+            status,
+            involvement: isConviction ? "DIRECT" : "MENTIONED_ONLY",
+            factsDate: null,
+            court: null,
+            charges: [label],
+            confidenceScore: confidence,
+            publicationStatus: publicationStatus as "PUBLISHED" | "DRAFT",
+            sources: [
+              {
+                url: `https://www.wikidata.org/wiki/${qid}`,
+                title: `Wikidata \u2014 ${politician.fullName}`,
+                publisher: "Wikidata",
+                sourceType: "WIKIDATA",
+              },
+            ],
+            phase: "wikidata",
+          });
+
+          stats.wikidataAffairsFound++;
+        }
+      }
+    } catch (error) {
+      stats.errors.push(
+        `Wikidata ${politician.fullName}: ${error instanceof Error ? error.message : error}`
+      );
+    }
+  }
+
+  return discovered;
+}
+
+async function runPhase2Wikipedia(
+  politicians: Array<{
+    id: string;
+    fullName: string;
+    externalIds: Array<{ externalId: string }>;
+  }>,
+  phase1Affairs: DiscoveredAffair[],
+  stats: DiscoverAffairsResult
+): Promise<DiscoveredAffair[]> {
+  const discovered: DiscoveredAffair[] = [];
+  const phase1Keys = new Set(phase1Affairs.map((a) => `${a.politicianId}:${a.category}`));
+
+  console.log(`Phase 2: Wikipedia - ${politicians.length} politicians`);
+
+  for (const politician of politicians) {
+    try {
+      const sections = await wikipediaService.findJudicialSections(politician.fullName);
+      if (sections.length === 0) continue;
+
+      for (const section of sections) {
+        const pageUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(politician.fullName.replace(/ /g, "_"))}`;
+
+        const result = await extractAffairsFromWikipedia({
+          politicianName: politician.fullName,
+          sectionTitle: section.title,
+          wikitext: section.wikitext,
+          pageUrl,
+        });
+
+        for (const extracted of result.affairs) {
+          if (
+            extracted.involvement !== "DIRECT" &&
+            extracted.involvement !== "VICTIM" &&
+            extracted.involvement !== "PLAINTIFF"
+          )
+            continue;
+
+          if (extracted.confidenceScore < 40) continue;
+
+          const dedupKey = `${politician.id}:${extracted.category}`;
+          if (phase1Keys.has(dedupKey)) continue;
+
+          const sources: DiscoveredAffair["sources"] = [
+            {
+              url: pageUrl,
+              title: `Wikipedia \u2014 ${politician.fullName}`,
+              publisher: "Wikipedia",
+              sourceType: "WIKIPEDIA",
+            },
+          ];
+
+          for (const sourceUrl of extracted.sourceUrls) {
+            sources.push({
+              url: sourceUrl,
+              title: extracted.title,
+              publisher: extractPublisherFromUrl(sourceUrl),
+              sourceType: "PRESSE",
+            });
+          }
+
+          discovered.push({
+            politicianId: politician.id,
+            politicianName: politician.fullName,
+            title: `[\u00c0 V\u00c9RIFIER] ${extracted.title}`,
+            description: extracted.description,
+            category: extracted.category as AffairCategory,
+            status: extracted.status as AffairStatus,
+            involvement: extracted.involvement,
+            factsDate: extracted.factsDate ? new Date(extracted.factsDate) : null,
+            court: extracted.court,
+            charges: extracted.charges,
+            confidenceScore: extracted.confidenceScore,
+            publicationStatus: "DRAFT",
+            sources,
+            phase: "wikipedia",
+          });
+
+          stats.wikipediaAffairsFound++;
+        }
+      }
+    } catch (error) {
+      stats.errors.push(
+        `Wikipedia ${politician.fullName}: ${error instanceof Error ? error.message : error}`
+      );
+    }
+  }
+
+  return discovered;
+}
+
+async function runPhase3Reconciliation(
+  allAffairs: DiscoveredAffair[],
+  stats: DiscoverAffairsResult
+): Promise<void> {
+  console.log(`Phase 3: Reconciliation - ${allAffairs.length} affairs`);
+
+  for (const affair of allAffairs) {
+    try {
+      const matches = await findMatchingAffairs({
+        politicianId: affair.politicianId,
+        title: affair.title,
+        category: affair.category,
+      });
+
+      const highMatch = matches.find((m) => m.confidence === "HIGH" || m.confidence === "CERTAIN");
+
+      if (highMatch) {
+        stats.duplicatesSkipped++;
+        continue;
+      }
+
+      const slug = await generateUniqueAffairSlug(affair.title);
+
+      await db.affair.create({
+        data: {
+          politicianId: affair.politicianId,
+          title: affair.title,
+          slug,
+          description: affair.description,
+          status: affair.status,
+          category: affair.category,
+          involvement: affair.involvement,
+          factsDate: affair.factsDate,
+          court: affair.court,
+          confidenceScore: affair.confidenceScore,
+          publicationStatus: affair.publicationStatus,
+          verifiedAt: affair.publicationStatus === "PUBLISHED" ? new Date() : null,
+          sources: {
+            create: affair.sources.map((s) => ({
+              url: s.url,
+              title: s.title,
+              publisher: s.publisher,
+              publishedAt: new Date(),
+              sourceType: s.sourceType,
+            })),
+          },
+        },
+      });
+
+      stats.affairsCreated++;
+    } catch (error) {
+      stats.errors.push(
+        `Create "${affair.title}": ${error instanceof Error ? error.message : error}`
+      );
+    }
+  }
+}

--- a/src/services/sync/generate-biographies.ts
+++ b/src/services/sync/generate-biographies.ts
@@ -1,0 +1,175 @@
+/**
+ * Orchestration service for generating AI biographies.
+ * Queries DB → loops → calls generateBiography → updates DB.
+ * Extracted from scripts/generate-biographies.ts for Inngest compatibility.
+ */
+
+import { db } from "@/lib/db";
+import { generateBiography, type BiographyRequest } from "@/services/summarize";
+import { MANDATE_TYPE_LABELS } from "@/config/labels";
+import { MandateType } from "@/generated/prisma";
+import { AI_RATE_LIMIT_MS, AI_429_BACKOFF_MS } from "@/config/rate-limits";
+
+export interface BiographiesResult {
+  processed: number;
+  generated: number;
+  skipped: number;
+  errors: string[];
+}
+
+function mandateTitle(mandate: {
+  type: string;
+  title: string | null;
+  institution: string | null;
+}): string {
+  const label = MANDATE_TYPE_LABELS[mandate.type as MandateType] || mandate.type;
+  if (mandate.title) return mandate.title;
+  if (mandate.institution) return `${label} — ${mandate.institution}`;
+  return label;
+}
+
+export async function generateBiographies(options?: {
+  limit?: number;
+  force?: boolean;
+}): Promise<BiographiesResult> {
+  const { limit, force = false } = options ?? {};
+
+  const stats: BiographiesResult = {
+    processed: 0,
+    generated: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  const whereClause: Record<string, unknown> = {};
+  if (!force) {
+    whereClause.biography = null;
+  }
+
+  let politicians = await db.politician.findMany({
+    where: whereClause,
+    orderBy: { fullName: "asc" },
+    select: {
+      id: true,
+      fullName: true,
+      civility: true,
+      birthDate: true,
+      birthPlace: true,
+      deathDate: true,
+      currentParty: { select: { name: true } },
+      mandates: {
+        select: {
+          type: true,
+          title: true,
+          institution: true,
+          isCurrent: true,
+          startDate: true,
+          endDate: true,
+        },
+        orderBy: { startDate: "desc" },
+      },
+      declarations: {
+        select: { year: true },
+        orderBy: { year: "desc" },
+      },
+      _count: { select: { affairs: true, votes: true } },
+    },
+  });
+
+  if (limit) {
+    politicians = politicians.slice(0, limit);
+  }
+
+  console.log(`Found ${politicians.length} politicians to process`);
+
+  if (politicians.length === 0) {
+    return stats;
+  }
+
+  // Get vote stats
+  const voteStatsByPolitician = new Map<
+    string,
+    { total: number; pour: number; contre: number; abstention: number }
+  >();
+
+  const voteStats = await db.vote.groupBy({
+    by: ["politicianId", "position"],
+    _count: true,
+  });
+
+  for (const vs of voteStats) {
+    const existing = voteStatsByPolitician.get(vs.politicianId) || {
+      total: 0,
+      pour: 0,
+      contre: 0,
+      abstention: 0,
+    };
+    existing.total += vs._count;
+    switch (vs.position) {
+      case "POUR":
+        existing.pour += vs._count;
+        break;
+      case "CONTRE":
+        existing.contre += vs._count;
+        break;
+      case "ABSTENTION":
+        existing.abstention += vs._count;
+        break;
+    }
+    voteStatsByPolitician.set(vs.politicianId, existing);
+  }
+
+  for (let i = 0; i < politicians.length; i++) {
+    const pol = politicians[i];
+
+    try {
+      const bioRequest: BiographyRequest = {
+        fullName: pol.fullName,
+        civility: pol.civility,
+        birthDate: pol.birthDate,
+        birthPlace: pol.birthPlace,
+        deathDate: pol.deathDate,
+        currentParty: pol.currentParty?.name || null,
+        mandates: pol.mandates.map((m) => ({
+          type: m.type,
+          title: mandateTitle(m),
+          isCurrent: m.isCurrent,
+          startDate: m.startDate,
+          endDate: m.endDate,
+        })),
+        voteStats: voteStatsByPolitician.get(pol.id) || null,
+        affairsCount: pol._count.affairs,
+        declarationsCount: pol.declarations.length,
+        latestDeclarationYear: pol.declarations.length > 0 ? pol.declarations[0].year : null,
+      };
+
+      const biography = await generateBiography(bioRequest);
+
+      await db.politician.update({
+        where: { id: pol.id },
+        data: {
+          biography,
+          biographyGeneratedAt: new Date(),
+        },
+      });
+
+      stats.generated++;
+      stats.processed++;
+
+      if (i < politicians.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, AI_RATE_LIMIT_MS));
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      stats.errors.push(`${pol.fullName}: ${errorMsg}`);
+      stats.processed++;
+
+      if (errorMsg.includes("429") || errorMsg.includes("rate")) {
+        console.log("Rate limited, waiting 30s...");
+        await new Promise((resolve) => setTimeout(resolve, AI_429_BACKOFF_MS));
+      }
+    }
+  }
+
+  return stats;
+}

--- a/src/services/sync/generate-scrutin-summaries.ts
+++ b/src/services/sync/generate-scrutin-summaries.ts
@@ -1,0 +1,121 @@
+/**
+ * Orchestration service for generating AI summaries for scrutins (votes).
+ * Extracted from scripts/generate-scrutin-summaries.ts for Inngest compatibility.
+ */
+
+import { db } from "@/lib/db";
+import { summarizeScrutin, type SummaryResponse } from "@/services/summarize";
+import { AI_RATE_LIMIT_MS, AI_429_BACKOFF_MS } from "@/config/rate-limits";
+
+export interface ScrutinSummariesResult {
+  processed: number;
+  generated: number;
+  skipped: number;
+  errors: string[];
+}
+
+function formatSummary(summary: SummaryResponse): string {
+  let formatted = summary.shortSummary;
+
+  if (summary.keyPoints.length > 0) {
+    formatted += "\n\n**Points cl\u00e9s :**\n";
+    for (const point of summary.keyPoints) {
+      formatted += `\u2022 ${point}\n`;
+    }
+  }
+
+  return formatted.trim();
+}
+
+export async function generateScrutinSummaries(options?: {
+  limit?: number;
+  force?: boolean;
+  chamber?: "AN" | "SENAT";
+}): Promise<ScrutinSummariesResult> {
+  const { limit, force = false, chamber } = options ?? {};
+
+  const stats: ScrutinSummariesResult = {
+    processed: 0,
+    generated: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  const whereClause: Record<string, unknown> = {};
+  if (!force) {
+    whereClause.summary = null;
+  }
+  if (chamber) {
+    whereClause.chamber = chamber;
+  }
+
+  let scrutins = await db.scrutin.findMany({
+    where: whereClause,
+    orderBy: { votingDate: "desc" },
+    select: {
+      id: true,
+      externalId: true,
+      title: true,
+      chamber: true,
+      votingDate: true,
+      result: true,
+      votesFor: true,
+      votesAgainst: true,
+      votesAbstain: true,
+    },
+  });
+
+  if (limit) {
+    scrutins = scrutins.slice(0, limit);
+  }
+
+  console.log(`Found ${scrutins.length} scrutins to process`);
+
+  if (scrutins.length === 0) {
+    return stats;
+  }
+
+  for (let i = 0; i < scrutins.length; i++) {
+    const scrutin = scrutins[i];
+
+    try {
+      const summary: SummaryResponse = await summarizeScrutin({
+        title: scrutin.title,
+        chamber: scrutin.chamber as "AN" | "SENAT",
+        votingDate: scrutin.votingDate.toISOString().split("T")[0],
+        result: scrutin.result as "ADOPTED" | "REJECTED",
+        votesFor: scrutin.votesFor,
+        votesAgainst: scrutin.votesAgainst,
+        votesAbstain: scrutin.votesAbstain,
+      });
+
+      const formattedSummary = formatSummary(summary);
+
+      await db.scrutin.update({
+        where: { id: scrutin.id },
+        data: {
+          summary: formattedSummary,
+          summaryDate: new Date(),
+        },
+      });
+
+      stats.generated++;
+      stats.processed++;
+
+      if (i < scrutins.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, AI_RATE_LIMIT_MS));
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      stats.errors.push(`${scrutin.externalId}: ${errorMsg}`);
+      stats.processed++;
+
+      if (errorMsg.includes("429") || errorMsg.includes("rate")) {
+        console.log("Rate limited, waiting 30s...");
+        await new Promise((resolve) => setTimeout(resolve, AI_429_BACKOFF_MS));
+      }
+    }
+  }
+
+  return stats;
+}

--- a/src/services/sync/generate-summaries.ts
+++ b/src/services/sync/generate-summaries.ts
@@ -1,0 +1,116 @@
+/**
+ * Orchestration service for generating AI summaries for legislative dossiers.
+ * Extracted from scripts/generate-summaries.ts for Inngest compatibility.
+ */
+
+import { db } from "@/lib/db";
+import { summarizeDossier, type SummaryResponse } from "@/services/summarize";
+import { AI_RATE_LIMIT_MS, AI_429_BACKOFF_MS } from "@/config/rate-limits";
+
+export interface SummariesResult {
+  processed: number;
+  generated: number;
+  skipped: number;
+  errors: string[];
+}
+
+function formatSummary(summary: SummaryResponse): string {
+  let formatted = summary.shortSummary;
+
+  if (summary.keyPoints.length > 0) {
+    formatted += "\n\n**Points cl\u00e9s :**\n";
+    for (const point of summary.keyPoints) {
+      formatted += `\u2022 ${point}\n`;
+    }
+  }
+
+  return formatted.trim();
+}
+
+export async function generateSummaries(options?: {
+  limit?: number;
+  force?: boolean;
+  activeOnly?: boolean;
+}): Promise<SummariesResult> {
+  const { limit, force = false, activeOnly = true } = options ?? {};
+
+  const stats: SummariesResult = {
+    processed: 0,
+    generated: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  const whereClause: Record<string, unknown> = {};
+  if (!force) {
+    whereClause.summary = null;
+  }
+  if (activeOnly) {
+    whereClause.status = "EN_COURS";
+  }
+
+  let dossiers = await db.legislativeDossier.findMany({
+    where: whereClause,
+    orderBy: { filingDate: "desc" },
+    select: {
+      id: true,
+      externalId: true,
+      title: true,
+      shortTitle: true,
+      number: true,
+      category: true,
+      status: true,
+      exposeDesMotifs: true,
+    },
+  });
+
+  if (limit) {
+    dossiers = dossiers.slice(0, limit);
+  }
+
+  console.log(`Found ${dossiers.length} dossiers to process`);
+
+  if (dossiers.length === 0) {
+    return stats;
+  }
+
+  for (let i = 0; i < dossiers.length; i++) {
+    const dossier = dossiers[i];
+
+    try {
+      const summary: SummaryResponse = await summarizeDossier({
+        title: dossier.title,
+        content: dossier.exposeDesMotifs || dossier.title,
+        procedure: dossier.category || undefined,
+      });
+
+      const formattedSummary = formatSummary(summary);
+
+      await db.legislativeDossier.update({
+        where: { id: dossier.id },
+        data: {
+          summary: formattedSummary,
+          summaryDate: new Date(),
+        },
+      });
+
+      stats.generated++;
+      stats.processed++;
+
+      if (i < dossiers.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, AI_RATE_LIMIT_MS));
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      stats.errors.push(`${dossier.externalId}: ${errorMsg}`);
+      stats.processed++;
+
+      if (errorMsg.includes("429") || errorMsg.includes("rate")) {
+        console.log("Rate limited, waiting 30s...");
+        await new Promise((resolve) => setTimeout(resolve, AI_429_BACKOFF_MS));
+      }
+    }
+  }
+
+  return stats;
+}

--- a/src/services/sync/legislation-content.ts
+++ b/src/services/sync/legislation-content.ts
@@ -1,0 +1,160 @@
+/**
+ * Service to download .docx documents and extract exposé des motifs.
+ * Extracted from scripts/sync-legislation-content.ts for Inngest compatibility.
+ */
+
+import { db } from "@/lib/db";
+import mammoth from "mammoth";
+import { ASSEMBLEE_DOCPARL_RATE_LIMIT_MS } from "@/config/rate-limits";
+import { HTTPClient, HTTPError } from "@/lib/api/http-client";
+
+const DOCPARL_URL_TEMPLATE =
+  "https://docparl.assemblee-nationale.fr/base/{id}?format=application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+const EXPOSE_REGEX =
+  /EXPOS[\u00c9Ee\u00e9]\s+DES\s+MOTIFS\s*([\s\S]*?)(?=TITRE\s+[IVX]|Article\s+(?:1er|premier|unique)|CHAPITRE|$)/i;
+
+const MAX_FALLBACK_LENGTH = 5000;
+
+export interface LegislationContentSyncResult {
+  processed: number;
+  downloaded: number;
+  extracted: number;
+  notFound: number;
+  skipped: number;
+  errors: string[];
+}
+
+async function downloadDocx(documentId: string): Promise<Buffer | null> {
+  const docparlClient = new HTTPClient({
+    rateLimitMs: ASSEMBLEE_DOCPARL_RATE_LIMIT_MS,
+    retries: 3,
+    timeout: 60_000,
+    sourceName: "docparl AN",
+  });
+
+  const url = DOCPARL_URL_TEMPLATE.replace("{id}", documentId);
+
+  try {
+    const { data } = await docparlClient.getBuffer(url, {
+      headers: {
+        Accept: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      },
+    });
+    return data;
+  } catch (err) {
+    if (err instanceof HTTPError && err.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function extractText(buffer: Buffer): Promise<string> {
+  const result = await mammoth.extractRawText({ buffer });
+  return result.value;
+}
+
+function extractExposeDesMotifs(fullText: string): string | null {
+  const match = fullText.match(EXPOSE_REGEX);
+
+  if (match && match[1]) {
+    const expose = match[1].trim();
+    if (expose.length > 50) {
+      return expose;
+    }
+  }
+
+  const trimmed = fullText.trim();
+  if (trimmed.length > 100) {
+    return trimmed.slice(0, MAX_FALLBACK_LENGTH);
+  }
+
+  return null;
+}
+
+export async function syncLegislationContent(options?: {
+  limit?: number;
+  force?: boolean;
+}): Promise<LegislationContentSyncResult> {
+  const { limit, force = false } = options ?? {};
+
+  const stats: LegislationContentSyncResult = {
+    processed: 0,
+    downloaded: 0,
+    extracted: 0,
+    notFound: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  const whereClause: Record<string, unknown> = {
+    documentExternalId: { not: null },
+  };
+
+  if (!force) {
+    whereClause.exposeDesMotifs = null;
+  }
+
+  let dossiers = await db.legislativeDossier.findMany({
+    where: whereClause,
+    select: {
+      id: true,
+      externalId: true,
+      documentExternalId: true,
+      title: true,
+    },
+    orderBy: { filingDate: "desc" },
+  });
+
+  if (limit) {
+    dossiers = dossiers.slice(0, limit);
+  }
+
+  console.log(`Found ${dossiers.length} dossiers to process`);
+
+  if (dossiers.length === 0) {
+    return stats;
+  }
+
+  for (const dossier of dossiers) {
+    const docId = dossier.documentExternalId!;
+
+    try {
+      const buffer = await downloadDocx(docId);
+
+      if (!buffer) {
+        stats.notFound++;
+        stats.processed++;
+        continue;
+      }
+
+      stats.downloaded++;
+
+      const fullText = await extractText(buffer);
+      const expose = extractExposeDesMotifs(fullText);
+
+      if (expose) {
+        await db.legislativeDossier.update({
+          where: { id: dossier.id },
+          data: {
+            exposeDesMotifs: expose,
+            exposeSource: "docparl",
+          },
+        });
+        stats.extracted++;
+      } else {
+        stats.skipped++;
+      }
+
+      stats.processed++;
+    } catch (err) {
+      stats.errors.push(
+        `${dossier.externalId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      stats.processed++;
+    }
+  }
+
+  return stats;
+}

--- a/src/services/sync/legislation.ts
+++ b/src/services/sync/legislation.ts
@@ -1,0 +1,411 @@
+/**
+ * Service to sync legislative dossiers from data.assemblee-nationale.fr.
+ * Extracted from scripts/sync-legislation.ts for Inngest compatibility.
+ *
+ * NOTE: This service uses execSync("unzip ...") for ZIP extraction.
+ * This is a system tool invocation (not a Node.js script spawn) and is
+ * acceptable on Vercel serverless.
+ */
+
+import { db } from "@/lib/db";
+import { generateDateSlug } from "@/lib/utils";
+import { DossierStatus } from "@/generated/prisma";
+import * as fs from "fs";
+import * as path from "path";
+import * as https from "https";
+import { createWriteStream, mkdirSync, rmSync, readdirSync, readFileSync } from "fs";
+import { execSync } from "child_process";
+
+const DEFAULT_LEGISLATURE = 17;
+const TEMP_DIR = "/tmp/dossiers-legislatifs-an";
+const ZIP_URL_TEMPLATE =
+  "https://data.assemblee-nationale.fr/static/openData/repository/{leg}/loi/dossiers_legislatifs/Dossiers_Legislatifs.json.zip";
+
+const CATEGORY_MAPPING: Record<string, string> = {
+  "Projet de loi de finances": "Budget",
+  "Projet de loi de financement de la s\u00e9curit\u00e9 sociale": "Sant\u00e9",
+  "Proposition de loi ordinaire": "L\u00e9gislation",
+  "Projet de loi ordinaire": "L\u00e9gislation",
+  "Projet ou proposition de loi organique": "Institutionnel",
+  "Projet ou proposition de loi constitutionnelle": "Constitution",
+  "Projet de ratification des trait\u00e9s et conventions": "International",
+  "Commission d'enqu\u00eate": "Contr\u00f4le",
+  "Mission d'information": "Information",
+  "Rapport d'information": "Information",
+  "Rapport d'information sans mission": "Information",
+};
+
+export interface LegislationSyncResult {
+  dossiersProcessed: number;
+  dossiersCreated: number;
+  dossiersUpdated: number;
+  dossiersSkipped: number;
+  errors: string[];
+}
+
+interface ANDossier {
+  dossierParlementaire: {
+    "@xsi:type": string;
+    uid: string;
+    legislature: string;
+    titreDossier: {
+      titre: string;
+      titreChemin: string;
+      senatChemin?: string | null;
+    };
+    procedureParlementaire: {
+      code: string;
+      libelle: string;
+    };
+    initiateur?: {
+      acteurs?: {
+        acteur: ANActeur | ANActeur[];
+      };
+    } | null;
+    actesLegislatifs?: {
+      acteLegislatif: ANActe | ANActe[];
+    } | null;
+    fusionDossier?: string | null;
+  };
+}
+
+interface ANActeur {
+  acteurRef: string;
+  mandatRef: string;
+}
+
+interface ANActe {
+  "@xsi:type": string;
+  uid: string;
+  codeActe: string;
+  libelleActe: {
+    nomCanonique: string;
+    libelleCourt?: string;
+  };
+  organeRef: string;
+  dateActe: string | null;
+  actesLegislatifs?: {
+    acteLegislatif: ANActe | ANActe[];
+  } | null;
+  texteAssocie?: string;
+  texteAdopte?: string;
+}
+
+function findAllCodes(actes: ANActe | ANActe[] | undefined | null): string[] {
+  if (!actes) return [];
+  const acteArray = Array.isArray(actes) ? actes : [actes];
+  const codes: string[] = [];
+  for (const acte of acteArray) {
+    codes.push(acte.codeActe);
+    if (acte.actesLegislatifs?.acteLegislatif) {
+      codes.push(...findAllCodes(acte.actesLegislatifs.acteLegislatif));
+    }
+  }
+  return codes;
+}
+
+function findFirstDocumentRef(actes: ANActe | ANActe[] | undefined | null): string | null {
+  if (!actes) return null;
+  const acteArray = Array.isArray(actes) ? actes : [actes];
+  for (const acte of acteArray) {
+    if (acte.texteAssocie) return acte.texteAssocie;
+    if (acte.actesLegislatifs?.acteLegislatif) {
+      const found = findFirstDocumentRef(acte.actesLegislatifs.acteLegislatif);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function findAllDates(actes: ANActe | ANActe[] | undefined | null): Date[] {
+  if (!actes) return [];
+  const acteArray = Array.isArray(actes) ? actes : [actes];
+  const dates: Date[] = [];
+  for (const acte of acteArray) {
+    if (acte.dateActe) {
+      try {
+        const d = new Date(acte.dateActe);
+        if (!isNaN(d.getTime())) dates.push(d);
+      } catch {
+        // Ignore invalid dates
+      }
+    }
+    if (acte.actesLegislatifs?.acteLegislatif) {
+      dates.push(...findAllDates(acte.actesLegislatifs.acteLegislatif));
+    }
+  }
+  return dates;
+}
+
+function determineStatus(codes: string[], legislature?: number): DossierStatus {
+  if (codes.some((c) => c === "PROM" || c === "PROM-PUB")) return "ADOPTE";
+  if (codes.some((c) => c.includes("REJET"))) return "REJETE";
+  if (codes.some((c) => c.includes("RETRAIT") || c.includes("RETIRE"))) return "RETIRE";
+  if (codes.some((c) => c.startsWith("CC-SAISIE"))) return "CONSEIL_CONSTITUTIONNEL";
+  if (legislature && legislature < DEFAULT_LEGISLATURE) return "CADUQUE";
+
+  const hasDebates = codes.some(
+    (c) =>
+      c.includes("DEBATS-SEANCE") ||
+      c.includes("DEBATS-DEC") ||
+      c.startsWith("CMP") ||
+      c.startsWith("ANLUNI") ||
+      c.startsWith("ANLDEF") ||
+      c.startsWith("SNLDEF")
+  );
+  if (hasDebates) return "EN_COURS";
+
+  const hasCommitteeReport = codes.some(
+    (c) => c.includes("COM-FOND-RAPPORT") || c.includes("COM-AVIS-RAPPORT")
+  );
+  if (hasCommitteeReport) return "EN_COMMISSION";
+
+  return "DEPOSE";
+}
+
+function generateShortTitle(title: string): string {
+  let short = title
+    .replace(/^Projet de loi /i, "")
+    .replace(/^Proposition de loi /i, "")
+    .replace(/^(relatif|relative) (\u00e0|au|aux|\u00e0 la|\u00e0 l') /i, "")
+    .replace(/^(portant|visant \u00e0) /i, "")
+    .replace(/^(pour|sur) (le|la|les|l') /i, "");
+  short = short.charAt(0).toUpperCase() + short.slice(1);
+  if (short.length > 100) short = short.substring(0, 97) + "...";
+  return short;
+}
+
+function extractNumber(dossier: ANDossier): string | null {
+  const uid = dossier.dossierParlementaire.uid;
+  const procedure = dossier.dossierParlementaire.procedureParlementaire?.libelle || "";
+  const match = uid.match(/N(\d+)$/);
+  if (!match) return null;
+  const num = match[1];
+  if (procedure.toLowerCase().includes("projet")) return `PJL ${num}`;
+  if (procedure.toLowerCase().includes("proposition")) return `PPL ${num}`;
+  return num;
+}
+
+function getCategory(procedure: string): string | null {
+  return CATEGORY_MAPPING[procedure] || null;
+}
+
+async function generateUniqueDossierSlug(date: Date | null, title: string): Promise<string> {
+  const baseSlug = generateDateSlug(date, title);
+  const existing = await db.legislativeDossier.findUnique({
+    where: { slug: baseSlug },
+  });
+  if (!existing) return baseSlug;
+  let counter = 2;
+  while (counter < 100) {
+    const suffix = `-${counter}`;
+    const maxBaseLength = 80 - suffix.length;
+    const truncatedBase = baseSlug.slice(0, maxBaseLength).replace(/-$/, "");
+    const slugWithSuffix = `${truncatedBase}${suffix}`;
+    const existsWithSuffix = await db.legislativeDossier.findUnique({
+      where: { slug: slugWithSuffix },
+    });
+    if (!existsWithSuffix) return slugWithSuffix;
+    counter++;
+  }
+  return `${baseSlug.slice(0, 60)}-${Date.now()}`;
+}
+
+async function downloadFile(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const file = createWriteStream(dest);
+    https
+      .get(url, (response) => {
+        if (response.statusCode === 302 || response.statusCode === 301) {
+          const redirectUrl = response.headers.location;
+          if (redirectUrl) {
+            downloadFile(redirectUrl, dest).then(resolve).catch(reject);
+            return;
+          }
+        }
+        if (response.statusCode !== 200) {
+          reject(new Error(`HTTP ${response.statusCode} for ${url}`));
+          return;
+        }
+        response.pipe(file);
+        file.on("finish", () => {
+          file.close();
+          resolve();
+        });
+      })
+      .on("error", (err) => {
+        fs.unlinkSync(dest);
+        reject(err);
+      });
+  });
+}
+
+export async function syncLegislation(options?: {
+  legislature?: number;
+  activeOnly?: boolean;
+  todayOnly?: boolean;
+  limit?: number;
+}): Promise<LegislationSyncResult> {
+  const {
+    legislature = DEFAULT_LEGISLATURE,
+    activeOnly = false,
+    todayOnly = false,
+    limit,
+  } = options ?? {};
+
+  const stats: LegislationSyncResult = {
+    dossiersProcessed: 0,
+    dossiersCreated: 0,
+    dossiersUpdated: 0,
+    dossiersSkipped: 0,
+    errors: [],
+  };
+
+  try {
+    // Download ZIP
+    console.log("Downloading dossiers ZIP...");
+    const zipUrl = ZIP_URL_TEMPLATE.replace("{leg}", String(legislature));
+    const zipPath = path.join(TEMP_DIR, "dossiers.zip");
+
+    if (fs.existsSync(TEMP_DIR)) {
+      rmSync(TEMP_DIR, { recursive: true });
+    }
+    mkdirSync(TEMP_DIR, { recursive: true });
+
+    await downloadFile(zipUrl, zipPath);
+    console.log("Downloaded ZIP file");
+
+    // Extract ZIP (system tool, not Node.js script spawn)
+    execSync(`unzip -o "${zipPath}" -d "${TEMP_DIR}"`, { stdio: "pipe" });
+    console.log("Extracted ZIP file");
+
+    // List JSON files
+    const jsonDir = path.join(TEMP_DIR, "json", "dossierParlementaire");
+    if (!fs.existsSync(jsonDir)) {
+      throw new Error(`Directory not found: ${jsonDir}`);
+    }
+
+    let jsonFiles = readdirSync(jsonDir).filter((f) => f.endsWith(".json"));
+    jsonFiles = jsonFiles.filter((f) => f.includes(`L${legislature}`));
+
+    if (limit) {
+      jsonFiles = jsonFiles.slice(0, limit);
+    }
+
+    console.log(`Found ${jsonFiles.length} dossiers to process`);
+
+    for (const file of jsonFiles) {
+      try {
+        const filePath = path.join(jsonDir, file);
+        const content = readFileSync(filePath, "utf-8");
+        if (!content.trim()) {
+          stats.dossiersSkipped++;
+          continue;
+        }
+
+        const data: ANDossier = JSON.parse(content);
+        const dp = data.dossierParlementaire;
+
+        const type = dp["@xsi:type"];
+        if (
+          !type.includes("Legislatif") &&
+          !type.includes("Loi") &&
+          type !== "DossierLegislatif_Type"
+        ) {
+          stats.dossiersSkipped++;
+          continue;
+        }
+
+        const externalId = dp.uid;
+        const title = dp.titreDossier?.titre || "Sans titre";
+        const shortTitle = generateShortTitle(title);
+        const number = extractNumber(data);
+        const procedure = dp.procedureParlementaire?.libelle || "";
+        const category = getCategory(procedure);
+        const documentExternalId = findFirstDocumentRef(dp.actesLegislatifs?.acteLegislatif);
+
+        const allCodes = findAllCodes(dp.actesLegislatifs?.acteLegislatif);
+        const dossierLeg = parseInt(dp.legislature, 10) || legislature;
+        const status = determineStatus(allCodes, dossierLeg);
+
+        const activeStatuses: DossierStatus[] = [
+          "DEPOSE",
+          "EN_COMMISSION",
+          "EN_COURS",
+          "CONSEIL_CONSTITUTIONNEL",
+        ];
+        if (activeOnly && !activeStatuses.includes(status)) {
+          stats.dossiersSkipped++;
+          continue;
+        }
+
+        const allDates = findAllDates(dp.actesLegislatifs?.acteLegislatif).sort(
+          (a, b) => a.getTime() - b.getTime()
+        );
+
+        if (todayOnly && allDates.length > 0) {
+          const today = new Date().toISOString().split("T")[0];
+          const mostRecent = allDates[allDates.length - 1].toISOString().split("T")[0];
+          if (mostRecent !== today) {
+            stats.dossiersSkipped++;
+            continue;
+          }
+        }
+
+        const filingDate = allDates.length > 0 ? allDates[0] : null;
+        const adoptionDate =
+          status === "ADOPTE" && allDates.length > 0 ? allDates[allDates.length - 1] : null;
+
+        const sourceUrl = `https://www.assemblee-nationale.fr/dyn/${legislature}/dossiers/${dp.titreDossier?.titreChemin || externalId}`;
+
+        const existing = await db.legislativeDossier.findUnique({
+          where: { externalId },
+        });
+
+        const dossierData = {
+          externalId,
+          title,
+          shortTitle,
+          number,
+          status,
+          category,
+          filingDate,
+          adoptionDate,
+          sourceUrl,
+          documentExternalId,
+        };
+
+        if (existing) {
+          const updateData: typeof dossierData & { slug?: string } = {
+            ...dossierData,
+          };
+          if (!existing.slug) {
+            updateData.slug = await generateUniqueDossierSlug(filingDate, shortTitle || title);
+          }
+          await db.legislativeDossier.update({
+            where: { id: existing.id },
+            data: updateData,
+          });
+          stats.dossiersUpdated++;
+        } else {
+          const slug = await generateUniqueDossierSlug(filingDate, shortTitle || title);
+          await db.legislativeDossier.create({
+            data: { ...dossierData, slug },
+          });
+          stats.dossiersCreated++;
+        }
+
+        stats.dossiersProcessed++;
+      } catch (err) {
+        stats.errors.push(`${file}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    // Cleanup
+    rmSync(TEMP_DIR, { recursive: true });
+  } catch (err) {
+    stats.errors.push(`Fatal: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return stats;
+}

--- a/src/services/sync/mep-parties.ts
+++ b/src/services/sync/mep-parties.ts
@@ -1,0 +1,155 @@
+/**
+ * Service to associate French MEPs with their national political party.
+ * Uses Wikidata P102 (member of political party).
+ * Extracted from scripts/sync-mep-parties.ts for Inngest compatibility.
+ */
+
+import { WikidataService } from "@/lib/api";
+import type { WikidataPartyAffiliation } from "@/lib/api";
+import { db } from "@/lib/db";
+import { DataSource, MandateType } from "@/generated/prisma";
+import { politicianService } from "@/services/politician";
+import { WIKIDATA_SPARQL_RATE_LIMIT_MS } from "@/config/rate-limits";
+
+export interface MepPartiesSyncResult {
+  partiesSet: number;
+  alreadyCorrect: number;
+  partyNotInDB: number;
+  noPartyFound: number;
+  skippedHasParty: number;
+  errors: string[];
+}
+
+function findCurrentAffiliation(
+  affiliations: WikidataPartyAffiliation[]
+): WikidataPartyAffiliation | null {
+  if (affiliations.length === 0) return null;
+
+  const current = affiliations.filter((a) => !a.endDate);
+  if (current.length === 1) return current[0];
+
+  if (current.length > 1) {
+    return current.sort((a, b) => (b.startDate?.getTime() ?? 0) - (a.startDate?.getTime() ?? 0))[0];
+  }
+
+  return affiliations.sort((a, b) => (b.endDate?.getTime() ?? 0) - (a.endDate?.getTime() ?? 0))[0];
+}
+
+export async function syncMepParties(options?: {
+  limit?: number;
+  force?: boolean;
+}): Promise<MepPartiesSyncResult> {
+  const { limit, force = false } = options ?? {};
+
+  const wikidata = new WikidataService({
+    rateLimitMs: WIKIDATA_SPARQL_RATE_LIMIT_MS,
+  });
+
+  const stats: MepPartiesSyncResult = {
+    partiesSet: 0,
+    alreadyCorrect: 0,
+    partyNotInDB: 0,
+    noPartyFound: 0,
+    skippedHasParty: 0,
+    errors: [],
+  };
+
+  // 1. Load current MEPs with Wikidata IDs
+  console.log("Fetching current MEPs with Wikidata IDs...");
+
+  const meps = await db.politician.findMany({
+    where: {
+      mandates: {
+        some: { type: MandateType.DEPUTE_EUROPEEN, isCurrent: true },
+      },
+      externalIds: { some: { source: DataSource.WIKIDATA } },
+    },
+    include: {
+      externalIds: {
+        where: { source: DataSource.WIKIDATA },
+        take: 1,
+      },
+      currentParty: { select: { id: true, shortName: true } },
+    },
+    take: limit,
+  });
+
+  console.log(`Found ${meps.length} MEPs with Wikidata IDs`);
+
+  if (meps.length === 0) {
+    console.log("No MEPs with Wikidata IDs found. Run sync:wikidata-ids first.");
+    return stats;
+  }
+
+  // 2. Build map: wikidataId → local party ID
+  console.log("Building party Wikidata → local ID map...");
+
+  const partyExternalIds = await db.externalId.findMany({
+    where: {
+      source: DataSource.WIKIDATA,
+      partyId: { not: null },
+    },
+    select: {
+      externalId: true,
+      partyId: true,
+    },
+  });
+
+  const wikidataToPartyId = new Map<string, string>();
+  for (const ext of partyExternalIds) {
+    if (ext.partyId) {
+      wikidataToPartyId.set(ext.externalId, ext.partyId);
+    }
+  }
+
+  console.log(`Found ${wikidataToPartyId.size} parties with Wikidata IDs`);
+
+  // 3. Batch-fetch P102 from Wikidata
+  const wikidataIds = meps.map((m) => m.externalIds[0]?.externalId).filter(Boolean) as string[];
+
+  console.log(`Fetching P102 (political party) for ${wikidataIds.length} entities...`);
+  const partiesMap = await wikidata.getPoliticalParties(wikidataIds);
+  console.log(`Fetched party data for ${partiesMap.size} entities`);
+
+  // 4. Process each MEP
+  for (const mep of meps) {
+    const wikidataId = mep.externalIds[0]?.externalId;
+    if (!wikidataId) continue;
+
+    // Skip if already has party and not --force
+    if (mep.currentPartyId && !force) {
+      stats.skippedHasParty++;
+      continue;
+    }
+
+    const affiliations = partiesMap.get(wikidataId) || [];
+    const current = findCurrentAffiliation(affiliations);
+
+    if (!current) {
+      stats.noPartyFound++;
+      continue;
+    }
+
+    const localPartyId = wikidataToPartyId.get(current.partyWikidataId);
+
+    if (!localPartyId) {
+      stats.partyNotInDB++;
+      continue;
+    }
+
+    // Check if already correct
+    if (mep.currentPartyId === localPartyId) {
+      stats.alreadyCorrect++;
+      continue;
+    }
+
+    try {
+      await politicianService.setCurrentParty(mep.id, localPartyId);
+      stats.partiesSet++;
+    } catch (error) {
+      stats.errors.push(`${mep.fullName}: ${error}`);
+    }
+  }
+
+  return stats;
+}

--- a/src/services/sync/parties.ts
+++ b/src/services/sync/parties.ts
@@ -1,0 +1,382 @@
+/**
+ * Service to sync French political parties from local config + Wikidata.
+ * Extracted from scripts/sync-parties.ts for Inngest compatibility.
+ */
+
+import { db } from "@/lib/db";
+import { DataSource, PoliticalPosition } from "@/generated/prisma";
+import { FRENCH_ASSEMBLY_PARTIES, FRENCH_SENATE_PARTIES, type PartyConfig } from "@/config/parties";
+import { generateSlug } from "@/lib/utils";
+import { HTTPClient } from "@/lib/api/http-client";
+import { WIKIDATA_SPARQL_RATE_LIMIT_MS } from "@/config/rate-limits";
+
+export interface PartiesSyncResult {
+  configUpdated: number;
+  wikidataUpdated: number;
+  wikidataCreated: number;
+  skipped: number;
+  errors: string[];
+}
+
+const ALL_PARTY_CONFIGS: Record<string, PartyConfig> = {
+  ...FRENCH_ASSEMBLY_PARTIES,
+  ...FRENCH_SENATE_PARTIES,
+};
+
+const WIKIDATA_ENDPOINT = "https://query.wikidata.org/sparql";
+
+const POLITICAL_POSITION_MAP: Record<string, PoliticalPosition> = {
+  Q49768: PoliticalPosition.FAR_RIGHT,
+  Q3909293: PoliticalPosition.RIGHT,
+  Q844984: PoliticalPosition.CENTER_RIGHT,
+  Q28738992: PoliticalPosition.CENTER,
+  Q1293577: PoliticalPosition.CENTER,
+  Q844839: PoliticalPosition.CENTER_LEFT,
+  Q2169699: PoliticalPosition.LEFT,
+  Q214503: PoliticalPosition.FAR_LEFT,
+};
+
+interface WikidataPartyResult {
+  party: { value: string };
+  partyLabel: { value: string };
+  shortName?: { value: string };
+  foundedDate?: { value: string };
+  dissolvedDate?: { value: string };
+  color?: { value: string };
+  logo?: { value: string };
+  website?: { value: string };
+  headquarters?: { value: string };
+  ideology?: { value: string };
+  position?: { value: string };
+}
+
+async function applyLocalConfig(): Promise<{
+  updated: number;
+  notFound: string[];
+}> {
+  console.log("Applying local party configuration...");
+
+  let updated = 0;
+  const notFound: string[] = [];
+
+  for (const [abbrev, config] of Object.entries(ALL_PARTY_CONFIGS)) {
+    const party = await db.party.findUnique({
+      where: { shortName: config.shortName },
+    });
+
+    if (!party) {
+      const byName = await db.party.findUnique({
+        where: { name: config.fullName },
+      });
+
+      if (!byName) {
+        notFound.push(`${abbrev} (${config.shortName})`);
+        continue;
+      }
+    }
+
+    const partyId = party?.id;
+    if (!partyId) continue;
+
+    await db.party.update({
+      where: { id: partyId },
+      data: { color: config.color },
+    });
+
+    if (config.wikidataId) {
+      await db.externalId.upsert({
+        where: {
+          source_externalId: {
+            source: DataSource.WIKIDATA,
+            externalId: config.wikidataId,
+          },
+        },
+        create: {
+          partyId,
+          source: DataSource.WIKIDATA,
+          externalId: config.wikidataId,
+          url: `https://www.wikidata.org/wiki/${config.wikidataId}`,
+        },
+        update: { partyId },
+      });
+    }
+
+    updated++;
+  }
+
+  console.log(`  Updated ${updated} parties from local config`);
+  if (notFound.length > 0) {
+    console.log(
+      `  Not found: ${notFound.slice(0, 5).join(", ")}${notFound.length > 5 ? ` (+${notFound.length - 5} more)` : ""}`
+    );
+  }
+
+  return { updated, notFound };
+}
+
+async function fetchWikidataParties(): Promise<WikidataPartyResult[]> {
+  const sparqlClient = new HTTPClient({
+    rateLimitMs: WIKIDATA_SPARQL_RATE_LIMIT_MS,
+  });
+
+  const query = `
+    SELECT DISTINCT ?party ?partyLabel ?shortName ?foundedDate ?dissolvedDate ?color ?logo ?website ?headquarters
+           (GROUP_CONCAT(DISTINCT ?ideologyLabel; SEPARATOR=", ") AS ?ideology)
+           (SAMPLE(?positionId) AS ?position)
+    WHERE {
+      ?party wdt:P31/wdt:P279* wd:Q7278 .
+      ?party wdt:P17 wd:Q142 .
+      OPTIONAL { ?party wdt:P1813 ?shortName }
+      OPTIONAL { ?party wdt:P571 ?foundedDate }
+      OPTIONAL { ?party wdt:P576 ?dissolvedDate }
+      OPTIONAL { ?party wdt:P465 ?color }
+      OPTIONAL { ?party wdt:P154 ?logo }
+      OPTIONAL { ?party wdt:P856 ?website }
+      OPTIONAL { ?party wdt:P159 ?hq . ?hq rdfs:label ?headquarters . FILTER(LANG(?headquarters) = "fr") }
+      OPTIONAL { ?party wdt:P1142 ?ideologyItem . ?ideologyItem rdfs:label ?ideologyLabel . FILTER(LANG(?ideologyLabel) = "fr") }
+      OPTIONAL { ?party wdt:P1387 ?positionId }
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "fr,en" }
+    }
+    GROUP BY ?party ?partyLabel ?shortName ?foundedDate ?dissolvedDate ?color ?logo ?website ?headquarters
+    ORDER BY DESC(?foundedDate)
+    LIMIT 500
+  `;
+
+  const url = new URL(WIKIDATA_ENDPOINT);
+  url.searchParams.set("query", query);
+
+  const { data } = await sparqlClient.get<{
+    results: { bindings: WikidataPartyResult[] };
+  }>(url.toString(), { headers: { Accept: "application/json" } });
+  return data.results.bindings;
+}
+
+async function enrichFromWikidata(): Promise<{
+  updated: number;
+  created: number;
+  skipped: number;
+}> {
+  console.log("Enriching parties from Wikidata...");
+
+  const results = await fetchWikidataParties();
+  console.log(`  Found ${results.length} parties in Wikidata`);
+
+  let updated = 0;
+  let created = 0;
+  let skipped = 0;
+
+  for (const result of results) {
+    const wikidataId = result.party.value.split("/").pop() || "";
+    const name = result.partyLabel.value;
+
+    if (/^Q\d+$/.test(name)) {
+      skipped++;
+      continue;
+    }
+
+    if (result.dissolvedDate?.value) {
+      const dissolvedYear = new Date(result.dissolvedDate.value).getFullYear();
+      if (dissolvedYear < 1958) {
+        skipped++;
+        continue;
+      }
+    }
+
+    const shortName = result.shortName?.value || null;
+    const foundedDate = result.foundedDate?.value ? new Date(result.foundedDate.value) : null;
+    const dissolvedDate = result.dissolvedDate?.value ? new Date(result.dissolvedDate.value) : null;
+    const wikidataColor = result.color?.value
+      ? result.color.value.startsWith("#")
+        ? result.color.value
+        : `#${result.color.value}`
+      : null;
+    const logoUrl = result.logo?.value || null;
+    const website = result.website?.value || null;
+    const headquarters = result.headquarters?.value || null;
+    const ideology = result.ideology?.value || null;
+    const positionId = result.position?.value?.split("/").pop() || "";
+    const politicalPosition = POLITICAL_POSITION_MAP[positionId] || null;
+
+    try {
+      const existingByWikidata = await db.externalId.findUnique({
+        where: {
+          source_externalId: {
+            source: DataSource.WIKIDATA,
+            externalId: wikidataId,
+          },
+        },
+        include: { party: true },
+      });
+
+      if (existingByWikidata?.party) {
+        const party = existingByWikidata.party;
+        await db.party.update({
+          where: { id: party.id },
+          data: {
+            foundedDate: foundedDate || party.foundedDate,
+            dissolvedDate: dissolvedDate || party.dissolvedDate,
+            color: party.color || wikidataColor,
+            logoUrl: logoUrl || party.logoUrl,
+            website: website || party.website,
+            headquarters: headquarters || party.headquarters,
+            ideology: ideology || party.ideology,
+            ...(!party.politicalPositionOverride && politicalPosition
+              ? {
+                  politicalPosition,
+                  politicalPositionSource: "wikidata",
+                  politicalPositionSourceUrl: `https://www.wikidata.org/wiki/${wikidataId}`,
+                }
+              : {}),
+          },
+        });
+        updated++;
+        continue;
+      }
+
+      let party = await db.party.findFirst({
+        where: {
+          OR: [
+            { name: { equals: name, mode: "insensitive" as const } },
+            ...(shortName
+              ? [
+                  {
+                    shortName: {
+                      equals: shortName,
+                      mode: "insensitive" as const,
+                    },
+                  },
+                ]
+              : []),
+          ],
+        },
+      });
+
+      if (party) {
+        await db.party.update({
+          where: { id: party.id },
+          data: {
+            foundedDate: foundedDate || party.foundedDate,
+            dissolvedDate: dissolvedDate || party.dissolvedDate,
+            color: party.color || wikidataColor,
+            logoUrl: logoUrl || party.logoUrl,
+            website: website || party.website,
+            headquarters: headquarters || party.headquarters,
+            ideology: ideology || party.ideology,
+            ...(!party.politicalPositionOverride && politicalPosition
+              ? {
+                  politicalPosition,
+                  politicalPositionSource: "wikidata",
+                  politicalPositionSourceUrl: `https://www.wikidata.org/wiki/${wikidataId}`,
+                }
+              : {}),
+          },
+        });
+
+        await db.externalId.upsert({
+          where: {
+            source_externalId: {
+              source: DataSource.WIKIDATA,
+              externalId: wikidataId,
+            },
+          },
+          create: {
+            partyId: party.id,
+            source: DataSource.WIKIDATA,
+            externalId: wikidataId,
+            url: `https://www.wikidata.org/wiki/${wikidataId}`,
+          },
+          update: { partyId: party.id },
+        });
+
+        updated++;
+        continue;
+      }
+
+      if (!shortName) {
+        skipped++;
+        continue;
+      }
+
+      // Skip dissolved parties (>30 years)
+      if (dissolvedDate) {
+        const yearsAgo = (Date.now() - dissolvedDate.getTime()) / (365.25 * 24 * 60 * 60 * 1000);
+        if (yearsAgo > 30) {
+          skipped++;
+          continue;
+        }
+      }
+
+      const existingShort = await db.party.findUnique({
+        where: { shortName },
+      });
+      if (existingShort) {
+        skipped++;
+        continue;
+      }
+
+      party = await db.party.create({
+        data: {
+          name,
+          shortName,
+          slug: generateSlug(name),
+          foundedDate,
+          dissolvedDate,
+          color: wikidataColor,
+          logoUrl,
+          website,
+          headquarters,
+          ideology,
+          politicalPosition,
+          politicalPositionSource: politicalPosition ? "wikidata" : null,
+          politicalPositionSourceUrl: politicalPosition
+            ? `https://www.wikidata.org/wiki/${wikidataId}`
+            : null,
+        },
+      });
+
+      await db.externalId.create({
+        data: {
+          partyId: party.id,
+          source: DataSource.WIKIDATA,
+          externalId: wikidataId,
+          url: `https://www.wikidata.org/wiki/${wikidataId}`,
+        },
+      });
+
+      created++;
+    } catch {
+      skipped++;
+    }
+  }
+
+  console.log(`  Updated: ${updated}, Created: ${created}, Skipped: ${skipped}`);
+  return { updated, created, skipped };
+}
+
+export async function syncParties(options?: { configOnly?: boolean }): Promise<PartiesSyncResult> {
+  const { configOnly = false } = options ?? {};
+
+  const stats: PartiesSyncResult = {
+    configUpdated: 0,
+    wikidataUpdated: 0,
+    wikidataCreated: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  try {
+    const configResult = await applyLocalConfig();
+    stats.configUpdated = configResult.updated;
+
+    if (!configOnly) {
+      const wikidataResult = await enrichFromWikidata();
+      stats.wikidataUpdated = wikidataResult.updated;
+      stats.wikidataCreated = wikidataResult.created;
+      stats.skipped = wikidataResult.skipped;
+    }
+  } catch (error) {
+    stats.errors.push(String(error));
+  }
+
+  return stats;
+}

--- a/src/services/sync/president.ts
+++ b/src/services/sync/president.ts
@@ -1,0 +1,220 @@
+/**
+ * Service to sync the current President of the Republic.
+ * Extracted from scripts/sync-president.ts for Inngest compatibility.
+ */
+
+import { db } from "@/lib/db";
+import { generateSlug } from "@/lib/utils";
+import { MandateType, DataSource } from "@/generated/prisma";
+
+// Emmanuel Macron's data (from official sources and Wikidata Q3052772)
+const PRESIDENT_DATA = {
+  firstName: "Emmanuel",
+  lastName: "Macron",
+  fullName: "Emmanuel Macron",
+  civility: "M",
+  birthDate: new Date("1977-12-21"),
+  birthPlace: "Amiens (Somme)",
+  wikidataId: "Q3052772",
+  photoUrl:
+    "https://www.elysee.fr/images/default/0001/14/66e6e3b6bbd98-emmanuel-macron-portrait-officiel-2024.jpg?v=2",
+  partyShortName: "RE",
+};
+
+const MANDATE_DATA = {
+  type: MandateType.PRESIDENT_REPUBLIQUE,
+  title: "Président de la République française",
+  institution: "Présidence de la République",
+  startDate: new Date("2017-05-14"),
+  endDate: null,
+  isCurrent: true,
+  source: DataSource.GOUVERNEMENT,
+  sourceUrl: "https://www.elysee.fr/emmanuel-macron",
+};
+
+export interface PresidentSyncResult {
+  created: number;
+  updated: number;
+  errors: string[];
+}
+
+async function findOrCreateParty(): Promise<string | null> {
+  let party = await db.party.findFirst({
+    where: {
+      OR: [
+        { shortName: "RE" },
+        { shortName: "REN" },
+        { name: { contains: "Renaissance", mode: "insensitive" } },
+      ],
+    },
+  });
+
+  if (!party) {
+    party = await db.party.findFirst({
+      where: {
+        OR: [
+          { shortName: "LREM" },
+          { shortName: "REM" },
+          { name: { contains: "Marche", mode: "insensitive" } },
+        ],
+      },
+    });
+  }
+
+  if (!party) {
+    console.log("Creating Renaissance party...");
+    party = await db.party.create({
+      data: {
+        name: "Renaissance",
+        shortName: "RE",
+        slug: "renaissance",
+        color: "#FFCC00",
+        description:
+          "Parti politique français fondé en 2016 par Emmanuel Macron, initialement sous le nom de La République en marche (LREM).",
+        foundedDate: new Date("2016-04-06"),
+        ideology: "Libéralisme social, Progressisme, Pro-européanisme",
+        website: "https://parti-renaissance.fr/",
+      },
+    });
+    console.log(`Created party: ${party.name} (${party.shortName})`);
+  }
+
+  return party.id;
+}
+
+export async function syncPresident(): Promise<PresidentSyncResult> {
+  const stats: PresidentSyncResult = { created: 0, updated: 0, errors: [] };
+
+  try {
+    const slug = generateSlug(`${PRESIDENT_DATA.firstName}-${PRESIDENT_DATA.lastName}`);
+    const partyId = await findOrCreateParty();
+
+    let politician = await db.politician.findUnique({
+      where: { slug },
+      include: { mandates: true },
+    });
+
+    if (!politician) {
+      politician = await db.politician.findFirst({
+        where: {
+          firstName: {
+            equals: PRESIDENT_DATA.firstName,
+            mode: "insensitive",
+          },
+          lastName: {
+            equals: PRESIDENT_DATA.lastName,
+            mode: "insensitive",
+          },
+        },
+        include: { mandates: true },
+      });
+    }
+
+    if (politician) {
+      console.log(`Found existing politician: ${politician.fullName}`);
+
+      const existingMandate = politician.mandates.find(
+        (m) => m.type === MandateType.PRESIDENT_REPUBLIQUE
+      );
+
+      if (existingMandate) {
+        await db.mandate.update({
+          where: { id: existingMandate.id },
+          data: {
+            title: MANDATE_DATA.title,
+            institution: MANDATE_DATA.institution,
+            startDate: MANDATE_DATA.startDate,
+            endDate: MANDATE_DATA.endDate,
+            isCurrent: MANDATE_DATA.isCurrent,
+            sourceUrl: MANDATE_DATA.sourceUrl,
+          },
+        });
+      } else {
+        await db.mandate.create({
+          data: {
+            ...MANDATE_DATA,
+            politicianId: politician.id,
+          },
+        });
+      }
+
+      await db.politician.update({
+        where: { id: politician.id },
+        data: {
+          civility: PRESIDENT_DATA.civility,
+          birthDate: PRESIDENT_DATA.birthDate,
+          birthPlace: PRESIDENT_DATA.birthPlace,
+          photoUrl: PRESIDENT_DATA.photoUrl,
+          photoSource: "elysee",
+          currentPartyId: partyId,
+        },
+      });
+
+      stats.updated = 1;
+      console.log(`Updated ${politician.fullName}`);
+    } else {
+      politician = await db.politician.create({
+        data: {
+          slug,
+          firstName: PRESIDENT_DATA.firstName,
+          lastName: PRESIDENT_DATA.lastName,
+          fullName: PRESIDENT_DATA.fullName,
+          civility: PRESIDENT_DATA.civility,
+          birthDate: PRESIDENT_DATA.birthDate,
+          birthPlace: PRESIDENT_DATA.birthPlace,
+          photoUrl: PRESIDENT_DATA.photoUrl,
+          photoSource: "elysee",
+          currentPartyId: partyId,
+          mandates: {
+            create: MANDATE_DATA,
+          },
+        },
+        include: { mandates: true },
+      });
+
+      stats.created = 1;
+      console.log(`Created ${politician.fullName}`);
+    }
+
+    // Upsert external IDs
+    await db.externalId.upsert({
+      where: {
+        source_externalId: {
+          source: DataSource.WIKIDATA,
+          externalId: PRESIDENT_DATA.wikidataId,
+        },
+      },
+      create: {
+        politicianId: politician.id,
+        source: DataSource.WIKIDATA,
+        externalId: PRESIDENT_DATA.wikidataId,
+        url: `https://www.wikidata.org/wiki/${PRESIDENT_DATA.wikidataId}`,
+      },
+      update: {
+        politicianId: politician.id,
+      },
+    });
+
+    await db.externalId.upsert({
+      where: {
+        source_externalId: {
+          source: DataSource.MANUAL,
+          externalId: "president-macron",
+        },
+      },
+      create: {
+        politicianId: politician.id,
+        source: DataSource.MANUAL,
+        externalId: "president-macron",
+        url: "https://www.elysee.fr/emmanuel-macron",
+      },
+      update: {
+        politicianId: politician.id,
+      },
+    });
+  } catch (error) {
+    stats.errors.push(String(error));
+  }
+
+  return stats;
+}

--- a/src/services/sync/wikidata-ids.ts
+++ b/src/services/sync/wikidata-ids.ts
@@ -1,0 +1,198 @@
+/**
+ * Service to enrich politicians with Wikidata IDs by name matching.
+ * Extracted from scripts/sync-wikidata-ids.ts for Inngest compatibility.
+ *
+ * NOTE: CheckpointManager and resume logic are CLI-only concerns
+ * and are NOT included here. The CLI script still handles those.
+ */
+
+import { WikidataService } from "@/lib/api";
+import { db } from "@/lib/db";
+import { WIKIDATA_RATE_LIMIT_MS } from "@/config/rate-limits";
+import { DataSource } from "@/generated/prisma";
+
+export interface WikidataIdsSyncResult {
+  processed: number;
+  idsCreated: number;
+  alreadyUsed: number;
+  noMatch: number;
+  multipleMatches: number;
+  errors: string[];
+}
+
+interface CandidateInfo {
+  id: string;
+  label: string;
+  isFrench: boolean;
+  isPolitician: boolean;
+  birthDate: Date | null;
+}
+
+function datesMatch(date1: Date | null, date2: Date | null, toleranceDays = 5): boolean {
+  if (!date1 || !date2) return true;
+  const diff = Math.abs(date1.getTime() - date2.getTime());
+  const daysDiff = diff / (1000 * 60 * 60 * 24);
+  return daysDiff <= toleranceDays;
+}
+
+function findBestMatch(
+  candidates: CandidateInfo[],
+  politicianBirthDate: Date | null
+): CandidateInfo | null {
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  // Strategy 1: Match by birth date
+  for (const candidate of candidates) {
+    if (candidate.birthDate && politicianBirthDate) {
+      if (datesMatch(politicianBirthDate, candidate.birthDate)) {
+        return candidate;
+      }
+    }
+  }
+
+  // Strategy 2: Filter to only politicians
+  const politicianCandidates = candidates.filter((c) => c.isPolitician);
+
+  if (politicianCandidates.length === 1) {
+    return politicianCandidates[0];
+  }
+
+  if (politicianCandidates.length > 1 && politicianBirthDate) {
+    for (const candidate of politicianCandidates) {
+      if (candidate.birthDate && datesMatch(politicianBirthDate, candidate.birthDate)) {
+        return candidate;
+      }
+    }
+  }
+
+  // Strategy 3: If only one French person, take it
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  return null;
+}
+
+export async function syncWikidataIds(options?: {
+  limit?: number;
+}): Promise<WikidataIdsSyncResult> {
+  const { limit } = options ?? {};
+
+  const wikidata = new WikidataService({ rateLimitMs: WIKIDATA_RATE_LIMIT_MS });
+
+  const stats: WikidataIdsSyncResult = {
+    processed: 0,
+    idsCreated: 0,
+    alreadyUsed: 0,
+    noMatch: 0,
+    multipleMatches: 0,
+    errors: [],
+  };
+
+  console.log("Fetching politicians from database...");
+
+  const politicians = await db.politician.findMany({
+    where: {
+      externalIds: {
+        none: { source: DataSource.WIKIDATA },
+      },
+    },
+    select: {
+      id: true,
+      fullName: true,
+      firstName: true,
+      lastName: true,
+      birthDate: true,
+    },
+    take: limit,
+    orderBy: { lastName: "asc" },
+  });
+
+  console.log(`Found ${politicians.length} politicians without Wikidata ID`);
+
+  if (politicians.length === 0) {
+    return stats;
+  }
+
+  for (const politician of politicians) {
+    stats.processed++;
+
+    try {
+      // Search by name
+      const searchResults = await wikidata.searchByName(politician.fullName, {
+        limit: 5,
+      });
+
+      if (searchResults.length === 0) {
+        stats.noMatch++;
+        continue;
+      }
+
+      // Get details for all candidates
+      const candidateIds = searchResults.map((r) => r.id);
+      const candidateDetails = await wikidata.checkFrenchPoliticians(candidateIds);
+
+      // Build candidate info list
+      const candidates: CandidateInfo[] = [];
+      candidateDetails.forEach((details, id) => {
+        const searchResult = searchResults.find((r) => r.id === id);
+        if (details.isFrench) {
+          candidates.push({
+            id,
+            label: searchResult?.label || id,
+            isFrench: details.isFrench,
+            isPolitician: details.isPolitician,
+            birthDate: details.birthDate,
+          });
+        }
+      });
+
+      if (candidates.length === 0) {
+        stats.noMatch++;
+        continue;
+      }
+
+      // Find best match
+      const bestMatch = findBestMatch(candidates, politician.birthDate);
+
+      if (!bestMatch) {
+        stats.multipleMatches++;
+        continue;
+      }
+
+      const wikidataId = bestMatch.id;
+
+      // Check if this Wikidata ID is already used
+      const existing = await db.externalId.findUnique({
+        where: {
+          source_externalId: {
+            source: DataSource.WIKIDATA,
+            externalId: wikidataId,
+          },
+        },
+      });
+
+      if (existing) {
+        stats.alreadyUsed++;
+        continue;
+      }
+
+      await db.externalId.create({
+        data: {
+          politicianId: politician.id,
+          source: DataSource.WIKIDATA,
+          externalId: wikidataId,
+          url: `https://www.wikidata.org/wiki/${wikidataId}`,
+        },
+      });
+      stats.idsCreated++;
+      console.log(`${politician.fullName} -> ${wikidataId}`);
+    } catch (error) {
+      stats.errors.push(`${politician.fullName}: ${error}`);
+    }
+  }
+
+  return stats;
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Inngest migration — **eliminates all `execSync` calls** from `src/inngest/`, making every sync function compatible with Vercel serverless.

### What changed

- **13 stub functions** replaced with real implementations using `createSyncFunction` + dynamic imports
- **5 grouped functions** (sync-politicians, generate-ai, index-embeddings, discover-affairs, sync-legislation) migrated from `execSync` to dynamic imports
- **12 new services** extracted from CLI scripts into `src/services/sync/` (president, birthdates, wikidata-ids, parties, mep-parties, careers, generate-biographies, generate-summaries, generate-scrutin-summaries, discover-affairs, legislation, legislation-content)
- **sync-daily** rewritten: 16 steps now use dynamic imports instead of `execSync`
- **Cron reactivated**: `0 5,11,19 * * *` (3x/day)
- **`createStubFunction` removed** — no longer needed

### What stays the same

- All CLI scripts (`scripts/*.ts`) are unchanged and still work via `npx tsx`
- Phase 1 migrated functions untouched
- No schema changes

### Verification

- `npx tsc --noEmit` — zero new errors
- `npm run build` — success
- `npm test` — 204 tests pass
- `grep -r "execSync" src/inngest/` — zero results
- `grep -r "child_process" src/inngest/` — zero results

## Test plan

- [ ] Deploy to staging
- [ ] Admin → Syncs → trigger "Assemblée nationale" → should complete
- [ ] Admin → Syncs → trigger "Wikidata IDs" → should work (previously failed as stub)
- [ ] Inngest dashboard → verify runs complete successfully
- [ ] Trigger sync-daily manually → verify all 16 steps execute
- [ ] Verify cron fires automatically at scheduled times

Closes #155