### PR TITLE
perf(votes): Phase 5a — denormalize votingDate + chamber (expand half)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -877,6 +877,14 @@ model Vote {
 
   position VotePosition // POUR, CONTRE, ABSTENTION, ABSENT
 
+  // Phase 5a expand-contract: denormalized from Scrutin.votingDate and
+  // Scrutin.chamber to avoid forced JOINs on hot queries (sort by date,
+  // filter by chamber). Backfilled in Phase 5a, made NOT NULL + indexed
+  // in Phase 5b. Maintained by Postgres trigger (Phase 5b) for the rare
+  // case where Scrutin.votingDate or Scrutin.chamber is updated.
+  votingDate DateTime?
+  chamber    Chamber?
+
   @@unique([scrutinId, politicianId])
   @@index([politicianId])
   @@index([politicianId, position])

--- a/scripts/backfill-vote-denorm.ts
+++ b/scripts/backfill-vote-denorm.ts
@@ -1,0 +1,121 @@
+/**
+ * One-shot backfill for Phase 5a Vote denormalization.
+ *
+ * Populates Vote.votingDate AND Vote.chamber from the parent Scrutin row for
+ * any Vote where either denorm field is NULL.
+ *
+ * Strategy: iterate scrutins (~10K of them) and issue one indexed UPDATE per
+ * scrutin. This avoids the seq-scan-on-NULL trap that a naive
+ * "WHERE votingDate IS NULL LIMIT N" approach would trigger on a 1.5M-row table.
+ *
+ * Idempotent: re-running this is safe (the UPDATE filters on
+ * "votingDate IS NULL OR chamber IS NULL" so already-backfilled rows are
+ * skipped).
+ * Resumable: progress is logged after each scrutin, and interrupting + re-running
+ * picks up where it left off (the WHERE filters on NULL).
+ *
+ * Production scale: ~10K scrutins × avg 150 votes = ~1.5M rows.
+ * Expect ~3-5 minutes total wall clock.
+ *
+ * Run:
+ *   npx dotenv -e .env -- npx tsx scripts/backfill-vote-denorm.ts
+ *
+ * Dry-run (count only, no writes):
+ *   npx dotenv -e .env -- npx tsx scripts/backfill-vote-denorm.ts --dry-run
+ */
+import { db } from "@/lib/db";
+
+const PROGRESS_EVERY = 100; // log every N scrutins
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const t0 = Date.now();
+
+  console.log(`[backfill-vote-denorm] starting (dry-run: ${dryRun})`);
+
+  // Count rows that need a backfill (one scan, fast enough at 1.5M)
+  const [{ count: nullCount }] = await db.$queryRaw<[{ count: bigint }]>`
+    SELECT COUNT(*)::bigint as count
+    FROM "Vote"
+    WHERE "votingDate" IS NULL OR "chamber" IS NULL
+  `;
+  console.log(`[backfill-vote-denorm] ${nullCount} Vote rows need backfill`);
+
+  if (dryRun) {
+    console.log("[backfill-vote-denorm] dry-run, exiting");
+    return;
+  }
+  if (nullCount === BigInt(0)) {
+    console.log("[backfill-vote-denorm] nothing to do, exiting");
+    return;
+  }
+
+  // Find scrutins that have at least one Vote needing backfill.
+  // We use a DISTINCT subquery to avoid scanning Vote multiple times.
+  const scrutinIds = await db.$queryRaw<Array<{ id: string }>>`
+    SELECT DISTINCT v."scrutinId" as id
+    FROM "Vote" v
+    WHERE v."votingDate" IS NULL OR v."chamber" IS NULL
+    ORDER BY v."scrutinId"
+  `;
+  console.log(`[backfill-vote-denorm] ${scrutinIds.length} scrutins to process`);
+
+  let totalUpdated = BigInt(0);
+  let processed = 0;
+
+  for (const { id: scrutinId } of scrutinIds) {
+    // Single-statement UPDATE: indexed lookup by scrutinId, no seq scan.
+    const result = await db.$queryRaw<[{ updated: bigint }]>`
+      WITH src AS (
+        SELECT "votingDate", "chamber" FROM "Scrutin" WHERE id = ${scrutinId}
+      ),
+      upd AS (
+        UPDATE "Vote" v
+        SET "votingDate" = src."votingDate", "chamber" = src."chamber"
+        FROM src
+        WHERE v."scrutinId" = ${scrutinId}
+          AND (v."votingDate" IS NULL OR v."chamber" IS NULL)
+        RETURNING v.id
+      )
+      SELECT COUNT(*)::bigint as updated FROM upd
+    `;
+
+    const updated = result[0]?.updated ?? BigInt(0);
+    totalUpdated += updated;
+    processed += 1;
+
+    if (processed % PROGRESS_EVERY === 0) {
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+      console.log(
+        `[backfill-vote-denorm] processed ${processed}/${scrutinIds.length} scrutins, ${totalUpdated} rows updated (${elapsed}s elapsed)`
+      );
+    }
+  }
+
+  const totalElapsed = ((Date.now() - t0) / 1000).toFixed(1);
+  console.log(
+    `[backfill-vote-denorm] DONE: ${totalUpdated} rows across ${processed} scrutins in ${totalElapsed}s`
+  );
+
+  // Verify zero NULLs remain
+  const [{ count: remaining }] = await db.$queryRaw<[{ count: bigint }]>`
+    SELECT COUNT(*)::bigint as count
+    FROM "Vote"
+    WHERE "votingDate" IS NULL OR "chamber" IS NULL
+  `;
+  if (remaining > BigInt(0)) {
+    console.warn(
+      `[backfill-vote-denorm] WARN: ${remaining} rows still NULL — did syncs run during backfill? Re-run the script.`
+    );
+    process.exitCode = 1;
+  } else {
+    console.log("[backfill-vote-denorm] verified: 0 NULL rows");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("[backfill-vote-denorm] FAILED:", err);
+    process.exit(1);
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/seed-fixtures.ts
+++ b/scripts/seed-fixtures.ts
@@ -593,6 +593,11 @@ async function seed() {
       p.mandates.some((m) => m.type === "DEPUTE" && m.isCurrent && s.chamber === "AN")
     );
     const positions = ["POUR", "CONTRE", "ABSTENTION", "POUR", "CONTRE"] as const;
+    // Phase 5a denormalization: must populate votingDate + chamber on every
+    // Vote row. This is the SECOND write surface for these denorm fields —
+    // the canonical helper is `writeVotesForScrutin()` in
+    // `src/services/sync/scrutins-vote-writer.ts`. If you change the shape
+    // of denormalized fields, update BOTH this seed loop AND the helper.
     for (let i = 0; i < deputies.length; i++) {
       const polId = politicianMap.get(deputies[i]!.lastName)!;
       await db.vote.create({
@@ -600,6 +605,8 @@ async function seed() {
           scrutinId: scrutin.id,
           politicianId: polId,
           position: positions[i % positions.length]!,
+          votingDate: scrutin.votingDate,
+          chamber: scrutin.chamber,
         },
       });
     }

--- a/src/__tests__/services/sync/votes-voting-date.test.ts
+++ b/src/__tests__/services/sync/votes-voting-date.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const createManyMock = vi.fn();
+const updateMock = vi.fn();
+const deleteManyMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    vote: {
+      createMany: (...args: unknown[]) => createManyMock(...args),
+      deleteMany: (...args: unknown[]) => deleteManyMock(...args),
+    },
+    scrutin: {
+      update: (...args: unknown[]) => updateMock(...args),
+    },
+  },
+}));
+
+describe("Vote denorm fields are populated by sync write paths", () => {
+  beforeEach(() => {
+    createManyMock.mockReset();
+    deleteManyMock.mockReset();
+    updateMock.mockReset();
+  });
+
+  it("writeVotesForScrutin writes votingDate AND chamber on every Vote row", async () => {
+    // Simulate the per-scrutin write block: load votesToCreate + scrutin metadata,
+    // call createMany with denormalized votingDate + chamber.
+    const scrutinVotingDate = new Date("2025-03-15T15:00:00Z");
+    const scrutinChamber = "AN" as const;
+    const votesToCreate = [
+      { politicianId: "p1", position: "POUR" },
+      { politicianId: "p2", position: "CONTRE" },
+    ];
+
+    // This is the SHAPE we want production code to produce after Task 5a.3:
+    const expectedData = votesToCreate.map((v) => ({
+      scrutinId: "s1",
+      politicianId: v.politicianId,
+      position: v.position,
+      votingDate: scrutinVotingDate, // <-- denorm field 1
+      chamber: scrutinChamber, // <-- denorm field 2
+    }));
+
+    const { writeVotesForScrutin } = await import("@/services/sync/scrutins-vote-writer");
+
+    await writeVotesForScrutin({
+      scrutinId: "s1",
+      votingDate: scrutinVotingDate,
+      chamber: scrutinChamber,
+      votes: votesToCreate as never,
+    });
+
+    expect(createManyMock).toHaveBeenCalledWith({
+      data: expectedData,
+      skipDuplicates: true,
+    });
+  });
+
+  it("the helper rejects calls without votingDate", async () => {
+    const { writeVotesForScrutin } = await import("@/services/sync/scrutins-vote-writer");
+
+    await expect(
+      writeVotesForScrutin({
+        scrutinId: "s1",
+        // @ts-expect-error -- intentional missing field
+        votingDate: undefined,
+        chamber: "AN",
+        votes: [],
+      })
+    ).rejects.toThrow(/votingDate is required/);
+  });
+
+  it("the helper rejects calls without chamber", async () => {
+    const { writeVotesForScrutin } = await import("@/services/sync/scrutins-vote-writer");
+
+    await expect(
+      writeVotesForScrutin({
+        scrutinId: "s1",
+        votingDate: new Date(),
+        // @ts-expect-error -- intentional missing field
+        chamber: undefined,
+        votes: [],
+      })
+    ).rejects.toThrow(/chamber is required/);
+  });
+});

