### PR TITLE
perf(cache): Phase 1 - scoped invalidation for municipales-2026 figées data

### DIFF
--- a/src/__tests__/lib/cache-tags.test.ts
+++ b/src/__tests__/lib/cache-tags.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const updateTagSpy = vi.fn();
+const revalidatePathSpy = vi.fn();
+
+vi.mock("next/cache", () => ({
+  updateTag: (tag: string) => updateTagSpy(tag),
+  revalidatePath: (path: string, type: string) => revalidatePathSpy(path, type),
+}));
+
+import { invalidateEntity, revalidateAll, ALL_TAGS } from "@/lib/cache";
+
+describe("cache invalidation scopes", () => {
+  beforeEach(() => {
+    updateTagSpy.mockClear();
+    revalidatePathSpy.mockClear();
+  });
+
+  it("invalidateEntity('election') updates only the global elections tag", () => {
+    invalidateEntity("election");
+    expect(updateTagSpy).toHaveBeenCalledWith("elections");
+    expect(updateTagSpy).not.toHaveBeenCalledWith("elections-municipales-2026");
+  });
+
+  it("invalidateEntity('election-2026') updates only the municipales-2026 tag", () => {
+    invalidateEntity("election-2026");
+    expect(updateTagSpy).toHaveBeenCalledWith("elections-municipales-2026");
+    expect(updateTagSpy).not.toHaveBeenCalledWith("elections");
+  });
+
+  it("revalidateAll does NOT touch elections-municipales-2026", () => {
+    revalidateAll();
+    const calls = updateTagSpy.mock.calls.map((c) => c[0]);
+    expect(calls).not.toContain("elections-municipales-2026");
+  });
+
+  it("ALL_TAGS does not include the figées municipales tag", () => {
+    expect(ALL_TAGS).not.toContain("elections-municipales-2026" as never);
+  });
+});

--- a/src/app/api/cron/revalidate/route.ts
+++ b/src/app/api/cron/revalidate/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { revalidateAll, revalidateTags } from "@/lib/cache";
+import { ALL_TAGS, revalidateAll, revalidateTags } from "@/lib/cache";
+
+const CRON_ALLOWED_TAGS = [...ALL_TAGS, "elections-municipales-2026"] as const;
+type CronAllowedTag = (typeof CRON_ALLOWED_TAGS)[number];
 
 /**
  * POST /api/cron/revalidate
@@ -27,7 +30,18 @@ export async function POST(request: NextRequest) {
     }
 
     if (Array.isArray(body.tags) && body.tags.length > 0) {
-      const tags = body.tags.filter((t: unknown) => typeof t === "string");
+      const tags = body.tags.filter(
+        (t: unknown): t is CronAllowedTag =>
+          typeof t === "string" && (CRON_ALLOWED_TAGS as readonly string[]).includes(t)
+      );
+
+      if (tags.length === 0) {
+        return NextResponse.json(
+          { error: "No valid tags provided", allowed: CRON_ALLOWED_TAGS },
+          { status: 400 }
+        );
+      }
+
       revalidateTags(tags);
       return NextResponse.json({ revalidated: tags });
     }

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -31,7 +31,8 @@ export type EntityType =
   | "dossier"
   | "factcheck"
   | "stats"
-  | "election";
+  | "election"
+  | "election-2026";
 
 /**
  * Invalidate CDN cache and data cache for a given entity.
@@ -100,6 +101,10 @@ export function invalidateEntity(type: EntityType, slug?: string): void {
 
     case "election":
       updateTag("elections");
+      break;
+
+    case "election-2026":
+      updateTag("elections-municipales-2026");
       break;
   }
 }

--- a/src/lib/data/municipales.ts
+++ b/src/lib/data/municipales.ts
@@ -419,7 +419,7 @@ export const getCommune = cache(async function getCommune(inseeCode: string) {
 
 export async function getDepartmentPartyData() {
   "use cache";
-  cacheTag("elections");
+  cacheTag("elections-municipales-2026");
   cacheLife("hours");
 
   const election = await db.election.findUnique({
@@ -474,6 +474,10 @@ export async function getDepartmentPartyData() {
 }
 
 export const getParityBySize = cache(async function getParityBySize() {
+  "use cache";
+  cacheTag("elections-municipales-2026");
+  cacheLife("hours");
+
   const election = await db.election.findUnique({
     where: { slug: "municipales-2026" },
     select: { id: true },
@@ -514,6 +518,10 @@ export const getParityBySize = cache(async function getParityBySize() {
 });
 
 export const getCumulCandidates = cache(async function getCumulCandidates() {
+  "use cache";
+  cacheTag("elections-municipales-2026");
+  cacheLife("hours");
+
   const election = await db.election.findUnique({
     where: { slug: "municipales-2026" },
     select: { id: true },
@@ -613,6 +621,10 @@ export const getMissingMaires = cache(async function getMissingMaires() {
 });
 
 export const getParityOutliers = cache(async function getParityOutliers() {
+  "use cache";
+  cacheTag("elections-municipales-2026");
+  cacheLife("hours");
+
   const election = await db.election.findUnique({
     where: { slug: "municipales-2026" },
     select: { id: true },

--- a/src/lib/security/schemas/admin.ts
+++ b/src/lib/security/schemas/admin.ts
@@ -8,6 +8,7 @@ const VALID_CACHE_TAGS = [
   "dossiers",
   "factchecks",
   "elections",
+  "elections-municipales-2026",
 ] as const;
 
 export const revalidateCacheSchema = z.union([


### PR DESCRIPTION
## Summary

- Add new `election-2026` entity type that targets the `elections-municipales-2026` cache tag
- Tag `getParityOutliers`, `getParityBySize`, `getCumulCandidates`, `getDepartmentPartyData` with the new scope
- Keep the new tag out of `revalidateAll()` so global syncs do not wipe figées 2026 aggregates
- Whitelist the new tag in admin and cron revalidation endpoints
- Audited `invalidateEntity("election")` callers: zero production callers exist today, no parallel migration needed (Task 1.4 was an audit-only no-op)

## Why

12 393 calls to `getDepartmentPartyData` over 7 days despite `cacheLife("hours")`, because `cacheTag("elections")` was being purged on every full sync. This PR isolates the figées 2026 dataset so it stays cached across syncs.

Part of the broader Supabase perf improvements plan: `docs/superpowers/plans/2026-04-07-supabase-perf-improvements.md` (Phase 1 of 5).

## Test plan

- [x] `npm run test:run` passes (932 tests, including 4 new `cache-tags.test.ts`)
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [ ] Manual smoke on /elections/municipales-2026/parite, /elections/municipales-2026/maires, /elections/municipales-2026 (on Vercel preview deploy)
- [ ] Check Vercel preview logs for runtime errors
- [ ] After merge: watch next Supabase performance report for `getParityOutliers`, `getParityBySize`, `getDepartmentPartyData` call counts (target: < 50/week for parity, < 200/week for dept-party)