### PR TITLE
fix(votes): drop generateStaticParams on /parlement/votes/[slug]

### DIFF
--- a/src/app/parlement/votes/[slug]/page.tsx
+++ b/src/app/parlement/votes/[slug]/page.tsx
@@ -51,14 +51,13 @@ function extractScrutinNumber(externalId: string): string | null {
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
-export async function generateStaticParams() {
-  const scrutins = await db.scrutin.findMany({
-    select: { slug: true },
-    orderBy: { votingDate: "desc" },
-    take: 50,
-  });
-  return scrutins.map((s) => ({ slug: s.slug }));
-}
+// NOTE: Do NOT add `generateStaticParams` here.
+// This page reads `searchParams.type` (date-archive branch) and downstream
+// calls `"use cache"` functions in `@/lib/data/scrutins`. Combining all three
+// (generateStaticParams + searchParams + "use cache") triggers
+// DYNAMIC_SERVER_USAGE on date-archive URLs like /parlement/votes/2026-04-08.
+// Rely on `revalidate = 3600` ISR alone, the same pattern used by the
+// sibling `parlement/votes/aujourd-hui/page.tsx`.
 
 interface PageProps {
   params: Promise<{ slug: string }>;


### PR DESCRIPTION
## Summary

- Fixes `DYNAMIC_SERVER_USAGE` crash on date-archive URLs (e.g. `/parlement/votes/2026-04-08`) reported in production logs at 2026-04-09 13:52
- Removes `generateStaticParams` from `parlement/votes/[slug]/page.tsx` to break the `generateStaticParams + searchParams + "use cache"` triple documented in `CLAUDE.local.md`
- Adds an in-file comment so nobody re-adds it

## Root cause

The page combined three incompatible features:
1. `generateStaticParams()` returning the 50 latest scrutin slugs
2. `searchParams.type` read in the date-archive branch (line 214)
3. Downstream `"use cache"` calls in `getScrutinsByDate` and `getAdjacentVoteDates` (`src/lib/data/scrutins.ts:82,114`)

When a request hit a date-archive slug like `2026-04-08` (not in the static params list), Next.js rendered on-demand, awaited `searchParams.type`, then called the cached data functions and crashed with `DYNAMIC_SERVER_USAGE`. This is the exact anti-pattern documented in `CLAUDE.local.md`:

> **NEVER use `generateStaticParams` on pages that use `searchParams`** (with `useCache: true`). This causes `DYNAMIC_SERVER_USAGE` crash. Use `revalidate = N` alone for ISR on dynamic pages.

## Why the fix is safe

The sibling `parlement/votes/aujourd-hui/page.tsx` already does the same work (reads `searchParams.type`, renders `<DailyVotesPage>` which calls the same `"use cache"` data functions) without `generateStaticParams`, with `revalidate = 300`, and works fine in production. The fix just brings `[slug]/page.tsx` into alignment with that working pattern.

## Trade-off

Lose deploy-time pre-build of the 50 most recent scrutin pages. They will now SSG on first request and cache for an hour via `revalidate = 3600`. Negligible cost: most prod traffic already goes through ISR for older scrutins anyway.

## Out of scope (deliberately)

Two other pages have `generateStaticParams + searchParams` but no `"use cache"` callee, so they don't crash:
- `src/app/parlement/votes/themes/[theme]/page.tsx`
- `src/app/politiques/[slug]/votes/page.tsx`

Refactoring them adds risk for no benefit. Left untouched.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx eslint src/app/parlement/votes/[slug]/page.tsx` clean
- [x] `npx prettier --check` clean
- [ ] After deploy: `curl https://poligraph.fr/parlement/votes/2026-04-08` returns 200 (or 404 if no votes that day, but no 500)
- [ ] After deploy: `curl https://poligraph.fr/parlement/votes/2026-04-08?type=amendements` returns 200
- [ ] After deploy: a canonical scrutin slug page (e.g. `/parlement/votes/<latest>`) still renders correctly

## Related

- Unblocks the production backfill for Phase 5a (`scripts/backfill-vote-denorm.ts`) by clearing the production error log