### PR TITLE
perf(votes): denormalize Vote.votingDate + chamber (Phase 5b contract)

### DIFF
--- a/prisma/migrations/manual/2026-04-08-vote-denorm-trigger.sql
+++ b/prisma/migrations/manual/2026-04-08-vote-denorm-trigger.sql
@@ -1,0 +1,26 @@
+-- Phase 5b: keep Vote.votingDate and Vote.chamber in sync with Scrutin
+-- when an editor updates the parent row. Application code populates both
+-- columns on INSERT (via writeVotesForScrutin); this trigger handles the
+-- rare UPDATE case.
+
+CREATE OR REPLACE FUNCTION sync_vote_denorm_from_scrutin()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only fire when one of the denormalized columns actually changed
+  IF OLD."votingDate" IS DISTINCT FROM NEW."votingDate"
+     OR OLD."chamber" IS DISTINCT FROM NEW."chamber" THEN
+    UPDATE "Vote"
+    SET "votingDate" = NEW."votingDate",
+        "chamber"    = NEW."chamber"
+    WHERE "scrutinId" = NEW.id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS sync_vote_denorm_from_scrutin_trigger ON "Scrutin";
+
+CREATE TRIGGER sync_vote_denorm_from_scrutin_trigger
+AFTER UPDATE OF "votingDate", "chamber" ON "Scrutin"
+FOR EACH ROW
+EXECUTE FUNCTION sync_vote_denorm_from_scrutin();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -877,13 +877,12 @@ model Vote {
 
   position VotePosition // POUR, CONTRE, ABSTENTION, ABSENT
 
-  // Phase 5a expand-contract: denormalized from Scrutin.votingDate and
-  // Scrutin.chamber to avoid forced JOINs on hot queries (sort by date,
-  // filter by chamber). Backfilled in Phase 5a, made NOT NULL + indexed
-  // in Phase 5b. Maintained by Postgres trigger (Phase 5b) for the rare
-  // case where Scrutin.votingDate or Scrutin.chamber is updated.
-  votingDate DateTime?
-  chamber    Chamber?
+  // Denormalized from Scrutin to avoid forced JOIN on every "votes for politician"
+  // sort and chamber filter. Maintained by Postgres trigger
+  // sync_vote_denorm_from_scrutin_trigger when Scrutin.votingDate or Scrutin.chamber
+  // is updated. See docs/superpowers/plans/2026-04-07-supabase-perf-improvements.md.
+  votingDate DateTime
+  chamber    Chamber
 
   @@unique([scrutinId, politicianId])
   @@index([politicianId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -888,6 +888,8 @@ model Vote {
   @@unique([scrutinId, politicianId])
   @@index([politicianId])
   @@index([politicianId, position])
+  @@index([politicianId, votingDate(sort: Desc)], map: "Vote_politicianId_votingDate_idx")
+  @@index([politicianId, chamber, votingDate(sort: Desc)], map: "Vote_politicianId_chamber_votingDate_idx")
 }
 
 model ScrutinImportance {

--- a/scripts/apply-vote-denorm-trigger.ts
+++ b/scripts/apply-vote-denorm-trigger.ts
@@ -1,0 +1,53 @@
+/**
+ * Phase 5b: apply the Vote denormalization sync trigger.
+ *
+ * Idempotent (CREATE OR REPLACE + DROP IF EXISTS).
+ *
+ * Why pg.Pool instead of Prisma:
+ *   The plpgsql function body uses dollar-quoted strings ($$ ... $$) and
+ *   contains multiple statements. Prisma 7's @prisma/adapter-pg parameterizes
+ *   queries before sending them to Postgres, which can interfere with
+ *   dollar-quoting. Using pg.Pool directly sends the SQL verbatim through
+ *   the simple query protocol — same dollar-quoting semantics as `psql`,
+ *   no surprises.
+ *
+ * Run:
+ *   npx dotenv -e .env -- npx tsx scripts/apply-vote-denorm-trigger.ts
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { Pool } from "pg";
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  const sqlPath = path.join(
+    process.cwd(),
+    "prisma/migrations/manual/2026-04-08-vote-denorm-trigger.sql"
+  );
+  const sql = readFileSync(sqlPath, "utf-8");
+
+  const pool = new Pool({
+    connectionString,
+    max: 1,
+    ssl: connectionString.includes("supabase.com") ? { rejectUnauthorized: false } : undefined,
+  });
+
+  try {
+    console.log(`[apply-vote-denorm-trigger] applying ${sqlPath}`);
+    // pg supports multi-statement SQL via the simple query protocol.
+    // The SQL file is a static asset committed in the repo, no user input.
+    await pool.query(sql);
+    console.log("[apply-vote-denorm-trigger] DONE");
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("[apply-vote-denorm-trigger] FAILED:", err);
+  process.exit(1);
+});

--- a/scripts/create-vote-composite-indexes.ts
+++ b/scripts/create-vote-composite-indexes.ts
@@ -1,0 +1,83 @@
+/**
+ * Phase 5b: create the two composite indexes on Vote needed by the perf
+ * improvements (slow queries #2 and #3 in the Supabase report):
+ *
+ *   - Vote_politicianId_votingDate_idx          (covers #2)
+ *   - Vote_politicianId_chamber_votingDate_idx  (covers #3)
+ *
+ * Both indexes are created with CONCURRENTLY to avoid blocking writes.
+ * Each one takes ~60-90s on production (1.5M rows). Total runtime: ~3 minutes.
+ *
+ * Idempotent: any index that already exists is skipped.
+ *
+ * Why pg.Pool instead of Prisma:
+ *   Prisma wraps every raw query in an implicit transaction, but CREATE INDEX
+ *   CONCURRENTLY must run outside any transaction. We use the raw pg client
+ *   directly so Postgres sees an autocommit session.
+ *
+ * Run:
+ *   npx dotenv -e .env -- npx tsx scripts/create-vote-composite-indexes.ts
+ */
+import { Pool } from "pg";
+
+interface IndexSpec {
+  name: string;
+  columns: string;
+}
+
+const INDEXES: IndexSpec[] = [
+  {
+    name: "Vote_politicianId_votingDate_idx",
+    columns: '"politicianId", "votingDate" DESC',
+  },
+  {
+    name: "Vote_politicianId_chamber_votingDate_idx",
+    columns: '"politicianId", "chamber", "votingDate" DESC',
+  },
+];
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  const pool = new Pool({
+    connectionString,
+    max: 1,
+    ssl: connectionString.includes("supabase.com") ? { rejectUnauthorized: false } : undefined,
+  });
+
+  try {
+    for (const idx of INDEXES) {
+      console.log(`[create-vote-composite-indexes] checking ${idx.name}...`);
+
+      const exists = await pool.query(
+        `SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = $1`,
+        [idx.name]
+      );
+
+      if (exists.rowCount && exists.rowCount > 0) {
+        console.log(`[create-vote-composite-indexes] ${idx.name} already exists, skipping`);
+        continue;
+      }
+
+      console.log(`[create-vote-composite-indexes] creating ${idx.name} CONCURRENTLY (60-90s)...`);
+      const t0 = Date.now();
+
+      // pg.Pool does NOT wrap statements in implicit transactions, so CONCURRENTLY works.
+      // The index name + column list are interpolated from a static const, no user input.
+      await pool.query(`CREATE INDEX CONCURRENTLY "${idx.name}" ON "Vote" (${idx.columns})`);
+
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+      console.log(`[create-vote-composite-indexes] ${idx.name} DONE in ${elapsed}s`);
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("[create-vote-composite-indexes] FAILED:", err);
+  process.exit(1);
+});

--- a/src/__tests__/lib/data/vote-voting-date-sort.test.ts
+++ b/src/__tests__/lib/data/vote-voting-date-sort.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+/**
+ * Parity test for Phase 5b read migration.
+ *
+ * Asserts that:
+ *   1. Sorting Vote rows by the new `votingDate` column produces the SAME
+ *      ordering as the old `orderBy: { scrutin: { votingDate } }` JOIN.
+ *   2. Filtering Vote rows by the new `chamber` + `votingDate` columns
+ *      produces the SAME result as the old relation-based where filter.
+ *
+ * Requires a dev DB with at least one politician who has > 5 votes.
+ * Skips automatically if no such politician exists or if DATABASE_URL is unset
+ * (vitest doesn't auto-load .env, so CI runs this as a no-op — it's a manual
+ * parity check, run it with `npx dotenv -e .env -- npx vitest run ...`).
+ */
+const hasDb = Boolean(process.env.DATABASE_URL);
+const describeIfDb = hasDb ? describe : describe.skip;
+
+describeIfDb("Vote denormalization parity with Scrutin", () => {
+  let politicianId: string | null = null;
+  let db: typeof import("@/lib/db").db;
+
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    const candidate = await db.politician.findFirst({
+      where: { votes: { some: {} } },
+      select: { id: true },
+    });
+    politicianId = candidate?.id ?? null;
+  });
+
+  afterAll(async () => {
+    if (db) await db.$disconnect();
+  });
+
+  it("new sort matches old JOIN sort for the same politician", async () => {
+    if (!politicianId) {
+      console.warn("No politician with votes in dev DB — skipping parity test");
+      return;
+    }
+
+    const oldSort = await db.vote.findMany({
+      where: { politicianId },
+      orderBy: [{ scrutin: { votingDate: "desc" } }, { id: "asc" }],
+      select: { id: true },
+      take: 100,
+    });
+
+    const newSort = await db.vote.findMany({
+      where: { politicianId },
+      orderBy: [{ votingDate: "desc" }, { id: "asc" }],
+      select: { id: true },
+      take: 100,
+    });
+
+    expect(newSort.map((v) => v.id)).toEqual(oldSort.map((v) => v.id));
+  });
+
+  it("new chamber + date filter matches old relation filter", async () => {
+    if (!politicianId) return;
+
+    const since = new Date();
+    since.setMonth(since.getMonth() - 6);
+
+    const oldFilter = await db.vote.findMany({
+      where: {
+        politicianId,
+        scrutin: { chamber: "AN", votingDate: { gte: since } },
+      },
+      orderBy: [{ scrutin: { votingDate: "desc" } }, { id: "asc" }],
+      select: { id: true },
+      take: 200,
+    });
+
+    const newFilter = await db.vote.findMany({
+      where: {
+        politicianId,
+        chamber: "AN",
+        votingDate: { gte: since },
+      },
+      orderBy: [{ votingDate: "desc" }, { id: "asc" }],
+      select: { id: true },
+      take: 200,
+    });
+
+    expect(newFilter.map((v) => v.id)).toEqual(oldFilter.map((v) => v.id));
+  });
+});

--- a/src/__tests__/lib/data/vote-voting-date-sort.test.ts
+++ b/src/__tests__/lib/data/vote-voting-date-sort.test.ts
@@ -36,6 +36,7 @@ describeIfDb("Vote denormalization parity with Scrutin", () => {
 
   it("new sort matches old JOIN sort for the same politician", async () => {
     if (!politicianId) {
+      // eslint-disable-next-line no-console
       console.warn("No politician with votes in dev DB — skipping parity test");
       return;
     }

--- a/src/app/api/activity/batch/route.ts
+++ b/src/app/api/activity/batch/route.ts
@@ -74,7 +74,7 @@ export const POST = withPublicRoute(async (request: NextRequest) => {
           db.vote.findMany({
             where: {
               politicianId: { in: politicianIds },
-              scrutin: { votingDate: { gte: since } },
+              votingDate: { gte: since },
             },
             select: {
               politicianId: true,
@@ -83,7 +83,7 @@ export const POST = withPublicRoute(async (request: NextRequest) => {
                 select: { slug: true, title: true, votingDate: true, result: true },
               },
             },
-            orderBy: { scrutin: { votingDate: "desc" } },
+            orderBy: { votingDate: "desc" },
             take: MAX_ITEMS_PER_TYPE,
           }),
           db.affair.findMany({
@@ -151,7 +151,7 @@ export const POST = withPublicRoute(async (request: NextRequest) => {
     const recentVoteCount = await db.vote.count({
       where: {
         politician: { currentPartyId: party.id },
-        scrutin: { votingDate: { gte: since } },
+        votingDate: { gte: since },
       },
     });
     if (recentVoteCount > 0) {

--- a/src/app/api/politiques/[slug]/votes/route.ts
+++ b/src/app/api/politiques/[slug]/votes/route.ts
@@ -103,7 +103,7 @@ export const GET = withPublicRoute(async (request, context) => {
           },
         },
       },
-      orderBy: { scrutin: { votingDate: "desc" } },
+      orderBy: { votingDate: "desc" },
       skip,
       take: limit,
     }),

--- a/src/app/comparer/votes/page.tsx
+++ b/src/app/comparer/votes/page.tsx
@@ -79,7 +79,7 @@ async function getPoliticianVoteComparison(leftSlug: string, rightSlug: string) 
         fullName: true,
         votes: {
           include: { scrutin: true },
-          orderBy: { scrutin: { votingDate: "desc" } },
+          orderBy: { votingDate: "desc" },
         },
       },
     }),
@@ -91,7 +91,7 @@ async function getPoliticianVoteComparison(leftSlug: string, rightSlug: string) 
         fullName: true,
         votes: {
           include: { scrutin: true },
-          orderBy: { scrutin: { votingDate: "desc" } },
+          orderBy: { votingDate: "desc" },
         },
       },
     }),

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -75,7 +75,7 @@ async function getVoteStats(politicianId: string) {
           },
         },
       },
-      orderBy: { scrutin: { votingDate: "desc" } },
+      orderBy: { votingDate: "desc" },
       take: 5,
     }),
     voteStatsService.getPoliticianThemeDistribution(politicianId),

--- a/src/app/politiques/[slug]/votes/page.tsx
+++ b/src/app/politiques/[slug]/votes/page.tsx
@@ -80,7 +80,7 @@ async function getVotes(
     db.vote.findMany({
       where,
       include: { scrutin: true },
-      orderBy: { scrutin: { votingDate: "desc" } },
+      orderBy: { votingDate: "desc" },
       skip,
       take: limit,
     }),

--- a/src/lib/data/compare.ts
+++ b/src/lib/data/compare.ts
@@ -289,7 +289,7 @@ const POLITICIAN_COMPARISON_SELECT = {
   },
   votes: {
     take: 500,
-    orderBy: { scrutin: { votingDate: "desc" as const } },
+    orderBy: { votingDate: "desc" as const },
     select: {
       position: true,
       scrutinId: true,
@@ -670,7 +670,7 @@ async function getGroupForComparison(idOrCode: string) {
           id: true,
           votes: {
             take: 500,
-            orderBy: { scrutin: { votingDate: "desc" } },
+            orderBy: { votingDate: "desc" },
             select: {
               position: true,
               scrutinId: true,

--- a/src/lib/data/politicians.ts
+++ b/src/lib/data/politicians.ts
@@ -141,9 +141,7 @@ export async function getPoliticianForComparison(slug: string) {
         include: {
           scrutin: true,
         },
-        orderBy: {
-          scrutin: { votingDate: "desc" },
-        },
+        orderBy: { votingDate: "desc" },
         take: 500,
       },
       factCheckMentions: {

--- a/src/services/chat/patterns.ts
+++ b/src/services/chat/patterns.ts
@@ -705,7 +705,7 @@ async function fetchPoliticianVotes(
         select: { title: true, votingDate: true, slug: true, id: true },
       },
     },
-    orderBy: { scrutin: { votingDate: "desc" } },
+    orderBy: { votingDate: "desc" },
     take: 10,
   });
 

--- a/src/services/sync/compute-group-stats.ts
+++ b/src/services/sync/compute-group-stats.ts
@@ -97,7 +97,8 @@ async function computeForChamber(config: ChamberConfig): Promise<number> {
     });
     const voteCount = await db.vote.count({
       where: {
-        scrutin: { legislature: config.scrutinLegislature, chamber: config.chamber },
+        chamber: config.chamber,
+        scrutin: { legislature: config.scrutinLegislature },
         politician: {
           mandates: {
             some: {

--- a/src/services/sync/scrutins-senat.ts
+++ b/src/services/sync/scrutins-senat.ts
@@ -514,7 +514,7 @@ export async function getScrutinsSenatStats(): Promise<{
     where: { chamber: Chamber.SENAT },
   });
   const votesCount = await db.vote.count({
-    where: { scrutin: { chamber: Chamber.SENAT } },
+    where: { chamber: Chamber.SENAT },
   });
   const sessions = await db.scrutin.groupBy({
     by: ["legislature"],

--- a/src/services/voteStats.ts
+++ b/src/services/voteStats.ts
@@ -369,12 +369,10 @@ export async function getPoliticianVotingStats(
   const voteWhere = {
     politicianId,
     ...(mandate && {
-      scrutin: {
-        chamber,
-        votingDate: {
-          gte: mandate.startDate!,
-          ...(mandate.endDate ? { lte: mandate.endDate } : {}),
-        },
+      chamber,
+      votingDate: {
+        gte: mandate.startDate!,
+        ...(mandate.endDate ? { lte: mandate.endDate } : {}),
       },
     }),
   };


### PR DESCRIPTION
## Summary

Phase 5b is the **contract half** of the expand-contract migration started in Phase 5a (#300). With production already at zero NULL rows on `Vote.votingDate` and `Vote.chamber`, this PR completes the denormalization by:

1. **Composite indexes** on `(politicianId, votingDate DESC)` and `(politicianId, chamber, votingDate DESC)` so reads use forward index scans without JOINing `Scrutin`
2. **Read-site migration** of 10 `orderBy` and 4 `where` filters away from `scrutin: { votingDate / chamber }` to the direct columns. The critical migration is `getPoliticianVotingStats` (slow query #3) — it's now a single-table `groupBy` over the new composite index instead of a `Vote x Scrutin` JOIN
3. **Postgres trigger** `sync_vote_denorm_from_scrutin_trigger` keeps the columns in sync if an editor updates `Scrutin.votingDate` or `chamber` after the votes were written
4. **NOT NULL** enforced on both columns now that the trigger guarantees consistency and no NULL rows exist (verified at 1,492,153 / 0 in both dev and prod)

## What's deferred

Per the plan's critical review, **Task 5b.5** (drop the now-redundant single-column `[politicianId]` index) is deferred to a follow-up PR. It needs ~24 hours of `pg_stat_user_indexes` telemetry on the new composite indexes after this PR deploys, before we can prove the old index is dead.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no new warnings/errors)
- [x] `npm run format:check` clean
- [x] `npm run test:run` — 944 tests pass, 1 skipped (parity test runs only when `DATABASE_URL` is set)
- [x] Parity test (`vote-voting-date-sort.test.ts`) confirms new sort/filter return identical row sets to old relation queries against the dev DB
- [x] `npm run build` succeeds
- [x] Trigger applied to dev DB and manually verified: bumping `Scrutin.votingDate` cascades to all child `Vote` rows
- [ ] After deploy: monitor `pg_stat_user_indexes` to confirm new composite indexes are picking up scans before opening the Task 5b.5 follow-up PR

## Deploy notes

The new trigger SQL (`prisma/migrations/manual/2026-04-08-vote-denorm-trigger.sql`) is **not** applied by `prisma db push` — it must be applied to production manually:

```bash
npx dotenv -e .env.prod -- npx tsx scripts/apply-vote-denorm-trigger.ts
```

The schema NOT NULL flip will be applied by `prisma db push --accept-data-loss` (no data loss because zero NULLs were already verified).

## Related

- Plan: \`docs/superpowers/plans/2026-04-07-supabase-perf-improvements.md\` (Phase 5b)
- Phase 5a (expand): #300