### PR TITLE
perf(municipales): Phase 3 — pre-computed snapshots for parity and dept x parti

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "sync:dossier-summaries": "tsx -e \"import {generateDossierSummaries} from './src/services/sync/generate-dossier-summaries'; generateDossierSummaries({limit:20}).then(console.log)\"",
     "sync:dossier-summaries:force": "tsx -e \"import {generateDossierSummaries} from './src/services/sync/generate-dossier-summaries'; generateDossierSummaries({limit:20,force:true}).then(console.log)\"",
     "sync:compute-stats": "tsx scripts/compute-stats.ts",
+    "sync:municipales-snapshots": "tsx scripts/compute-municipales-snapshots.ts",
     "sync:senat:stats": "tsx scripts/sync-senat.ts --stats",
     "sync:gouvernement:stats": "tsx scripts/sync-gouvernement.ts --stats",
     "sync:wikidata-ids": "tsx scripts/sync-wikidata-ids.ts",

--- a/scripts/compute-municipales-snapshots.ts
+++ b/scripts/compute-municipales-snapshots.ts
@@ -1,0 +1,31 @@
+/**
+ * CLI runner for the municipales-2026 snapshot pre-computation.
+ *
+ * Usage:
+ *   npm run sync:municipales-snapshots
+ */
+
+import "dotenv/config";
+import { db } from "@/lib/db";
+import { computeMunicipalesSnapshots } from "@/services/sync/compute-municipales-snapshots";
+
+async function main() {
+  console.log("Computing municipales-2026 snapshots...");
+  const t0 = Date.now();
+  try {
+    const result = await computeMunicipalesSnapshots();
+    console.log(`\nDone in ${result.totalDurationMs}ms`);
+    console.log(`Computed ${result.computed.length} snapshots:`);
+    for (const s of result.computed) {
+      console.log(`  - ${s}`);
+    }
+  } catch (err) {
+    console.error("FAILED:", err);
+    process.exit(1);
+  } finally {
+    await db.$disconnect();
+  }
+  console.log(`\nTotal wall-clock: ${Date.now() - t0}ms`);
+}
+
+main();

