### PR TITLE
perf(candidacy): Phase 2 - composite indexes for parity and dept queries

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1517,6 +1517,9 @@ model Candidacy {
 
   @@index([electionId])
   @@index([electionId, communeId])
+  @@index([electionId, listName])
+  @@index([electionId, partyLabel])
+  @@index([electionId, candidateId])
   @@index([politicianId])
   @@index([constituencyCode])
   @@index([candidateId])

--- a/scripts/tmp-create-candidacy-indexes.ts
+++ b/scripts/tmp-create-candidacy-indexes.ts
@@ -1,0 +1,75 @@
+/**
+ * Creates the Phase 2 composite indexes on Candidacy via CREATE INDEX CONCURRENTLY.
+ *
+ * Why CONCURRENTLY: standard CREATE INDEX takes an ACCESS EXCLUSIVE lock for the
+ * duration of the build (10-30s on 1.28M rows). CONCURRENTLY uses two sequential
+ * scans without blocking writes, at the cost of being slower wall-clock.
+ *
+ * Why not db:push: db:push wraps DDL in a transaction. CREATE INDEX CONCURRENTLY
+ * cannot run inside a transaction. Hence: raw SQL via direct connection.
+ *
+ * Idempotent: uses IF NOT EXISTS so re-running is safe.
+ *
+ * Usage:
+ *   npx dotenv -e .env -- npx tsx scripts/tmp-create-candidacy-indexes.ts
+ */
+import { db } from "../src/lib/db";
+
+const INDEXES = [
+  {
+    name: "Candidacy_electionId_listName_idx",
+    sql: `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Candidacy_electionId_listName_idx"
+          ON "Candidacy" ("electionId", "listName")`,
+    purpose: "parity by list (queries #4, #5)",
+  },
+  {
+    name: "Candidacy_electionId_partyLabel_idx",
+    sql: `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Candidacy_electionId_partyLabel_idx"
+          ON "Candidacy" ("electionId", "partyLabel")`,
+    purpose: "department x party (query #1)",
+  },
+  {
+    name: "Candidacy_electionId_candidateId_idx",
+    sql: `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Candidacy_electionId_candidateId_idx"
+          ON "Candidacy" ("electionId", "candidateId")`,
+    purpose: "join Candidate for parity",
+  },
+];
+
+async function main() {
+  console.log(`Creating ${INDEXES.length} indexes on Candidacy...`);
+
+  for (const idx of INDEXES) {
+    const start = Date.now();
+    console.log(`\n[${idx.name}] ${idx.purpose}`);
+    try {
+      // $executeRawUnsafe is required because CREATE INDEX CONCURRENTLY can't be
+      // parameterized and the SQL is static (no user input). The repo's CI grep
+      // forbids $executeRawUnsafe in src/ but allows it in scripts/.
+      await db.$executeRawUnsafe(idx.sql);
+      console.log(`  -> created in ${Date.now() - start}ms`);
+    } catch (err) {
+      console.error(`  -> FAILED: ${(err as Error).message}`);
+      throw err;
+    }
+  }
+
+  console.log('\nRunning ANALYZE "Candidacy" to refresh planner stats...');
+  await db.$executeRawUnsafe(`ANALYZE "Candidacy"`);
+  console.log("  -> done");
+
+  console.log("\nVerification - listing all indexes on Candidacy:");
+  const rows = await db.$queryRaw<{ indexname: string }[]>`
+    SELECT indexname FROM pg_indexes WHERE tablename = 'Candidacy' ORDER BY indexname
+  `;
+  for (const row of rows) {
+    console.log(`  ${row.indexname}`);
+  }
+
+  await db.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add three composite indexes on Candidacy: `(electionId, listName)`, `(electionId, partyLabel)`, `(electionId, candidateId)`
- Indexes were created via `CREATE INDEX CONCURRENTLY` against production before this PR (zero write blocking)
- Schema declarations added for codegen consistency, eliminating drift between Prisma schema and live DB
- `ANALYZE "Candidacy"` run after index creation to refresh planner stats
- Helper script `scripts/tmp-create-candidacy-indexes.ts` retained as reference for future operators

## Why
Queries #1, #4, #5 in the Supabase performance report all GROUP BY on Candidacy filtered by `electionId`. Without composite indexes, Postgres falls back to Seq Scan on 1.28M rows.

## Verification
- [x] Three indexes confirmed live in production via `pg_indexes` query
- [x] Typecheck clean
- [x] Format check clean
- [x] Test suite: 928 / 928 pass
- [ ] Mean time of query #1 drops below 1s on next Supabase report (post-deploy validation)
- [ ] No regression on `sync:resultats-csv` write throughput

## Notes
- This PR is mostly schema-tracking: the indexes were already created in production by the operator script. Merging brings `prisma/schema.prisma` in sync with the live DB so future migrations don't accidentally drop them.
- Phase 1 (PR #294) was merged immediately before this PR. Phase 2 is independent of Phase 1 and addresses a different bottleneck (planner choice vs cache scope).