--- a/src/services/sync/scrutins-an.ts
+++ b/src/services/sync/scrutins-an.ts
@@ -9,6 +9,7 @@
 import { db } from "@/lib/db";
 import { syncMetadata, hashFile, hashVotes, ProgressTracker } from "@/lib/sync";
 import { computeGroupPositionsForScrutin } from "@/services/sync/compute-group-positions";
+import { writeVotesForScrutin } from "@/services/sync/scrutins-vote-writer";
 import { generateDateSlug, generateUniqueSlug } from "@/lib/utils";
 import { VotePosition, VotingResult, DataSource } from "@/generated/prisma";
 import { classifyScrutinTitle } from "@/lib/scrutin-type";
@@ -405,17 +406,11 @@ export async function syncScrutinsAN(
             if (scrutin.votesHash === newHash) {
               stats.votesSkipped += votesToCreate.length;
             } else {
-              await db.vote.deleteMany({
-                where: { scrutinId: scrutin.id },
-              });
-
-              await db.vote.createMany({
-                data: votesToCreate.map((v) => ({
-                  scrutinId: scrutin.id,
-                  politicianId: v.politicianId,
-                  position: v.position,
-                })),
-                skipDuplicates: true,
+              await writeVotesForScrutin({
+                scrutinId: scrutin.id,
+                votingDate: scrutin.votingDate,
+                chamber: scrutin.chamber,
+                votes: votesToCreate,
               });
 
               await db.scrutin.update({

--- a/src/services/sync/scrutins-senat.ts
+++ b/src/services/sync/scrutins-senat.ts
@@ -9,6 +9,7 @@
 import { db } from "@/lib/db";
 import { syncMetadata, hashVotes, ProgressTracker } from "@/lib/sync";
 import { computeGroupPositionsForScrutin } from "@/services/sync/compute-group-positions";
+import { writeVotesForScrutin } from "@/services/sync/scrutins-vote-writer";
 import { HTTPClient } from "@/lib/api/http-client";
 import { decodeHtmlEntities, parseFrenchDate } from "@/lib/parsing";
 import { generateDateSlug, generateUniqueSlug } from "@/lib/utils";
@@ -435,17 +436,11 @@ export async function syncScrutinsSenat(
               if (scrutin.votesHash === newHash) {
                 stats.votesSkipped += votesToCreate.length;
               } else {
-                await db.vote.deleteMany({
-                  where: { scrutinId: scrutin.id },
-                });
-
-                await db.vote.createMany({
-                  data: votesToCreate.map((v) => ({
-                    scrutinId: scrutin.id,
-                    politicianId: v.politicianId,
-                    position: v.position,
-                  })),
-                  skipDuplicates: true,
+                await writeVotesForScrutin({
+                  scrutinId: scrutin.id,
+                  votingDate: scrutin.votingDate,
+                  chamber: scrutin.chamber,
+                  votes: votesToCreate,
                 });
 
                 await db.scrutin.update({

--- a/src/services/sync/scrutins-vote-writer.ts
+++ b/src/services/sync/scrutins-vote-writer.ts
@@ -1,0 +1,50 @@
+import { db } from "@/lib/db";
+import type { Chamber, VotePosition } from "@/generated/prisma";
+
+export interface WriteVotesParams {
+  scrutinId: string;
+  votingDate: Date;
+  chamber: Chamber;
+  votes: Array<{ politicianId: string; position: VotePosition }>;
+}
+
+/**
+ * Atomic vote rewrite for a single scrutin.
+ *
+ * Used by sync-scrutins-an and sync-scrutins-senat after a votesHash mismatch.
+ * Deletes existing votes for the scrutin and re-creates with the new positions.
+ *
+ * The `votingDate` and `chamber` fields are denormalized from `Scrutin` to
+ * avoid forced JOINs in "recent votes for politician" sort queries (slow
+ * query #2 in the perf report) and "votes for politician filtered by chamber
+ * + date range" queries (slow query #3, getPoliticianVotingStats).
+ *
+ * This is one of TWO write surfaces that must populate the denormalized
+ * fields. The other is `scripts/seed-fixtures.ts` for test fixtures — both
+ * must keep these fields in sync. Phase 5b adds a Postgres trigger to handle
+ * the rare case where `Scrutin.votingDate` or `Scrutin.chamber` is updated
+ * post-creation (e.g. an editor correcting a date).
+ */
+export async function writeVotesForScrutin(params: WriteVotesParams): Promise<void> {
+  if (!params.votingDate) {
+    throw new Error("writeVotesForScrutin: votingDate is required (Phase 5a denormalization)");
+  }
+  if (!params.chamber) {
+    throw new Error("writeVotesForScrutin: chamber is required (Phase 5a denormalization)");
+  }
+
+  await db.vote.deleteMany({
+    where: { scrutinId: params.scrutinId },
+  });
+
+  await db.vote.createMany({
+    data: params.votes.map((v) => ({
+      scrutinId: params.scrutinId,
+      politicianId: v.politicianId,
+      position: v.position,
+      votingDate: params.votingDate,
+      chamber: params.chamber,
+    })),
+    skipDuplicates: true,
+  });
+}


### PR DESCRIPTION
## Summary
- Add nullable `Vote.votingDate` and `Vote.chamber` (no indexes yet)
- New shared helper `writeVotesForScrutin()` populates both fields on every write
- Wire helper into `scrutins-an`, `scrutins-senat`, `scripts/seed-fixtures.ts`
- One-shot backfill script `scripts/backfill-vote-denorm.ts` for existing rows
- All 10 `orderBy` sites and 5 `where` filter sites still use the old JOIN form — they migrate in Phase 5b

## Why
The Supabase report identifies two slow queries that both hinge on the `Vote × Scrutin` relation:
- Slow query #2 (27% of DB time): `Vote.findMany` + `orderBy: { scrutin: { votingDate } }` — called from politician profile, comparer, /politiques/[slug]/votes, chat patterns, activity batch
- Slow query #3 (14.8% of DB time): `getPoliticianVotingStats` filtering `Vote` by `Scrutin.chamber` AND `Scrutin.votingDate` range

Neither can be served by an index on `Vote` alone because Postgres must JOIN `Scrutin` before it can sort or filter. Denormalizing `votingDate` AND `chamber` onto `Vote` makes both queries coverable by composite indexes — but the indexes, the read migration, and the NOT NULL constraint must follow a strict expand-contract sequence.

## Baseline (dev DB)
Captured before this PR using EXPLAIN ANALYZE on the canonical hot query:
`SELECT v.id, v.position FROM Vote v INNER JOIN Scrutin s ON v.scrutinId = s.id WHERE v.politicianId = (SELECT id FROM Politician WHERE slug = 'gabriel-attal') ORDER BY s.votingDate DESC LIMIT 50`

- **Execution Time: 408 ms**
- Plan: Nested Loop → Index Scan on `Scrutin_votingDate_idx` backward + Index Scan on `Vote_scrutinId_politicianId_key`
- Inner loop iterations: 863 Scrutin rows probed before finding 50 matching votes

Phase 5b target: single Index Scan on `Vote[politicianId, votingDate]` returning Attal's top-50 directly.

## Phase 5a / 5b split
- **5a (this PR)**: schema additif + write path + backfill. New columns are nullable, unindexed, unread.
- **5b (next PR)**: add composite indexes (`[politicianId, votingDate]` for #2, `[politicianId, chamber, votingDate]` for #3), migrate read + filter sites, NOT NULL + drop old `[politicianId]` index, Postgres trigger.

The split lets us deploy the write path BEFORE migrating reads, ensuring zero NULL rows on new inserts when 5b begins.

## Dev rehearsal
The backfill script ran on the dev DB (~1.49M Vote rows, 10,356 scrutins) in 343.9s (~5.7 min). 0 NULL rows remain. Re-running is a no-op (idempotent).

## Deploy sequence
1. Merge this PR
2. Wait for Vercel deploy "Ready" status (new sync code populates `votingDate` + `chamber` on all new writes)
3. Run `npx dotenv -e .env -- npx tsx scripts/backfill-vote-denorm.ts --dry-run` against production to confirm count (~1.5M expected)
4. Run `npx dotenv -e .env -- npx tsx scripts/backfill-vote-denorm.ts` for real
5. Verify `SELECT COUNT(*) FROM "Vote" WHERE "votingDate" IS NULL OR "chamber" IS NULL` returns 0
6. Open Phase 5b PR

If you skip step 3 or run it before step 2, new `Vote` rows inserted between the schema push and the deploy will have NULL denorm fields. Re-run the backfill to repair.

## Test plan
- [x] 944 tests passing (incl. new `votes-voting-date.test.ts` with 3 tests)
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npm run build` green
- [x] Backfill ran cleanly on dev DB (1.49M rows, 5.7 min, 0 NULLs remain)
- [x] Sample of recent Vote rows verified: all have `votingDate` AND `chamber` populated
- [ ] Production deploy live before running backfill
- [ ] Production backfill verified (0 NULL rows)