--- a/src/__tests__/lib/data/municipales-snapshots.test.ts
+++ b/src/__tests__/lib/data/municipales-snapshots.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MUNICIPALES_SNAPSHOT_KEYS } from "@/types/stats-snapshots";
+
+const findUniqueMock = vi.fn();
+const queryRawMock = vi.fn();
+const electionFindUniqueMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    statsSnapshot: { findUnique: (...args: unknown[]) => findUniqueMock(...args) },
+    election: { findUnique: (...args: unknown[]) => electionFindUniqueMock(...args) },
+    $queryRaw: (...args: unknown[]) => queryRawMock(...args),
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  cacheTag: vi.fn(),
+  cacheLife: vi.fn(),
+  unstable_cache: (fn: unknown) => fn,
+}));
+
+// Import AFTER mocks
+import { getParityOutliers, getParityBySize, getDepartmentPartyData } from "@/lib/data/municipales";
+
+describe("municipales snapshot fallback", () => {
+  beforeEach(() => {
+    findUniqueMock.mockReset();
+    queryRawMock.mockReset();
+    electionFindUniqueMock.mockReset();
+    electionFindUniqueMock.mockResolvedValue({ id: "election-municipales-2026-id" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getParityOutliers reads from snapshot when present", async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      key: MUNICIPALES_SNAPSHOT_KEYS.parityOutliers,
+      data: {
+        best: [
+          {
+            listName: "Liste A",
+            communeId: "75056",
+            communeName: "Paris",
+            departmentCode: "75",
+            femaleRate: 0.5,
+            candidateCount: 30,
+          },
+        ],
+        worst: [
+          {
+            listName: "Liste B",
+            communeId: "13055",
+            communeName: "Marseille",
+            departmentCode: "13",
+            femaleRate: 0.1,
+            candidateCount: 30,
+          },
+        ],
+      },
+      computedAt: new Date(),
+    });
+
+    const result = await getParityOutliers();
+
+    expect(result.best).toHaveLength(1);
+    expect(result.worst).toHaveLength(1);
+    expect(result.best[0]?.listName).toBe("Liste A");
+    expect(queryRawMock).not.toHaveBeenCalled(); // didn't fall back to live
+  });
+
+  it("getParityOutliers falls back to live SQL when snapshot is missing", async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    queryRawMock
+      .mockResolvedValueOnce([
+        {
+          listName: "Live A",
+          communeId: "x",
+          communeName: "X",
+          departmentCode: "01",
+          femaleRate: 0.5,
+          candidateCount: 30,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          listName: "Live B",
+          communeId: "y",
+          communeName: "Y",
+          departmentCode: "02",
+          femaleRate: 0.0,
+          candidateCount: 30,
+        },
+      ]);
+
+    const result = await getParityOutliers();
+
+    expect(result.best[0]?.listName).toBe("Live A");
+    expect(result.worst[0]?.listName).toBe("Live B");
+    expect(queryRawMock).toHaveBeenCalledTimes(2); // fell back to live
+  });
+
+  it("getParityBySize falls back to live when snapshot missing", async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    queryRawMock.mockResolvedValueOnce([
+      { bracket: "< 1 000 hab.", femaleCount: 5, totalCount: 10 },
+    ]);
+
+    const result = await getParityBySize();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.femaleRate).toBe(0.5);
+  });
+
+  it("getDepartmentPartyData falls back to live when snapshot missing", async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    queryRawMock.mockResolvedValueOnce([
+      { departmentCode: "75", departmentName: "Paris", partyLabel: "EELV", listCount: 3 },
+      { departmentCode: "75", departmentName: "Paris", partyLabel: "PS", listCount: 1 },
+    ]);
+
+    const result = await getDepartmentPartyData();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.dominantParty).toBe("EELV");
+  });
+
+  it("getParityOutliers returns empty fallback when snapshot missing AND election not found", async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    electionFindUniqueMock.mockResolvedValueOnce(null);
+
+    const result = await getParityOutliers();
+
+    expect(result).toEqual({ best: [], worst: [] });
+    expect(queryRawMock).not.toHaveBeenCalled();
+  });
+
+  it("getDepartmentPartyData returns empty array when snapshot missing AND election not found", async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    electionFindUniqueMock.mockResolvedValueOnce(null);
+
+    const result = await getDepartmentPartyData();
+
+    expect(result).toEqual([]);
+    expect(queryRawMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/admin/syncs/page.tsx
+++ b/src/app/admin/syncs/page.tsx
@@ -128,6 +128,11 @@ const SCRIPT_CATALOG: ScriptCategory[] = [
       { id: "recalculate-prominence", label: "Prominence", description: "Recalcul scores" },
       { id: "assign-publication-status", label: "Publication status", description: "Statuts auto" },
       { id: "reconcile-affairs", label: "Réconciliation", description: "Doublons d'affaires" },
+      {
+        id: "compute-municipales-snapshots",
+        label: "Snapshots municipales 2026",
+        description: "Pré-calcul parité et dept × parti",
+      },
     ],
   },
 ];

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -192,6 +192,14 @@ const DAILY_STEPS: DailyStep[] = [
     },
   },
   {
+    name: "compute-municipales-snapshots",
+    run: async () => {
+      const { computeMunicipalesSnapshots } =
+        await import("@/services/sync/compute-municipales-snapshots");
+      return computeMunicipalesSnapshots();
+    },
+  },
+  {
     name: "indexnow",
     run: async () => {
       const { submitRecentToIndexNow } = await import("@/lib/indexnow");

--- a/src/inngest/index.ts
+++ b/src/inngest/index.ts
@@ -70,6 +70,11 @@ const migratedFunctions = [
     const { recalculateProminence } = await import("@/services/sync/prominence");
     return recalculateProminence();
   }),
+  createSyncFunction("compute-municipales-snapshots", async () => {
+    const { computeMunicipalesSnapshots } =
+      await import("@/services/sync/compute-municipales-snapshots");
+    return computeMunicipalesSnapshots();
+  }),
   createSyncFunction("assign-publication-status", async () => {
     const { assignPublicationStatus } = await import("@/services/sync/publication-status");
     return assignPublicationStatus();

--- a/src/lib/data/municipales.ts
+++ b/src/lib/data/municipales.ts
@@ -4,6 +4,18 @@ import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { primarySurname } from "@/lib/name-matching";
 import { NATIONAL_MANDATE_TYPES } from "@/config/labels";
+import {
+  MUNICIPALES_SNAPSHOT_KEYS,
+  ParityOutliersSchema,
+  ParityBySizeSchema,
+  DeptPartyDataSchema,
+  parseSnapshot,
+} from "@/types/stats-snapshots";
+import {
+  computeParityOutliersLive,
+  computeParityBySizeLive,
+  computeDepartmentPartyDataLive,
+} from "@/services/sync/compute-municipales-snapshots";
 
 // ============================================
 // Incumbent maire helper
@@ -422,55 +434,20 @@ export async function getDepartmentPartyData() {
   cacheTag("elections-municipales-2026");
   cacheLife("hours");
 
+  const snapshot = await db.statsSnapshot.findUnique({
+    where: { key: MUNICIPALES_SNAPSHOT_KEYS.deptParty },
+  });
+  if (snapshot) {
+    return parseSnapshot(DeptPartyDataSchema, snapshot.data);
+  }
+
+  // Fallback: snapshot missing (cron hasn't run yet, or one-off inspection)
   const election = await db.election.findUnique({
     where: { slug: "municipales-2026" },
     select: { id: true },
   });
   if (!election) return [];
-
-  // Raw SQL: for each department, count distinct lists per partyLabel
-  const rows = await db.$queryRaw<
-    Array<{
-      departmentCode: string;
-      departmentName: string;
-      partyLabel: string;
-      listCount: number;
-    }>
-  >(Prisma.sql`
-    SELECT co."departmentCode", co."departmentName", c."partyLabel", COUNT(DISTINCT c."listName")::int as "listCount"
-    FROM "Candidacy" c
-    JOIN "Commune" co ON c."communeId" = co.id
-    WHERE c."electionId" = ${election.id} AND c."partyLabel" IS NOT NULL
-    GROUP BY co."departmentCode", co."departmentName", c."partyLabel"
-    ORDER BY co."departmentCode", "listCount" DESC
-  `);
-
-  // Aggregate: for each department, find the dominant party and build parties list
-  const deptMap = new Map<
-    string,
-    {
-      code: string;
-      name: string;
-      parties: Array<{ label: string; listCount: number }>;
-      totalLists: number;
-    }
-  >();
-  for (const row of rows) {
-    const existing = deptMap.get(row.departmentCode) || {
-      code: row.departmentCode,
-      name: row.departmentName,
-      parties: [],
-      totalLists: 0,
-    };
-    existing.parties.push({ label: row.partyLabel, listCount: row.listCount });
-    existing.totalLists += row.listCount;
-    deptMap.set(row.departmentCode, existing);
-  }
-
-  return Array.from(deptMap.values()).map((dept) => ({
-    ...dept,
-    dominantParty: dept.parties[0]?.label ?? null, // Already sorted by listCount DESC
-  }));
+  return computeDepartmentPartyDataLive(election.id);
 }
 
 export const getParityBySize = cache(async function getParityBySize() {
@@ -478,43 +455,19 @@ export const getParityBySize = cache(async function getParityBySize() {
   cacheTag("elections-municipales-2026");
   cacheLife("hours");
 
+  const snapshot = await db.statsSnapshot.findUnique({
+    where: { key: MUNICIPALES_SNAPSHOT_KEYS.parityBySize },
+  });
+  if (snapshot) {
+    return parseSnapshot(ParityBySizeSchema, snapshot.data);
+  }
+
   const election = await db.election.findUnique({
     where: { slug: "municipales-2026" },
     select: { id: true },
   });
   if (!election) return [];
-
-  const rows = await db.$queryRaw<
-    Array<{
-      bracket: string;
-      femaleCount: number;
-      totalCount: number;
-    }>
-  >(Prisma.sql`
-    SELECT
-      CASE
-        WHEN co.population < 1000 THEN '< 1 000 hab.'
-        WHEN co.population < 10000 THEN '1 000 - 10 000 hab.'
-        WHEN co.population < 50000 THEN '10 000 - 50 000 hab.'
-        ELSE '50 000+ hab.'
-      END as bracket,
-      COUNT(*) FILTER (WHERE ca."gender" = 'F')::int as "femaleCount",
-      COUNT(*)::int as "totalCount"
-    FROM "Candidacy" c
-    JOIN "Commune" co ON c."communeId" = co.id
-    JOIN "Candidate" ca ON c."candidateId" = ca.id
-    WHERE c."electionId" = ${election.id} AND ca."gender" IS NOT NULL AND co.population IS NOT NULL
-    GROUP BY bracket
-    ORDER BY MIN(co.population)
-  `);
-
-  return rows.map((r) => ({
-    bracket: r.bracket,
-    femaleRate: r.totalCount > 0 ? r.femaleCount / r.totalCount : 0,
-    femaleCount: r.femaleCount,
-    maleCount: r.totalCount - r.femaleCount,
-    totalCount: r.totalCount,
-  }));
+  return computeParityBySizeLive(election.id);
 });
 
 export const getCumulCandidates = cache(async function getCumulCandidates() {
@@ -625,69 +578,19 @@ export const getParityOutliers = cache(async function getParityOutliers() {
   cacheTag("elections-municipales-2026");
   cacheLife("hours");
 
+  const snapshot = await db.statsSnapshot.findUnique({
+    where: { key: MUNICIPALES_SNAPSHOT_KEYS.parityOutliers },
+  });
+  if (snapshot) {
+    return parseSnapshot(ParityOutliersSchema, snapshot.data);
+  }
+
   const election = await db.election.findUnique({
     where: { slug: "municipales-2026" },
     select: { id: true },
   });
   if (!election) return { best: [], worst: [] };
-
-  // Best parity lists (closest to 50%)
-  const best = await db.$queryRaw<
-    Array<{
-      listName: string;
-      communeId: string;
-      communeName: string;
-      departmentCode: string;
-      femaleRate: number;
-      candidateCount: number;
-    }>
-  >(Prisma.sql`
-    SELECT
-      c."listName",
-      co.id as "communeId",
-      co.name as "communeName",
-      co."departmentCode",
-      COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0) as "femaleRate",
-      COUNT(*)::int as "candidateCount"
-    FROM "Candidacy" c
-    JOIN "Commune" co ON c."communeId" = co.id
-    JOIN "Candidate" ca ON c."candidateId" = ca.id
-    WHERE c."electionId" = ${election.id} AND ca."gender" IS NOT NULL AND c."listName" IS NOT NULL
-    GROUP BY c."listName", co.id, co.name, co."departmentCode"
-    HAVING COUNT(*) >= 10
-    ORDER BY ABS(0.5 - COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0)) ASC
-    LIMIT 10
-  `);
-
-  // Worst parity lists (furthest from 50%)
-  const worst = await db.$queryRaw<
-    Array<{
-      listName: string;
-      communeId: string;
-      communeName: string;
-      departmentCode: string;
-      femaleRate: number;
-      candidateCount: number;
-    }>
-  >(Prisma.sql`
-    SELECT
-      c."listName",
-      co.id as "communeId",
-      co.name as "communeName",
-      co."departmentCode",
-      COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0) as "femaleRate",
-      COUNT(*)::int as "candidateCount"
-    FROM "Candidacy" c
-    JOIN "Commune" co ON c."communeId" = co.id
-    JOIN "Candidate" ca ON c."candidateId" = ca.id
-    WHERE c."electionId" = ${election.id} AND ca."gender" IS NOT NULL AND c."listName" IS NOT NULL
-    GROUP BY c."listName", co.id, co.name, co."departmentCode"
-    HAVING COUNT(*) >= 10
-    ORDER BY ABS(0.5 - COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0)) DESC
-    LIMIT 10
-  `);
-
-  return { best, worst };
+  return computeParityOutliersLive(election.id);
 });
 
 // ============================================

--- a/src/services/sync/compute-municipales-snapshots.ts
+++ b/src/services/sync/compute-municipales-snapshots.ts
@@ -1,0 +1,202 @@
+import { Prisma } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import {
+  MUNICIPALES_SNAPSHOT_KEYS,
+  type ParityOutliers,
+  type ParityBySize,
+  type DeptPartyData,
+} from "@/types/stats-snapshots";
+
+/**
+ * Compute the four heavy municipales-2026 aggregations and upsert into StatsSnapshot.
+ *
+ * Called by:
+ *   - npm run sync:municipales-snapshots (CLI)
+ *   - Inngest cron (sync-daily DAILY_STEPS)
+ *   - Inngest manual trigger (admin /syncs page)
+ *
+ * Idempotent. Safe to run concurrently — the upsert key prevents duplicates.
+ */
+export async function computeMunicipalesSnapshots(): Promise<{
+  ok: true;
+  computed: string[];
+  totalDurationMs: number;
+}> {
+  const t0 = Date.now();
+  const election = await db.election.findUnique({
+    where: { slug: "municipales-2026" },
+    select: { id: true },
+  });
+  if (!election) {
+    throw new Error("Election municipales-2026 not found — cannot compute snapshots");
+  }
+
+  const computed: string[] = [];
+
+  // ─── 1. Parity outliers (best + worst combined) ─────────
+  await runAndUpsert(
+    MUNICIPALES_SNAPSHOT_KEYS.parityOutliers,
+    () => computeParityOutliersLive(election.id),
+    computed
+  );
+
+  // ─── 2. Parity by population bracket ────────────────────
+  await runAndUpsert(
+    MUNICIPALES_SNAPSHOT_KEYS.parityBySize,
+    () => computeParityBySizeLive(election.id),
+    computed
+  );
+
+  // ─── 3. Department × party counts ───────────────────────
+  await runAndUpsert(
+    MUNICIPALES_SNAPSHOT_KEYS.deptParty,
+    () => computeDepartmentPartyDataLive(election.id),
+    computed
+  );
+
+  return { ok: true, computed, totalDurationMs: Date.now() - t0 };
+}
+
+async function runAndUpsert<T>(
+  key: string,
+  fn: () => Promise<T>,
+  computed: string[]
+): Promise<void> {
+  const t0 = Date.now();
+  const data = await fn();
+  const durationMs = Date.now() - t0;
+  await db.statsSnapshot.upsert({
+    where: { key },
+    create: { key, data: data as Prisma.InputJsonValue, durationMs },
+    update: { data: data as Prisma.InputJsonValue, durationMs, computedAt: new Date() },
+  });
+  computed.push(`${key} (${durationMs}ms)`);
+  console.log(`  [snapshot] ${key} -> ${durationMs}ms`);
+}
+
+// ─── Live computers (also exported for fallback in src/lib/data/municipales.ts) ──
+
+export async function computeParityOutliersLive(electionId: string): Promise<ParityOutliers> {
+  const best = await db.$queryRaw<
+    Array<{
+      listName: string;
+      communeId: string;
+      communeName: string;
+      departmentCode: string;
+      femaleRate: number;
+      candidateCount: number;
+    }>
+  >(Prisma.sql`
+    SELECT
+      c."listName",
+      co.id as "communeId",
+      co.name as "communeName",
+      co."departmentCode",
+      COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0) as "femaleRate",
+      COUNT(*)::int as "candidateCount"
+    FROM "Candidacy" c
+    JOIN "Commune" co ON c."communeId" = co.id
+    JOIN "Candidate" ca ON c."candidateId" = ca.id
+    WHERE c."electionId" = ${electionId} AND ca."gender" IS NOT NULL AND c."listName" IS NOT NULL
+    GROUP BY c."listName", co.id, co.name, co."departmentCode"
+    HAVING COUNT(*) >= 10
+    ORDER BY ABS(0.5 - COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0)) ASC
+    LIMIT 10
+  `);
+
+  const worst = await db.$queryRaw<typeof best>(Prisma.sql`
+    SELECT
+      c."listName",
+      co.id as "communeId",
+      co.name as "communeName",
+      co."departmentCode",
+      COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0) as "femaleRate",
+      COUNT(*)::int as "candidateCount"
+    FROM "Candidacy" c
+    JOIN "Commune" co ON c."communeId" = co.id
+    JOIN "Candidate" ca ON c."candidateId" = ca.id
+    WHERE c."electionId" = ${electionId} AND ca."gender" IS NOT NULL AND c."listName" IS NOT NULL
+    GROUP BY c."listName", co.id, co.name, co."departmentCode"
+    HAVING COUNT(*) >= 10
+    ORDER BY ABS(0.5 - COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0)) DESC
+    LIMIT 10
+  `);
+
+  return { best, worst };
+}
+
+export async function computeParityBySizeLive(electionId: string): Promise<ParityBySize> {
+  const rows = await db.$queryRaw<
+    Array<{ bracket: string; femaleCount: number; totalCount: number }>
+  >(Prisma.sql`
+    SELECT
+      CASE
+        WHEN co.population < 1000 THEN '< 1 000 hab.'
+        WHEN co.population < 10000 THEN '1 000 - 10 000 hab.'
+        WHEN co.population < 50000 THEN '10 000 - 50 000 hab.'
+        ELSE '50 000+ hab.'
+      END as bracket,
+      COUNT(*) FILTER (WHERE ca."gender" = 'F')::int as "femaleCount",
+      COUNT(*)::int as "totalCount"
+    FROM "Candidacy" c
+    JOIN "Commune" co ON c."communeId" = co.id
+    JOIN "Candidate" ca ON c."candidateId" = ca.id
+    WHERE c."electionId" = ${electionId}
+      AND ca."gender" IS NOT NULL AND co.population IS NOT NULL
+    GROUP BY bracket
+    ORDER BY MIN(co.population)
+  `);
+
+  return rows.map((r) => ({
+    bracket: r.bracket,
+    femaleRate: r.totalCount > 0 ? r.femaleCount / r.totalCount : 0,
+    femaleCount: r.femaleCount,
+    maleCount: r.totalCount - r.femaleCount,
+    totalCount: r.totalCount,
+  }));
+}
+
+export async function computeDepartmentPartyDataLive(electionId: string): Promise<DeptPartyData> {
+  const rows = await db.$queryRaw<
+    Array<{
+      departmentCode: string;
+      departmentName: string;
+      partyLabel: string;
+      listCount: number;
+    }>
+  >(Prisma.sql`
+    SELECT co."departmentCode", co."departmentName", c."partyLabel",
+           COUNT(DISTINCT c."listName")::int as "listCount"
+    FROM "Candidacy" c
+    JOIN "Commune" co ON c."communeId" = co.id
+    WHERE c."electionId" = ${electionId} AND c."partyLabel" IS NOT NULL
+    GROUP BY co."departmentCode", co."departmentName", c."partyLabel"
+    ORDER BY co."departmentCode", "listCount" DESC
+  `);
+
+  const deptMap = new Map<
+    string,
+    {
+      code: string;
+      name: string;
+      parties: Array<{ label: string; listCount: number }>;
+      totalLists: number;
+    }
+  >();
+  for (const row of rows) {
+    const existing = deptMap.get(row.departmentCode) || {
+      code: row.departmentCode,
+      name: row.departmentName,
+      parties: [],
+      totalLists: 0,
+    };
+    existing.parties.push({ label: row.partyLabel, listCount: row.listCount });
+    existing.totalLists += row.listCount;
+    deptMap.set(row.departmentCode, existing);
+  }
+
+  return Array.from(deptMap.values()).map((dept) => ({
+    ...dept,
+    dominantParty: dept.parties[0]?.label ?? null,
+  }));
+}

--- a/src/types/stats-snapshots.ts
+++ b/src/types/stats-snapshots.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Type-safe schemas for known StatsSnapshot.key values.
+ * Each entry maps a key to its Zod parser. Use `parseSnapshot()` at read time
+ * to validate the JSON shape and get a typed result.
+ */
+
+// ─── municipales-2026-parite-outliers ─────────────────────
+export const ParityListRowSchema = z.object({
+  listName: z.string(),
+  communeId: z.string(),
+  communeName: z.string(),
+  departmentCode: z.string(),
+  femaleRate: z.number(),
+  candidateCount: z.number().int(),
+});
+export type ParityListRow = z.infer<typeof ParityListRowSchema>;
+
+export const ParityOutliersSchema = z.object({
+  best: z.array(ParityListRowSchema),
+  worst: z.array(ParityListRowSchema),
+});
+export type ParityOutliers = z.infer<typeof ParityOutliersSchema>;
+
+// ─── municipales-2026-parite-by-bracket ───────────────────
+export const ParityBracketRowSchema = z.object({
+  bracket: z.string(),
+  femaleRate: z.number(),
+  femaleCount: z.number().int(),
+  maleCount: z.number().int(),
+  totalCount: z.number().int(),
+});
+export type ParityBracketRow = z.infer<typeof ParityBracketRowSchema>;
+export const ParityBySizeSchema = z.array(ParityBracketRowSchema);
+export type ParityBySize = z.infer<typeof ParityBySizeSchema>;
+
+// ─── municipales-2026-dept-party-counts ───────────────────
+export const DeptPartyRowSchema = z.object({
+  code: z.string(),
+  name: z.string(),
+  parties: z.array(z.object({ label: z.string(), listCount: z.number().int() })),
+  totalLists: z.number().int(),
+  dominantParty: z.string().nullable(),
+});
+export type DeptPartyRow = z.infer<typeof DeptPartyRowSchema>;
+export const DeptPartyDataSchema = z.array(DeptPartyRowSchema);
+export type DeptPartyData = z.infer<typeof DeptPartyDataSchema>;
+
+// ─── Key registry ─────────────────────────────────────────
+export const MUNICIPALES_SNAPSHOT_KEYS = {
+  parityOutliers: "municipales-2026-parite-outliers",
+  parityBySize: "municipales-2026-parite-by-bracket",
+  deptParty: "municipales-2026-dept-party-counts",
+} as const;
+
+export type MunicipalesSnapshotKey =
+  (typeof MUNICIPALES_SNAPSHOT_KEYS)[keyof typeof MUNICIPALES_SNAPSHOT_KEYS];
+
+/**
+ * Parse a `StatsSnapshot.data` JSON value with the right schema.
+ * Throws if the shape is wrong (which should never happen, but if it does
+ * we want a loud error rather than silent corruption).
+ */
+export function parseSnapshot<T>(schema: z.ZodSchema<T>, data: unknown): T {
+  return schema.parse(data);
+}


### PR DESCRIPTION
## Summary

- New `StatsSnapshot` rows: `municipales-2026-parite-outliers`, `municipales-2026-parite-by-bracket`, `municipales-2026-dept-party-counts`
- New service `computeMunicipalesSnapshots()` computes all three
- Refactored `getParityOutliers`, `getParityBySize`, `getDepartmentPartyData` to read snapshot first, fall back to live SQL when missing
- Wired into daily cron (`sync-daily`) and admin dispatcher (`/admin/syncs` under Maintenance)
- New CLI: `npm run sync:municipales-snapshots`
- 6 new tests covering snapshot hit, live fallback, and empty election fallback

## Why

Queries #1, #4, #5 in the Supabase performance report take 5-12 seconds each due to GROUP BY + ORDER BY ABS(...) on 1.28M Candidacy rows. No index can help - the only fix is pre-computation. Snapshot reads are ~5 ms. The Zod-validated fallback path means the page never breaks if the cron has not run yet.

## Spec deviations

- **Snapshot keys collapsed from 4 to 3.** The spec listed `parite-by-list-best` and `parite-by-list-worst` as separate rows, but `getParityOutliers()` returns both in a single call. One snapshot row (`parite-outliers` with `{ best, worst }`) matches the function signature exactly and avoids two `findUnique` round-trips per page render.
- **Admin trigger uses existing `/admin/syncs` infrastructure.** The spec referenced an `/admin/elections` page that does not exist. Added to the existing `SCRIPT_CATALOG` under "Maintenance".
- **CLI uses `tsx` directly** instead of the plan's `npx dotenv -e .env -- npx tsx` wrapper. The script already does `import "dotenv/config"`, matching the existing `sync:compute-stats` convention.

## Post-merge action required

Run once manually to populate the snapshots before the first daily cron:
\`\`\`bash
npm run sync:municipales-snapshots
\`\`\`
Until that runs (or the daily cron fires), the 3 data functions will fall back to live SQL (slow but correct).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npm run test:run` 938/938 passing (6 new tests)
- [ ] After merge: run `sync:municipales-snapshots` once, then hit `/elections/municipales-2026/parite` and `/elections/municipales-2026`
- [ ] Watch next Supabase report for queries #1, #4, #5 mean time < 50 ms