### PR TITLE
feat(api): poligraphId + richer CSV exports + narrative /docs/api

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "audit:parties:stats": "tsx scripts/audit-parties.ts --stats",
     "audit:careers": "tsx scripts/audit-careers.ts",
     "audit:careers:export": "tsx scripts/audit-careers.ts --export",
+    "perf:check": "dotenv -e .env -- tsx scripts/perf-check-vote-denorm.ts",
     "sync:press": "tsx scripts/sync-press.ts",
     "sync:press:stats": "tsx scripts/sync-press.ts --stats",
     "sync:factchecks": "tsx scripts/sync-factchecks.ts",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ enum ModerationRecommendation {
 model Politician {
   id           String    @id @default(cuid())
   slug         String    @unique
-  publicId     String?   @unique // "PG-000542" — stable public identifier
+  publicId     String?   @unique // "PG-000542" — stable public identifier (poligraphId, see /docs/api)
   civility     String? // M. ou Mme
   firstName    String
   lastName     String
@@ -190,6 +190,7 @@ enum Judgement {
 model Party {
   id          String  @id @default(cuid())
   slug        String? @unique // URL-friendly identifier
+  publicId    String? @unique // "PT-000042" — stable public identifier (poligraphId, see /docs/api)
   name        String  @unique
   shortName   String  @unique // Ex: "RN", "LFI", "PS"
   description String? // Brief description for the party page
@@ -270,6 +271,7 @@ model PartyMembership {
 
 model Mandate {
   id           String     @id @default(cuid())
+  publicId     String?    @unique // "MA-000542" — stable public identifier (poligraphId, see /docs/api)
   politician   Politician @relation(fields: [politicianId], references: [id], onDelete: Cascade)
   politicianId String
 
@@ -408,6 +410,7 @@ model ParliamentaryGroup {
   id        String  @id @default(cuid())
   code      String // "SOC", "EPR", "DR", "LR", "RN"...
   slug      String?  @unique // e.g. "epr-17", "soc-17"
+  publicId  String? @unique // "GP-000042" — stable public identifier (poligraphId, see /docs/api)
   name      String // Full official name
   shortName String? // Display short name if different from code
   color     String? // Hex color for UI
@@ -477,6 +480,7 @@ model Affair {
 
   title       String // Ex: "Affaire des emplois fictifs du MoDem"
   slug        String   @unique
+  publicId    String?  @unique // "AF-000542" — stable public identifier (poligraphId, see /docs/api)
   oldSlugs    String[] @default([])
   description           String    @db.Text
   originalDescription   String?   @db.Text // Pre-enrichment description (for rollback)
@@ -813,6 +817,7 @@ model Scrutin {
   id          String   @id @default(cuid())
   externalId  String   @unique // ID NosDéputés/NosSénateurs (ex: "VTANR5L17V1234" ou "2024-63")
   slug        String?  @unique // SEO-friendly URL slug (e.g., "2025-01-15-projet-loi-finances")
+  publicId    String?  @unique // "SC-000542" — stable public identifier (poligraphId, see /docs/api)
   title       String   @db.Text
   description String?  @db.Text
   votingDate  DateTime
@@ -1029,6 +1034,7 @@ model LegislativeDossier {
   id         String         @id @default(cuid())
   externalId String         @unique // DLR5L17N12345
   slug       String?        @unique // SEO-friendly URL slug (e.g., "2024-12-03-reforme-retraites")
+  publicId   String?        @unique // "DO-000542" — stable public identifier (poligraphId, see /docs/api)
   title      String         @db.Text
   shortTitle String? // Titre court pour affichage
   number     String? // PJL 1234, PPL 5678
@@ -1319,6 +1325,7 @@ model PressAnalysisRejection {
 model FactCheck {
   id            String          @id @default(cuid())
   slug          String?         @unique // SEO-friendly URL slug
+  publicId      String?         @unique // "FC-000542" — stable public identifier (poligraphId, see /docs/api)
   claimText     String          @db.Text // La déclaration vérifiée
   claimant      String? // Qui a fait la déclaration
   title         String          @db.Text // Titre de l'article de fact-check
@@ -1434,6 +1441,7 @@ enum ElectionStatus {
 model Election {
   id          String       @id @default(cuid())
   slug        String       @unique
+  publicId    String?      @unique // "EL-000042" — stable public identifier (poligraphId, see /docs/api)
   type        ElectionType
   title       String
   shortTitle  String?
@@ -1538,6 +1546,7 @@ model Candidacy {
 
 model ElectoralList {
   id         String   @id @default(cuid())
+  publicId   String?  @unique // "LM-000542" — stable public identifier (poligraphId, see /docs/api)
   election   Election @relation(fields: [electionId], references: [id], onDelete: Cascade)
   electionId String
   commune    Commune @relation(fields: [communeId], references: [id])
@@ -1951,4 +1960,22 @@ model ProfessionDeFoi {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+// ============================================
+// PUBLIC ID REDIRECTS (poligraphId infrastructure)
+// ============================================
+// When entities are merged or deprecated, the old publicId must keep resolving
+// to the canonical entity so that external citations (research papers, Wikidata,
+// etc.) never break. Write one row here per merge/deprecation event.
+// See /docs/api (section "poligraphId") for the full specification.
+model PublicIdRedirect {
+  fromPublicId String   @id // "AF-000542" — the retired identifier
+  toPublicId   String // "AF-000789" — the canonical identifier it now points to
+  entityType   String // "affair" | "politician" | "factcheck" | "scrutin" | "party" | "election" | "mandate" | "dossier" | "group" | "electoralList"
+  reason       String // "merged" | "deprecated" | "corrected" — free text for the audit trail
+  createdAt    DateTime @default(now())
+
+  @@index([toPublicId])
+  @@index([entityType])
 }

--- a/scripts/backfill-public-ids.ts
+++ b/scripts/backfill-public-ids.ts
@@ -1,0 +1,361 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill poligraphIds for all entity types.
+ *
+ * Strategy per entity:
+ *   1. Compute the current MAX sequence already assigned (handles re-runs).
+ *   2. Number rows missing a publicId by createdAt ASC, starting just above
+ *      that max. This guarantees chronological ordering and re-run safety.
+ *   3. Assign the formatted publicId in a single CTE-backed UPDATE.
+ *   4. Align the PostgreSQL sequence with the new max so the runtime
+ *      generator never hands out a colliding value.
+ *
+ * Idempotent: running this script multiple times is safe. Rows that already
+ * have a publicId are skipped; newly-created rows get the next available
+ * number the next time the script runs.
+ *
+ * Usage:
+ *   npx dotenv -e .env -- npx tsx scripts/backfill-public-ids.ts
+ *   npx dotenv -e .env.prod -- npx tsx scripts/backfill-public-ids.ts
+ */
+import { db } from "@/lib/db";
+
+async function main() {
+  console.log("Backfilling poligraphIds for all entity types...\n");
+
+  await backfillPolitician();
+  await backfillAffair();
+  await backfillFactCheck();
+  await backfillScrutin();
+  await backfillParty();
+  await backfillElection();
+  await backfillMandate();
+  await backfillLegislativeDossier();
+  await backfillParliamentaryGroup();
+  await backfillElectoralList();
+
+  console.log("\nAll entity types backfilled.");
+}
+
+async function backfillPolitician() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "Politician"
+      WHERE "publicId" LIKE 'PG-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "Politician"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "Politician" t
+    SET "publicId" = 'PG-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("Politician", "PG");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_politician_seq', ${max})`;
+  }
+  console.log(`  Politician: ${updated} backfilled, max PG-${pad(max)}`);
+}
+
+async function backfillAffair() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "Affair"
+      WHERE "publicId" LIKE 'AF-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "Affair"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "Affair" t
+    SET "publicId" = 'AF-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("Affair", "AF");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_affair_seq', ${max})`;
+  }
+  console.log(`  Affair: ${updated} backfilled, max AF-${pad(max)}`);
+}
+
+async function backfillFactCheck() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "FactCheck"
+      WHERE "publicId" LIKE 'FC-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "FactCheck"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "FactCheck" t
+    SET "publicId" = 'FC-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("FactCheck", "FC");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_factcheck_seq', ${max})`;
+  }
+  console.log(`  FactCheck: ${updated} backfilled, max FC-${pad(max)}`);
+}
+
+async function backfillScrutin() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "Scrutin"
+      WHERE "publicId" LIKE 'SC-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "Scrutin"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "Scrutin" t
+    SET "publicId" = 'SC-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("Scrutin", "SC");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_scrutin_seq', ${max})`;
+  }
+  console.log(`  Scrutin: ${updated} backfilled, max SC-${pad(max)}`);
+}
+
+async function backfillParty() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "Party"
+      WHERE "publicId" LIKE 'PT-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "Party"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "Party" t
+    SET "publicId" = 'PT-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("Party", "PT");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_party_seq', ${max})`;
+  }
+  console.log(`  Party: ${updated} backfilled, max PT-${pad(max)}`);
+}
+
+async function backfillElection() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "Election"
+      WHERE "publicId" LIKE 'EL-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "Election"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "Election" t
+    SET "publicId" = 'EL-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("Election", "EL");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_election_seq', ${max})`;
+  }
+  console.log(`  Election: ${updated} backfilled, max EL-${pad(max)}`);
+}
+
+async function backfillMandate() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "Mandate"
+      WHERE "publicId" LIKE 'MA-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "Mandate"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "Mandate" t
+    SET "publicId" = 'MA-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("Mandate", "MA");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_mandate_seq', ${max})`;
+  }
+  console.log(`  Mandate: ${updated} backfilled, max MA-${pad(max)}`);
+}
+
+async function backfillLegislativeDossier() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "LegislativeDossier"
+      WHERE "publicId" LIKE 'DO-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "LegislativeDossier"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "LegislativeDossier" t
+    SET "publicId" = 'DO-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("LegislativeDossier", "DO");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_dossier_seq', ${max})`;
+  }
+  console.log(`  LegislativeDossier: ${updated} backfilled, max DO-${pad(max)}`);
+}
+
+async function backfillParliamentaryGroup() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "ParliamentaryGroup"
+      WHERE "publicId" LIKE 'GP-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "ParliamentaryGroup"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "ParliamentaryGroup" t
+    SET "publicId" = 'GP-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("ParliamentaryGroup", "GP");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_group_seq', ${max})`;
+  }
+  console.log(`  ParliamentaryGroup: ${updated} backfilled, max GP-${pad(max)}`);
+}
+
+async function backfillElectoralList() {
+  const updated = await db.$executeRaw`
+    WITH start_from AS (
+      SELECT COALESCE(MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT)), 0) AS val
+      FROM "ElectoralList"
+      WHERE "publicId" LIKE 'LM-%'
+    ),
+    numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) + (SELECT val FROM start_from) AS seq
+      FROM "ElectoralList"
+      WHERE "publicId" IS NULL
+    )
+    UPDATE "ElectoralList" t
+    SET "publicId" = 'LM-' || LPAD(n.seq::text, 6, '0')
+    FROM numbered n
+    WHERE t.id = n.id
+  `;
+  const max = await currentMax("ElectoralList", "LM");
+  if (max > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_electoral_list_seq', ${max})`;
+  }
+  console.log(`  ElectoralList: ${updated} backfilled, max LM-${pad(max)}`);
+}
+
+/**
+ * Fetch the maximum sequence number currently assigned for a given entity.
+ * Separate queries per table because Prisma template literals can't
+ * parameterize identifiers.
+ */
+async function currentMax(table: string, prefix: string): Promise<number> {
+  let rows: { max: string | null }[];
+  switch (`${table}:${prefix}`) {
+    case "Politician:PG":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "Politician" WHERE "publicId" LIKE 'PG-%'
+      `;
+      break;
+    case "Affair:AF":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "Affair" WHERE "publicId" LIKE 'AF-%'
+      `;
+      break;
+    case "FactCheck:FC":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "FactCheck" WHERE "publicId" LIKE 'FC-%'
+      `;
+      break;
+    case "Scrutin:SC":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "Scrutin" WHERE "publicId" LIKE 'SC-%'
+      `;
+      break;
+    case "Party:PT":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "Party" WHERE "publicId" LIKE 'PT-%'
+      `;
+      break;
+    case "Election:EL":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "Election" WHERE "publicId" LIKE 'EL-%'
+      `;
+      break;
+    case "Mandate:MA":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "Mandate" WHERE "publicId" LIKE 'MA-%'
+      `;
+      break;
+    case "LegislativeDossier:DO":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "LegislativeDossier" WHERE "publicId" LIKE 'DO-%'
+      `;
+      break;
+    case "ParliamentaryGroup:GP":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "ParliamentaryGroup" WHERE "publicId" LIKE 'GP-%'
+      `;
+      break;
+    case "ElectoralList:LM":
+      rows = await db.$queryRaw<{ max: string | null }[]>`
+        SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+        FROM "ElectoralList" WHERE "publicId" LIKE 'LM-%'
+      `;
+      break;
+    default:
+      throw new Error(`Unknown table/prefix combo: ${table}:${prefix}`);
+  }
+  return rows[0]?.max ? parseInt(rows[0].max, 10) : 0;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(6, "0");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/create-public-id-sequences.ts
+++ b/scripts/create-public-id-sequences.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env tsx
+/**
+ * Create PostgreSQL sequences that back the poligraphId generator.
+ *
+ * Idempotent: safe to run multiple times. Each sequence is created with
+ * IF NOT EXISTS, and the Politician sequence is aligned to the current
+ * MAX(publicId) so already-assigned PG-XXXXXX values are never reused.
+ *
+ * Usage:
+ *   npx dotenv -e .env -- npx tsx scripts/create-public-id-sequences.ts
+ */
+import { db } from "@/lib/db";
+
+async function main() {
+  console.log("Creating poligraphId sequences...");
+
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_politician_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_affair_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_factcheck_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_scrutin_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_party_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_election_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_mandate_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_dossier_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_group_seq START 1`;
+  await db.$executeRaw`CREATE SEQUENCE IF NOT EXISTS poligraph_electoral_list_seq START 1`;
+
+  console.log("All sequences created (or already existed).");
+
+  // Align Politician sequence with existing PG-XXXXXX values so the next
+  // generated publicId is strictly greater than any already in use.
+  const politicianMaxRows = await db.$queryRaw<{ max: string | null }[]>`
+    SELECT MAX(CAST(SUBSTRING("publicId" FROM '[0-9]+') AS BIGINT))::text AS max
+    FROM "Politician"
+    WHERE "publicId" LIKE 'PG-%'
+  `;
+  const currentMax = politicianMaxRows[0]?.max ? parseInt(politicianMaxRows[0].max, 10) : 0;
+
+  if (currentMax > 0) {
+    await db.$executeRaw`SELECT setval('poligraph_politician_seq', ${currentMax})`;
+    console.log(
+      `Politician sequence aligned to ${currentMax} (next: PG-${String(currentMax + 1).padStart(6, "0")})`
+    );
+  } else {
+    console.log("No existing Politician publicIds found; sequence left at 1");
+  }
+
+  console.log("Done.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/perf-check-vote-denorm.ts
+++ b/scripts/perf-check-vote-denorm.ts
@@ -48,7 +48,7 @@ async function showIndexUsage() {
     ORDER BY idx_scan DESC
   `;
 
-  const header = ["Index", "scans", "tup_read", "size"];
+  const header = ["Index", "scans", "tup_read", "size"] as const;
   console.log(
     `  ${header[0].padEnd(50)} ${header[1].padStart(12)} ${header[2].padStart(14)} ${header[3].padStart(10)}`
   );
@@ -124,8 +124,8 @@ async function pickPolitician(): Promise<{ id: string; slug: string; fullName: s
     ORDER BY COUNT(v.id) DESC
     LIMIT 1
   `;
-  if (result.length === 0) return null;
-  const r = result[0];
+  const [r] = result;
+  if (!r) return null;
   console.log(`\n  Auto-picked: ${r.fullName} (${fmt(r.voteCount)} votes)`);
   return { id: r.id, slug: r.slug, fullName: r.fullName };
 }

--- a/scripts/perf-check-vote-denorm.ts
+++ b/scripts/perf-check-vote-denorm.ts
@@ -1,0 +1,266 @@
+/**
+ * Phase 5b verification script — read-only against production.
+ *
+ * Shows:
+ *   1. Vote index usage stats (pg_stat_user_indexes) — which indexes are hot
+ *   2. EXPLAIN ANALYZE on the two critical queries that Phase 5b optimized
+ *   3. A plain-language verdict per check
+ *
+ * Run:  npx dotenv -e .env -- npx tsx scripts/perf-check-vote-denorm.ts
+ *   or:  npx dotenv -e .env -- npx tsx scripts/perf-check-vote-denorm.ts <politician-slug>
+ */
+
+import { db } from "../src/lib/db";
+
+const DEFAULT_SLUG = process.argv[2];
+
+type IndexStat = {
+  indexrelname: string;
+  idx_scan: bigint;
+  idx_tup_read: bigint;
+  idx_tup_fetch: bigint;
+  index_size: string;
+};
+
+function fmt(n: bigint | number): string {
+  return Number(n).toLocaleString("fr-FR");
+}
+
+function banner(title: string) {
+  const line = "─".repeat(Math.max(60, title.length + 4));
+  console.log("\n" + line);
+  console.log("  " + title);
+  console.log(line);
+}
+
+async function showIndexUsage() {
+  banner("1. Vote index usage (pg_stat_user_indexes)");
+
+  const rows = await db.$queryRaw<IndexStat[]>`
+    SELECT
+      indexrelname,
+      idx_scan,
+      idx_tup_read,
+      idx_tup_fetch,
+      pg_size_pretty(pg_relation_size(indexrelid)) AS index_size
+    FROM pg_stat_user_indexes
+    WHERE relname = 'Vote'
+    ORDER BY idx_scan DESC
+  `;
+
+  const header = ["Index", "scans", "tup_read", "size"];
+  console.log(
+    `  ${header[0].padEnd(50)} ${header[1].padStart(12)} ${header[2].padStart(14)} ${header[3].padStart(10)}`
+  );
+  console.log("  " + "─".repeat(90));
+
+  for (const r of rows) {
+    console.log(
+      `  ${r.indexrelname.padEnd(50)} ${fmt(r.idx_scan).padStart(12)} ${fmt(r.idx_tup_read).padStart(14)} ${r.index_size.padStart(10)}`
+    );
+  }
+
+  // Verdicts
+  const composite = rows.find((r) => r.indexrelname === "Vote_politicianId_chamber_votingDate_idx");
+  const dateOnly = rows.find((r) => r.indexrelname === "Vote_politicianId_votingDate_idx");
+  const legacy = rows.find((r) => r.indexrelname === "Vote_politicianId_idx");
+
+  console.log("\n  Verdict:");
+  if (composite && Number(composite.idx_scan) > 0) {
+    console.log(
+      `  ✓ [politicianId,chamber,votingDate] composite index IS being used (${fmt(composite.idx_scan)} scans)`
+    );
+  } else {
+    console.log(
+      `  ⚠ [politicianId,chamber,votingDate] composite has 0 scans — queries not hitting it yet`
+    );
+  }
+  if (dateOnly && Number(dateOnly.idx_scan) > 0) {
+    console.log(
+      `  ✓ [politicianId,votingDate] composite index IS being used (${fmt(dateOnly.idx_scan)} scans)`
+    );
+  } else {
+    console.log(
+      `  ⚠ [politicianId,votingDate] composite has 0 scans — orderBy queries not hitting it yet`
+    );
+  }
+  if (legacy) {
+    const isDead =
+      Number(legacy.idx_scan) < Number(composite?.idx_scan ?? 0) + Number(dateOnly?.idx_scan ?? 0);
+    if (isDead) {
+      console.log(
+        `  ✓ Legacy [politicianId] index is colder than composites (${fmt(legacy.idx_scan)} scans) — Task 5b.5 drop is safe once scans plateau`
+      );
+    } else {
+      console.log(
+        `  ⚠ Legacy [politicianId] index is still hotter than composites (${fmt(legacy.idx_scan)}) — wait longer before dropping`
+      );
+    }
+  }
+}
+
+async function pickPolitician(): Promise<{ id: string; slug: string; fullName: string } | null> {
+  if (DEFAULT_SLUG) {
+    const p = await db.politician.findUnique({
+      where: { slug: DEFAULT_SLUG },
+      select: { id: true, slug: true, fullName: true },
+    });
+    if (!p) {
+      console.log(`\n  ⚠ No politician with slug "${DEFAULT_SLUG}" — falling back to auto-pick`);
+    } else {
+      return p;
+    }
+  }
+
+  // Auto-pick: a deputy with the most votes (representative case)
+  const result = await db.$queryRaw<
+    { id: string; slug: string; fullName: string; voteCount: bigint }[]
+  >`
+    SELECT p.id, p.slug, p."fullName", COUNT(v.id) AS "voteCount"
+    FROM "Politician" p
+    JOIN "Vote" v ON v."politicianId" = p.id
+    WHERE v.chamber = 'AN'
+    GROUP BY p.id, p.slug, p."fullName"
+    ORDER BY COUNT(v.id) DESC
+    LIMIT 1
+  `;
+  if (result.length === 0) return null;
+  const r = result[0];
+  console.log(`\n  Auto-picked: ${r.fullName} (${fmt(r.voteCount)} votes)`);
+  return { id: r.id, slug: r.slug, fullName: r.fullName };
+}
+
+async function explainVoteStatsQuery(politicianId: string) {
+  banner("2. EXPLAIN ANALYZE — getPoliticianVotingStats critical path");
+  console.log("  Query: Vote groupBy position WHERE politicianId + chamber + votingDate range");
+  console.log("  (This is the Site 13 query — the biggest win from Phase 5b)\n");
+
+  const start = new Date("2024-07-01");
+  const end = new Date("2026-12-31");
+
+  const plan = await db.$queryRaw<{ "QUERY PLAN": string }[]>`
+    EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+    SELECT position, COUNT(*) FROM "Vote"
+    WHERE "politicianId" = ${politicianId}
+      AND chamber = 'AN'::"Chamber"
+      AND "votingDate" >= ${start}
+      AND "votingDate" <= ${end}
+    GROUP BY position
+  `;
+
+  for (const row of plan) {
+    console.log("  " + row["QUERY PLAN"]);
+  }
+
+  const planText = plan.map((r) => r["QUERY PLAN"]).join("\n");
+  console.log("\n  Verdict:");
+  if (planText.includes("Vote_politicianId_chamber_votingDate_idx")) {
+    console.log(
+      "  ✓ Uses the new [politicianId,chamber,votingDate] composite — Phase 5b win confirmed"
+    );
+  } else if (planText.match(/Index.*Scan.*Vote/)) {
+    console.log("  ~ Uses a Vote index but not the target composite — check which one above");
+  } else if (planText.includes("Seq Scan")) {
+    console.log("  ✗ Sequential scan on Vote — indexes not being used, investigate");
+  }
+  const execMatch = planText.match(/Execution Time: ([\d.]+) ms/);
+  if (execMatch) {
+    console.log(`  Execution time: ${execMatch[1]} ms`);
+  }
+}
+
+async function explainVotesOrderByQuery(politicianId: string) {
+  banner("3. EXPLAIN ANALYZE — politician votes page (orderBy votingDate DESC)");
+  console.log("  Query: Vote ORDER BY votingDate DESC LIMIT 20 WHERE politicianId = ?");
+  console.log("  (This is the Site 7/8 query — politician profile votes tab)\n");
+
+  const plan = await db.$queryRaw<{ "QUERY PLAN": string }[]>`
+    EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+    SELECT id, position, "votingDate", "scrutinId"
+    FROM "Vote"
+    WHERE "politicianId" = ${politicianId}
+    ORDER BY "votingDate" DESC
+    LIMIT 20
+  `;
+
+  for (const row of plan) {
+    console.log("  " + row["QUERY PLAN"]);
+  }
+
+  const planText = plan.map((r) => r["QUERY PLAN"]).join("\n");
+  console.log("\n  Verdict:");
+  if (planText.includes("Vote_politicianId_votingDate_idx")) {
+    console.log(
+      "  ✓ Uses the new [politicianId,votingDate] composite with backward index scan — no sort step needed"
+    );
+  } else if (planText.match(/Sort.*Vote/)) {
+    console.log(
+      "  ⚠ Uses a sort step — ideally the composite should provide pre-sorted rows. Check plan above"
+    );
+  } else if (planText.includes("Seq Scan")) {
+    console.log("  ✗ Sequential scan — investigate");
+  }
+  const execMatch = planText.match(/Execution Time: ([\d.]+) ms/);
+  if (execMatch) {
+    console.log(`  Execution time: ${execMatch[1]} ms`);
+  }
+}
+
+async function showTriggerStatus() {
+  banner("4. Trigger status (Phase 5b denorm sync)");
+
+  const rows = await db.$queryRaw<{ tgname: string; tgenabled: string }[]>`
+    SELECT tgname, tgenabled::text
+    FROM pg_trigger
+    WHERE tgrelid = '"Scrutin"'::regclass
+      AND NOT tgisinternal
+  `;
+
+  if (rows.length === 0) {
+    console.log("  ✗ No triggers on Scrutin — denorm sync trigger is MISSING");
+    return;
+  }
+
+  for (const r of rows) {
+    const enabled = r.tgenabled === "O" ? "enabled" : `state=${r.tgenabled}`;
+    console.log(`  ${r.tgname}: ${enabled}`);
+  }
+
+  const hasTrigger = rows.some((r) => r.tgname === "sync_vote_denorm_from_scrutin_trigger");
+  console.log("\n  Verdict:");
+  if (hasTrigger) {
+    console.log("  ✓ Denorm sync trigger is installed on Scrutin");
+  } else {
+    console.log("  ✗ sync_vote_denorm_from_scrutin_trigger is MISSING");
+  }
+}
+
+async function main() {
+  console.log("\n═══ Phase 5b performance verification ═══");
+  console.log(`  Time: ${new Date().toISOString()}`);
+  console.log(`  DB: ${process.env.DATABASE_URL?.replace(/:[^:@]+@/, ":***@")}`);
+
+  await showIndexUsage();
+  await showTriggerStatus();
+
+  const politician = await pickPolitician();
+  if (!politician) {
+    console.log("\n  ⚠ No politician found — skipping EXPLAIN checks");
+    return;
+  }
+  console.log(`\n  Using politician: ${politician.fullName} (${politician.slug})`);
+
+  await explainVoteStatsQuery(politician.id);
+  await explainVotesOrderByQuery(politician.id);
+
+  console.log("\n═══ Done ═══\n");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/src/app/api/admin/affaires/merge/route.ts
+++ b/src/app/api/admin/affaires/merge/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation, getRequestMeta } from "@/lib/security";
@@ -33,6 +34,12 @@ export const POST = withAdminAuth(
       }),
     ]);
 
+    // Capture identifiers before mutation so we can build a redirect row
+    // after the secondary affair is deleted. Any external citation pointing
+    // at the retired poligraphId must keep resolving to the survivor.
+    const secondaryPublicId = secondary?.publicId ?? null;
+    const primaryPublicId = primary?.publicId ?? null;
+
     if (!primary || !secondary) {
       return NextResponse.json({ error: "Affaire(s) non trouvée(s)" }, { status: 404 });
     }
@@ -63,7 +70,7 @@ export const POST = withAdminAuth(
     });
 
     // Merge judicial identifiers if primary is missing them
-    const updates: Record<string, unknown> = {};
+    const updates: Prisma.AffairUpdateInput = {};
     if (!primary.ecli && secondary.ecli) updates.ecli = secondary.ecli;
     if (!primary.pourvoiNumber && secondary.pourvoiNumber)
       updates.pourvoiNumber = secondary.pourvoiNumber;
@@ -82,6 +89,24 @@ export const POST = withAdminAuth(
 
     // Delete secondary affair (remaining sources will cascade)
     await db.affair.delete({ where: { id: secondaryId } });
+
+    // Preserve the retired poligraphId as a redirect so external citations
+    // keep resolving. Only write the redirect if both IDs exist and differ.
+    if (secondaryPublicId && primaryPublicId && secondaryPublicId !== primaryPublicId) {
+      await db.publicIdRedirect.upsert({
+        where: { fromPublicId: secondaryPublicId },
+        create: {
+          fromPublicId: secondaryPublicId,
+          toPublicId: primaryPublicId,
+          entityType: "affair",
+          reason: "merged",
+        },
+        update: {
+          toPublicId: primaryPublicId,
+          reason: "merged",
+        },
+      });
+    }
 
     // Audit log
     const meta = getRequestMeta(request);

--- a/src/app/api/admin/politiques/[id]/party-membership/[membershipId]/route.ts
+++ b/src/app/api/admin/politiques/[id]/party-membership/[membershipId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation, getRequestMeta } from "@/lib/security";
@@ -21,7 +22,7 @@ export const PATCH = withAdminAuth(
       return NextResponse.json({ error: "Membership non trouvé" }, { status: 404 });
     }
 
-    const updateData: Record<string, unknown> = {};
+    const updateData: Prisma.PartyMembershipUpdateInput = {};
 
     if (body.startDate !== undefined) {
       updateData.startDate = body.startDate ? new Date(body.startDate) : null;

--- a/src/app/api/export/affaires/route.ts
+++ b/src/app/api/export/affaires/route.ts
@@ -1,6 +1,18 @@
 import { db } from "@/lib/db";
-import { toCSV, formatDateForCSV, createCSVResponse } from "@/lib/csv";
-import { AFFAIR_STATUS_LABELS, AFFAIR_CATEGORY_LABELS } from "@/config/labels";
+import {
+  toCSV,
+  formatDateForCSV,
+  formatDateTimeForCSV,
+  stripMarkdownForCSV,
+  createCSVResponse,
+} from "@/lib/csv";
+import {
+  AFFAIR_STATUS_LABELS,
+  AFFAIR_CATEGORY_LABELS,
+  AFFAIR_SEVERITY_LABELS,
+  INVOLVEMENT_LABELS,
+  POLITICAL_POSITION_LABELS,
+} from "@/config/labels";
 import { parsePagination } from "@/lib/api/pagination";
 import type { AffairStatus, AffairCategory } from "@/types";
 import { SITE_URL } from "@/config/site";
@@ -8,90 +20,188 @@ import { withPublicRoute } from "@/lib/api/with-public-route";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * @openapi
+ * /api/export/affaires:
+ *   get:
+ *     summary: Export CSV des affaires judiciaires
+ *     description: >
+ *       Retourne toutes les affaires judiciaires publiées au format CSV,
+ *       prêtes à l'emploi pour l'analyse statistique (R, Python, Excel).
+ *       Chaque ligne inclut le poligraphId (identifiant stable pour citation),
+ *       les métadonnées du politique et du parti (actuel + au moment des
+ *       faits), la classification Sapin II (gravité, catégorie, implication),
+ *       le détail de la peine (prison, amende, inéligibilité), et la
+ *       description complète nettoyée du markdown.
+ *     tags: [Exports]
+ *     parameters:
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [ENQUETE_PRELIMINAIRE, INSTRUCTION, MISE_EN_EXAMEN, RENVOI_TRIBUNAL, PROCES_EN_COURS, CONDAMNATION_PREMIERE_INSTANCE, APPEL_EN_COURS, CONDAMNATION_DEFINITIVE, RELAXE, ACQUITTEMENT, NON_LIEU, PRESCRIPTION, ABANDONNEE, CLASSEE_SANS_SUITE]
+ *       - in: query
+ *         name: category
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: politicianId
+ *         schema:
+ *           type: string
+ *         description: Filtrer par ID interne du politique
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 10000
+ *           minimum: 1
+ *           maximum: 50000
+ *     responses:
+ *       200:
+ *         description: Fichier CSV UTF-8 avec BOM
+ *         content:
+ *           text/csv:
+ *             schema:
+ *               type: string
+ */
 export const GET = withPublicRoute(async (request) => {
   const searchParams = request.nextUrl.searchParams;
 
-  // Optional filters
   const status = searchParams.get("status") as AffairStatus | null;
   const category = searchParams.get("category") as AffairCategory | null;
   const politicianId = searchParams.get("politicianId");
-  const { limit } = parsePagination(searchParams, { defaultLimit: 10000, maxLimit: 50000 });
+  const { limit } = parsePagination(searchParams, {
+    defaultLimit: 10000,
+    maxLimit: 50000,
+  });
 
-  // Build where clause
   const where: Record<string, unknown> = {
     publicationStatus: "PUBLISHED",
   };
+  if (status) where.status = status;
+  if (category) where.category = category;
+  if (politicianId) where.politicianId = politicianId;
 
-  if (status) {
-    where.status = status;
-  }
-
-  if (category) {
-    where.category = category;
-  }
-
-  if (politicianId) {
-    where.politicianId = politicianId;
-  }
-
-  // Fetch affairs with politician and sources
   const affairs = await db.affair.findMany({
     where,
     include: {
       politician: {
         select: {
-          id: true,
+          publicId: true,
           slug: true,
           fullName: true,
-          currentParty: { select: { shortName: true } },
+          currentParty: {
+            select: {
+              shortName: true,
+              name: true,
+              politicalPosition: true,
+            },
+          },
         },
       },
-      partyAtTime: { select: { shortName: true } },
-      sources: { take: 1 },
+      partyAtTime: {
+        select: {
+          shortName: true,
+          name: true,
+        },
+      },
+      sources: {
+        select: { url: true, title: true },
+      },
+      _count: {
+        select: { sources: true },
+      },
     },
     orderBy: { createdAt: "desc" },
     take: limit,
   });
 
-  // Transform to flat structure for CSV
   const data = affairs.map((a) => ({
-    id: a.id,
-    slug: a.slug,
+    poligraphId: a.publicId ?? "",
+    affairSlug: a.slug,
     title: a.title,
-    politicianName: a.politician.fullName,
+    politicianPoligraphId: a.politician.publicId ?? "",
     politicianSlug: a.politician.slug,
-    currentParty: a.politician.currentParty?.shortName || "",
-    partyAtTime: a.partyAtTime?.shortName || "",
+    politicianName: a.politician.fullName,
+    partyCurrentShort: a.politician.currentParty?.shortName ?? "",
+    partyCurrentLong: a.politician.currentParty?.name ?? "",
+    partyCurrentPosition: a.politician.currentParty?.politicalPosition
+      ? POLITICAL_POSITION_LABELS[a.politician.currentParty.politicalPosition]
+      : "",
+    partyAtTimeShort: a.partyAtTime?.shortName ?? "",
+    partyAtTimeLong: a.partyAtTime?.name ?? "",
     status: AFFAIR_STATUS_LABELS[a.status],
+    statusCode: a.status,
     category: AFFAIR_CATEGORY_LABELS[a.category],
+    categoryCode: a.category,
+    severity: AFFAIR_SEVERITY_LABELS[a.severity],
+    severityCode: a.severity,
+    involvement: INVOLVEMENT_LABELS[a.involvement],
+    involvementCode: a.involvement,
+    isRelatedToMandate: a.isRelatedToMandate ? "oui" : "non",
     factsDate: formatDateForCSV(a.factsDate),
     startDate: formatDateForCSV(a.startDate),
     verdictDate: formatDateForCSV(a.verdictDate),
-    sentence: a.sentence || "",
-    description: a.description.substring(0, 500), // Truncate for CSV
-    sourceUrl: a.sources[0]?.url || "",
-    sourceTitle: a.sources[0]?.title || "",
+    fineAmount: a.fineAmount !== null ? Number(a.fineAmount) : "",
+    prisonMonths: a.prisonMonths ?? "",
+    prisonSuspended: a.prisonSuspended === null ? "" : a.prisonSuspended ? "oui" : "non",
+    ineligibilityMonths: a.ineligibilityMonths ?? "",
+    communityService: a.communityService ?? "",
+    appeal: a.appeal ? "oui" : "non",
+    sentence: a.sentence ?? "",
+    otherSentence: a.otherSentence ?? "",
+    court: a.court ?? "",
+    ecli: a.ecli ?? "",
+    descriptionPlain: stripMarkdownForCSV(a.description),
+    sourceCount: a._count.sources,
+    sourceUrl: a.sources[0]?.url ?? "",
+    sourceTitle: a.sources[0]?.title ?? "",
     pageUrl: `${SITE_URL}/affaires/${a.slug}`,
+    createdAt: formatDateTimeForCSV(a.createdAt),
+    updatedAt: formatDateTimeForCSV(a.updatedAt),
   }));
 
   const columns = [
-    { key: "id" as const, header: "ID" },
-    { key: "slug" as const, header: "Slug" },
+    { key: "poligraphId" as const, header: "poligraphId" },
+    { key: "affairSlug" as const, header: "Slug affaire" },
     { key: "title" as const, header: "Titre" },
+    { key: "politicianPoligraphId" as const, header: "poligraphId politique" },
+    { key: "politicianSlug" as const, header: "Slug politique" },
     { key: "politicianName" as const, header: "Politique" },
-    { key: "politicianSlug" as const, header: "Politique Slug" },
-    { key: "currentParty" as const, header: "Parti Actuel" },
-    { key: "partyAtTime" as const, header: "Parti au Moment" },
+    { key: "partyCurrentShort" as const, header: "Parti actuel (abrégé)" },
+    { key: "partyCurrentLong" as const, header: "Parti actuel" },
+    { key: "partyCurrentPosition" as const, header: "Position politique" },
+    { key: "partyAtTimeShort" as const, header: "Parti au moment (abrégé)" },
+    { key: "partyAtTimeLong" as const, header: "Parti au moment" },
     { key: "status" as const, header: "Statut" },
-    { key: "category" as const, header: "Categorie" },
-    { key: "factsDate" as const, header: "Date des Faits" },
-    { key: "startDate" as const, header: "Date de Debut" },
-    { key: "verdictDate" as const, header: "Date du Verdict" },
-    { key: "sentence" as const, header: "Peine" },
-    { key: "description" as const, header: "Description" },
-    { key: "sourceUrl" as const, header: "Source URL" },
-    { key: "sourceTitle" as const, header: "Source Titre" },
-    { key: "pageUrl" as const, header: "Page URL" },
+    { key: "statusCode" as const, header: "Statut (code)" },
+    { key: "category" as const, header: "Catégorie" },
+    { key: "categoryCode" as const, header: "Catégorie (code)" },
+    { key: "severity" as const, header: "Gravité" },
+    { key: "severityCode" as const, header: "Gravité (code)" },
+    { key: "involvement" as const, header: "Implication" },
+    { key: "involvementCode" as const, header: "Implication (code)" },
+    { key: "isRelatedToMandate" as const, header: "Liée au mandat" },
+    { key: "factsDate" as const, header: "Date des faits" },
+    { key: "startDate" as const, header: "Date de début" },
+    { key: "verdictDate" as const, header: "Date du verdict" },
+    { key: "fineAmount" as const, header: "Amende (EUR)" },
+    { key: "prisonMonths" as const, header: "Prison (mois)" },
+    { key: "prisonSuspended" as const, header: "Prison avec sursis" },
+    { key: "ineligibilityMonths" as const, header: "Inéligibilité (mois)" },
+    { key: "communityService" as const, header: "TIG (heures)" },
+    { key: "appeal" as const, header: "Appel" },
+    { key: "sentence" as const, header: "Peine (texte libre)" },
+    { key: "otherSentence" as const, header: "Autres peines" },
+    { key: "court" as const, header: "Juridiction" },
+    { key: "ecli" as const, header: "ECLI" },
+    { key: "descriptionPlain" as const, header: "Description" },
+    { key: "sourceCount" as const, header: "Nombre de sources" },
+    { key: "sourceUrl" as const, header: "Première source (URL)" },
+    { key: "sourceTitle" as const, header: "Première source (titre)" },
+    { key: "pageUrl" as const, header: "Page Poligraph" },
+    { key: "createdAt" as const, header: "Créée le" },
+    { key: "updatedAt" as const, header: "Mise à jour le" },
   ];
 
   const csv = toCSV(data, columns);

--- a/src/app/api/export/factchecks/route.ts
+++ b/src/app/api/export/factchecks/route.ts
@@ -1,0 +1,190 @@
+import { db } from "@/lib/db";
+import { toCSV, formatDateForCSV, formatDateTimeForCSV, createCSVResponse } from "@/lib/csv";
+import { FACTCHECK_RATING_LABELS, POLITICAL_POSITION_LABELS } from "@/config/labels";
+import { parsePagination } from "@/lib/api/pagination";
+import type { FactCheckRating } from "@/types";
+import { SITE_URL } from "@/config/site";
+import { withPublicRoute } from "@/lib/api/with-public-route";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * @openapi
+ * /api/export/factchecks:
+ *   get:
+ *     summary: Export CSV des fact-checks
+ *     description: >
+ *       Retourne les fact-checks publiés au format CSV, dénormalisés par
+ *       politique mentionné (une ligne par paire factcheck + politique).
+ *       Un fact-check sans mention apparaît sur une seule ligne avec les
+ *       colonnes politique vides. Cette structure permet l'agrégation par
+ *       parti politique sans join côté client.
+ *     tags: [Exports]
+ *     parameters:
+ *       - in: query
+ *         name: verdict
+ *         schema:
+ *           type: string
+ *           enum: [TRUE, MOSTLY_TRUE, HALF_TRUE, MISLEADING, OUT_OF_CONTEXT, MOSTLY_FALSE, FALSE, UNVERIFIABLE]
+ *       - in: query
+ *         name: source
+ *         schema:
+ *           type: string
+ *         description: Nom du fact-checker (AFP Factuel, Les Décodeurs, etc.)
+ *       - in: query
+ *         name: politicianSlug
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 10000
+ *           minimum: 1
+ *           maximum: 50000
+ *     responses:
+ *       200:
+ *         description: Fichier CSV UTF-8 avec BOM
+ *         content:
+ *           text/csv:
+ *             schema:
+ *               type: string
+ */
+export const GET = withPublicRoute(async (request) => {
+  const searchParams = request.nextUrl.searchParams;
+
+  const verdict = searchParams.get("verdict") as FactCheckRating | null;
+  const source = searchParams.get("source");
+  const politicianSlug = searchParams.get("politicianSlug");
+  const { limit } = parsePagination(searchParams, {
+    defaultLimit: 10000,
+    maxLimit: 50000,
+  });
+
+  const where: Record<string, unknown> = {
+    publicationStatus: "PUBLISHED",
+  };
+  if (verdict) where.verdictRating = verdict;
+  if (source) where.source = source;
+  if (politicianSlug) {
+    where.mentions = {
+      some: { politician: { slug: politicianSlug } },
+    };
+  }
+
+  const factchecks = await db.factCheck.findMany({
+    where,
+    include: {
+      mentions: {
+        include: {
+          politician: {
+            select: {
+              publicId: true,
+              slug: true,
+              fullName: true,
+              currentParty: {
+                select: {
+                  publicId: true,
+                  shortName: true,
+                  name: true,
+                  politicalPosition: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    orderBy: { publishedAt: "desc" },
+    take: limit,
+  });
+
+  // Denormalise: one row per (factcheck, mention) pair. Factchecks with no
+  // mentioned politicians still emit one row with empty politician columns
+  // so the output is never silently filtered.
+  const data = factchecks.flatMap((fc) => {
+    const base = {
+      poligraphId: fc.publicId ?? "",
+      slug: fc.slug ?? "",
+      title: fc.title,
+      claim: fc.claimText,
+      claimant: fc.claimant ?? "",
+      verdict: fc.verdict,
+      verdictRating: FACTCHECK_RATING_LABELS[fc.verdictRating],
+      verdictRatingCode: fc.verdictRating,
+      sourcePublisher: fc.source,
+      sourceUrl: fc.sourceUrl,
+      publishedAt: formatDateForCSV(fc.publishedAt),
+      claimDate: formatDateForCSV(fc.claimDate),
+      languageCode: fc.languageCode ?? "",
+      createdAt: formatDateTimeForCSV(fc.createdAt),
+      updatedAt: formatDateTimeForCSV(fc.updatedAt),
+      pageUrl: fc.slug ? `${SITE_URL}/factchecks/${fc.slug}` : `${SITE_URL}/factchecks`,
+    };
+
+    if (fc.mentions.length === 0) {
+      return [
+        {
+          ...base,
+          politicianPoligraphId: "",
+          politicianSlug: "",
+          politicianName: "",
+          isClaimant: "",
+          matchedName: "",
+          partyPoligraphId: "",
+          partyShort: "",
+          partyLong: "",
+          partyPosition: "",
+        },
+      ];
+    }
+
+    return fc.mentions.map((m) => ({
+      ...base,
+      politicianPoligraphId: m.politician.publicId ?? "",
+      politicianSlug: m.politician.slug,
+      politicianName: m.politician.fullName,
+      isClaimant: m.isClaimant ? "oui" : "non",
+      matchedName: m.matchedName ?? "",
+      partyPoligraphId: m.politician.currentParty?.publicId ?? "",
+      partyShort: m.politician.currentParty?.shortName ?? "",
+      partyLong: m.politician.currentParty?.name ?? "",
+      partyPosition: m.politician.currentParty?.politicalPosition
+        ? POLITICAL_POSITION_LABELS[m.politician.currentParty.politicalPosition]
+        : "",
+    }));
+  });
+
+  const columns = [
+    { key: "poligraphId" as const, header: "poligraphId" },
+    { key: "slug" as const, header: "Slug" },
+    { key: "title" as const, header: "Titre" },
+    { key: "claim" as const, header: "Déclaration vérifiée" },
+    { key: "claimant" as const, header: "Auteur de la déclaration" },
+    { key: "verdict" as const, header: "Verdict (texte)" },
+    { key: "verdictRating" as const, header: "Verdict (normalisé)" },
+    { key: "verdictRatingCode" as const, header: "Verdict (code)" },
+    { key: "sourcePublisher" as const, header: "Fact-checker" },
+    { key: "sourceUrl" as const, header: "URL source" },
+    { key: "publishedAt" as const, header: "Date de publication" },
+    { key: "claimDate" as const, header: "Date de la déclaration" },
+    { key: "languageCode" as const, header: "Langue" },
+    { key: "politicianPoligraphId" as const, header: "poligraphId politique" },
+    { key: "politicianSlug" as const, header: "Slug politique" },
+    { key: "politicianName" as const, header: "Politique" },
+    { key: "isClaimant" as const, header: "Auteur direct" },
+    { key: "matchedName" as const, header: "Nom détecté" },
+    { key: "partyPoligraphId" as const, header: "poligraphId parti" },
+    { key: "partyShort" as const, header: "Parti (abrégé)" },
+    { key: "partyLong" as const, header: "Parti" },
+    { key: "partyPosition" as const, header: "Position politique" },
+    { key: "pageUrl" as const, header: "Page Poligraph" },
+    { key: "createdAt" as const, header: "Créé le" },
+    { key: "updatedAt" as const, header: "Mis à jour le" },
+  ];
+
+  const csv = toCSV(data, columns);
+  const filename = `factchecks-${new Date().toISOString().split("T")[0]}.csv`;
+
+  return createCSVResponse(csv, filename);
+});

--- a/src/app/api/export/politiques/route.ts
+++ b/src/app/api/export/politiques/route.ts
@@ -1,23 +1,60 @@
 import { db } from "@/lib/db";
-import { toCSV, formatDateForCSV, createCSVResponse } from "@/lib/csv";
-import { MANDATE_TYPE_LABELS } from "@/config/labels";
+import { toCSV, formatDateForCSV, formatDateTimeForCSV, createCSVResponse } from "@/lib/csv";
+import { MANDATE_TYPE_LABELS, POLITICAL_POSITION_LABELS } from "@/config/labels";
 import type { MandateType } from "@/types";
 import { SITE_URL } from "@/config/site";
 import { withPublicRoute } from "@/lib/api/with-public-route";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * @openapi
+ * /api/export/politiques:
+ *   get:
+ *     summary: Export CSV des politiques
+ *     description: >
+ *       Retourne les politiques publiés au format CSV, avec leur poligraphId
+ *       (identifiant stable pour citation), parti actuel, mandat en cours,
+ *       département, score de prominence et Q-ID Wikidata pour croisement
+ *       avec d'autres jeux de données.
+ *     tags: [Exports]
+ *     parameters:
+ *       - in: query
+ *         name: partyId
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: mandateType
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: hasAffairs
+ *         schema:
+ *           type: boolean
+ *       - in: query
+ *         name: activeOnly
+ *         schema:
+ *           type: boolean
+ *           default: true
+ *     responses:
+ *       200:
+ *         description: Fichier CSV UTF-8 avec BOM
+ *         content:
+ *           text/csv:
+ *             schema:
+ *               type: string
+ */
 export const GET = withPublicRoute(async (request) => {
   const searchParams = request.nextUrl.searchParams;
 
-  // Optional filters
   const partyId = searchParams.get("partyId");
   const mandateType = searchParams.get("mandateType") as MandateType | null;
   const hasAffairs = searchParams.get("hasAffairs") === "true";
-  const activeOnly = searchParams.get("activeOnly") !== "false"; // Default true
+  const activeOnly = searchParams.get("activeOnly") !== "false";
 
-  // Build where clause
-  const where: Record<string, unknown> = {};
+  const where: Record<string, unknown> = {
+    publicationStatus: "PUBLISHED",
+  };
 
   if (partyId) {
     where.currentPartyId = partyId;
@@ -40,58 +77,112 @@ export const GET = withPublicRoute(async (request) => {
     where.affairs = { some: { publicationStatus: "PUBLISHED" } };
   }
 
-  // Fetch politicians with current mandate and party
   const politicians = await db.politician.findMany({
     where,
     include: {
-      currentParty: true,
+      currentParty: {
+        select: {
+          publicId: true,
+          slug: true,
+          shortName: true,
+          name: true,
+          politicalPosition: true,
+        },
+      },
       mandates: {
         where: activeOnly ? { isCurrent: true } : undefined,
         orderBy: { startDate: "desc" },
         take: 1,
+        select: {
+          type: true,
+          title: true,
+          constituency: true,
+          departmentCode: true,
+          startDate: true,
+          endDate: true,
+        },
       },
-      _count: { select: { affairs: { where: { publicationStatus: "PUBLISHED" } } } },
+      externalIds: {
+        where: { source: "WIKIDATA" },
+        select: { externalId: true },
+        take: 1,
+      },
+      _count: {
+        select: {
+          affairs: { where: { publicationStatus: "PUBLISHED" } },
+          factCheckMentions: true,
+        },
+      },
     },
     orderBy: { lastName: "asc" },
   });
 
-  // Transform to flat structure for CSV
-  const data = politicians.map((p) => ({
-    id: p.id,
-    slug: p.slug,
-    civility: p.civility || "",
-    firstName: p.firstName,
-    lastName: p.lastName,
-    fullName: p.fullName,
-    birthDate: formatDateForCSV(p.birthDate),
-    birthPlace: p.birthPlace || "",
-    deathDate: formatDateForCSV(p.deathDate),
-    partyName: p.currentParty?.name || "",
-    partyShortName: p.currentParty?.shortName || "",
-    currentMandate: p.mandates[0] ? MANDATE_TYPE_LABELS[p.mandates[0].type] : "",
-    constituency: p.mandates[0]?.constituency || "",
-    affairsCount: p._count.affairs,
-    photoUrl: p.photoUrl || "",
-    profileUrl: `${SITE_URL}/politiques/${p.slug}`,
-  }));
+  const data = politicians.map((p) => {
+    const mandate = p.mandates[0];
+    const gender = p.civility === "M." ? "M" : p.civility === "Mme" ? "F" : "";
+    return {
+      poligraphId: p.publicId ?? "",
+      slug: p.slug,
+      civility: p.civility ?? "",
+      firstName: p.firstName,
+      lastName: p.lastName,
+      fullName: p.fullName,
+      gender,
+      birthDate: formatDateForCSV(p.birthDate),
+      birthPlace: p.birthPlace ?? "",
+      deathDate: formatDateForCSV(p.deathDate),
+      partyPoligraphId: p.currentParty?.publicId ?? "",
+      partyShort: p.currentParty?.shortName ?? "",
+      partyLong: p.currentParty?.name ?? "",
+      partyPosition: p.currentParty?.politicalPosition
+        ? POLITICAL_POSITION_LABELS[p.currentParty.politicalPosition]
+        : "",
+      currentMandateType: mandate ? MANDATE_TYPE_LABELS[mandate.type] : "",
+      currentMandateTitle: mandate?.title ?? "",
+      currentMandateStart: formatDateForCSV(mandate?.startDate),
+      currentMandateEnd: formatDateForCSV(mandate?.endDate),
+      constituency: mandate?.constituency ?? "",
+      departmentCode: mandate?.departmentCode ?? "",
+      affairsCount: p._count.affairs,
+      factcheckMentionsCount: p._count.factCheckMentions,
+      prominenceScore: p.prominenceScore,
+      wikidataId: p.externalIds[0]?.externalId ?? "",
+      photoUrl: p.blobPhotoUrl ?? p.photoUrl ?? "",
+      profileUrl: `${SITE_URL}/politiques/${p.slug}`,
+      createdAt: formatDateTimeForCSV(p.createdAt),
+      updatedAt: formatDateTimeForCSV(p.updatedAt),
+    };
+  });
 
   const columns = [
-    { key: "id" as const, header: "ID" },
+    { key: "poligraphId" as const, header: "poligraphId" },
     { key: "slug" as const, header: "Slug" },
-    { key: "civility" as const, header: "Civilite" },
-    { key: "firstName" as const, header: "Prenom" },
+    { key: "civility" as const, header: "Civilité" },
+    { key: "firstName" as const, header: "Prénom" },
     { key: "lastName" as const, header: "Nom" },
-    { key: "fullName" as const, header: "Nom Complet" },
-    { key: "birthDate" as const, header: "Date Naissance" },
-    { key: "birthPlace" as const, header: "Lieu Naissance" },
-    { key: "deathDate" as const, header: "Date Deces" },
-    { key: "partyName" as const, header: "Parti" },
-    { key: "partyShortName" as const, header: "Parti (abrege)" },
-    { key: "currentMandate" as const, header: "Mandat Actuel" },
+    { key: "fullName" as const, header: "Nom complet" },
+    { key: "gender" as const, header: "Genre" },
+    { key: "birthDate" as const, header: "Date de naissance" },
+    { key: "birthPlace" as const, header: "Lieu de naissance" },
+    { key: "deathDate" as const, header: "Date de décès" },
+    { key: "partyPoligraphId" as const, header: "poligraphId parti" },
+    { key: "partyShort" as const, header: "Parti (abrégé)" },
+    { key: "partyLong" as const, header: "Parti" },
+    { key: "partyPosition" as const, header: "Position politique" },
+    { key: "currentMandateType" as const, header: "Mandat actuel" },
+    { key: "currentMandateTitle" as const, header: "Titre du mandat" },
+    { key: "currentMandateStart" as const, header: "Début du mandat" },
+    { key: "currentMandateEnd" as const, header: "Fin du mandat" },
     { key: "constituency" as const, header: "Circonscription" },
-    { key: "affairsCount" as const, header: "Nombre Affaires" },
-    { key: "photoUrl" as const, header: "Photo URL" },
-    { key: "profileUrl" as const, header: "Profil URL" },
+    { key: "departmentCode" as const, header: "Code département" },
+    { key: "affairsCount" as const, header: "Nombre d'affaires" },
+    { key: "factcheckMentionsCount" as const, header: "Fact-checks (mentions)" },
+    { key: "prominenceScore" as const, header: "Score de prominence" },
+    { key: "wikidataId" as const, header: "Wikidata Q-ID" },
+    { key: "photoUrl" as const, header: "Photo" },
+    { key: "profileUrl" as const, header: "Profil Poligraph" },
+    { key: "createdAt" as const, header: "Créé le" },
+    { key: "updatedAt" as const, header: "Mis à jour le" },
   ];
 
   const csv = toCSV(data, columns);

--- a/src/app/api/factchecks/route.ts
+++ b/src/app/api/factchecks/route.ts
@@ -12,7 +12,7 @@ import { withPublicRoute } from "@/lib/api/with-public-route";
  *   get:
  *     summary: Liste des fact-checks
  *     description: Retourne la liste paginée des fact-checks avec filtres
- *     tags: [FactChecks]
+ *     tags: [Fact-checks]
  *     parameters:
  *       - in: query
  *         name: search

--- a/src/app/docs/api/_components/CodeBlock.tsx
+++ b/src/app/docs/api/_components/CodeBlock.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+interface CodeBlockProps {
+  code: string;
+  language?: string;
+  label?: string;
+}
+
+export function CodeBlock({ code, language = "bash", label }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API can be blocked in insecure contexts — fail silently.
+    }
+  }
+
+  return (
+    <div className="relative group">
+      {label && <div className="text-xs font-mono text-muted-foreground mb-1">{label}</div>}
+      <pre className="bg-muted rounded-lg p-4 pr-12 text-sm overflow-x-auto font-mono">
+        <code className={`language-${language}`}>{code}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copié" : "Copier le code"}
+        title={copied ? "Copié" : "Copier le code"}
+        className="absolute top-3 right-3 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background hover:bg-muted transition-colors"
+      >
+        {copied ? (
+          <Check className="h-4 w-4 text-green-600" aria-hidden="true" />
+        ) : (
+          <Copy className="h-4 w-4" aria-hidden="true" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/app/docs/api/_components/DataDictionary.tsx
+++ b/src/app/docs/api/_components/DataDictionary.tsx
@@ -1,0 +1,91 @@
+import {
+  AFFAIR_STATUS_LABELS,
+  AFFAIR_CATEGORY_LABELS,
+  AFFAIR_SEVERITY_LABELS,
+  INVOLVEMENT_LABELS,
+  POLITICAL_POSITION_LABELS,
+  MANDATE_TYPE_LABELS,
+  FACTCHECK_RATING_LABELS,
+} from "@/config/labels";
+
+interface DictionaryTableProps {
+  title: string;
+  description?: string;
+  labels: Record<string, string>;
+}
+
+function DictionaryTable({ title, description, labels }: DictionaryTableProps) {
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="border-b px-4 py-3">
+        <h3 className="font-semibold">{title}</h3>
+        {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 border-b">
+            <tr>
+              <th className="text-left font-mono font-semibold px-4 py-2 w-1/3">Code</th>
+              <th className="text-left font-semibold px-4 py-2">Libellé</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(labels).map(([code, label]) => (
+              <tr key={code} className="border-b last:border-0">
+                <td className="font-mono text-xs px-4 py-2">{code}</td>
+                <td className="px-4 py-2">{label}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Data dictionary auto-generated from src/config/labels.ts at build time.
+ * Keeping this in sync with the actual DB enums is free because TypeScript
+ * enforces the Record<EnumValue, string> constraint at the source.
+ */
+export function DataDictionary() {
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <DictionaryTable
+        title="Statuts judiciaires (statusCode)"
+        description="État de l'affaire dans le processus judiciaire."
+        labels={AFFAIR_STATUS_LABELS}
+      />
+      <DictionaryTable
+        title="Catégories d'affaires (categoryCode)"
+        description="Type d'infraction principal."
+        labels={AFFAIR_CATEGORY_LABELS}
+      />
+      <DictionaryTable
+        title="Gravité Sapin II (severityCode)"
+        description="Hiérarchie inspirée de la loi Sapin II. Voir /sources pour la méthodologie."
+        labels={AFFAIR_SEVERITY_LABELS}
+      />
+      <DictionaryTable
+        title="Implication (involvementCode)"
+        description="Rôle du politique dans l'affaire. Par défaut l'API filtre sur DIRECT."
+        labels={INVOLVEMENT_LABELS}
+      />
+      <DictionaryTable
+        title="Verdict fact-check (verdictRatingCode)"
+        description="Note normalisée Google Fact Check Tools."
+        labels={FACTCHECK_RATING_LABELS}
+      />
+      <DictionaryTable
+        title="Position politique (parti)"
+        description="Classification du parti sur l'axe gauche-droite."
+        labels={POLITICAL_POSITION_LABELS}
+      />
+      <DictionaryTable
+        title="Types de mandat (mandateType)"
+        description="Tous les types d'élus indexés."
+        labels={MANDATE_TYPE_LABELS}
+      />
+    </div>
+  );
+}

--- a/src/app/docs/api/_components/QuickstartTabs.tsx
+++ b/src/app/docs/api/_components/QuickstartTabs.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CodeBlock } from "./CodeBlock";
+
+const PYTHON_CODE = `import requests
+import pandas as pd
+
+# Option 1: télécharger l'export CSV complet (recommandé pour l'analyse)
+df = pd.read_csv("https://poligraph.fr/api/export/affaires?limit=10000")
+print(df.shape, df["severityCode"].value_counts())
+
+# Option 2: pagination de l'API JSON (10 000 max par page)
+rows, page = [], 1
+while True:
+    r = requests.get(
+        "https://poligraph.fr/api/affaires",
+        params={"limit": 100, "page": page, "involvement": "DIRECT,MENTIONED_ONLY"},
+        timeout=30,
+    ).json()
+    rows.extend(r["data"])
+    if page >= r["pagination"]["totalPages"]:
+        break
+    page += 1
+
+print(f"Total: {len(rows)} affaires")
+`;
+
+const R_CODE = `library(readr)
+library(dplyr)
+
+# Option 1: télécharger l'export CSV complet (recommandé)
+affaires <- read_csv("https://poligraph.fr/api/export/affaires?limit=10000")
+
+# Affaires par parti et gravité
+affaires |>
+  count(partyCurrentLong, severity, sort = TRUE)
+
+# Option 2: API JSON avec httr2 (pagination manuelle)
+library(httr2)
+library(purrr)
+
+fetch_page <- function(page) {
+  request("https://poligraph.fr/api/affaires") |>
+    req_url_query(limit = 100, page = page, involvement = "DIRECT") |>
+    req_perform() |>
+    resp_body_json()
+}
+
+pages <- map(1:fetch_page(1)$pagination$totalPages, fetch_page)
+affaires_json <- map_dfr(pages, "data")
+`;
+
+const CURL_CODE = `# Export CSV (recommandé pour récupérer tout en une fois)
+curl -o affaires.csv "https://poligraph.fr/api/export/affaires?limit=50000"
+curl -o politiques.csv "https://poligraph.fr/api/export/politiques?activeOnly=true"
+curl -o factchecks.csv "https://poligraph.fr/api/export/factchecks?limit=10000"
+
+# API JSON paginée
+curl -s "https://poligraph.fr/api/affaires?limit=100&page=1" | jq '.pagination'
+# → { "page": 1, "limit": 100, "total": 260, "totalPages": 3 }
+
+# Résoudre un poligraphId vers la page canonique (suit le redirect 308)
+curl -sL "https://poligraph.fr/id/AF-000042" -o /dev/null -w "%{url_effective}\\n"
+`;
+
+export function QuickstartTabs() {
+  return (
+    <Tabs defaultValue="python" className="w-full">
+      <TabsList>
+        <TabsTrigger value="python">Python</TabsTrigger>
+        <TabsTrigger value="r">R</TabsTrigger>
+        <TabsTrigger value="curl">curl</TabsTrigger>
+      </TabsList>
+      <TabsContent value="python" className="mt-4">
+        <CodeBlock code={PYTHON_CODE} language="python" />
+      </TabsContent>
+      <TabsContent value="r" className="mt-4">
+        <CodeBlock code={R_CODE} language="r" />
+      </TabsContent>
+      <TabsContent value="curl" className="mt-4">
+        <CodeBlock code={CURL_CODE} language="bash" />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/app/docs/api/page.tsx
+++ b/src/app/docs/api/page.tsx
@@ -1,24 +1,345 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { BookOpen, Database, FileDown, Link2, ShieldCheck } from "lucide-react";
 import { SwaggerUIWrapper } from "./_components/SwaggerUIWrapper";
+import { QuickstartTabs } from "./_components/QuickstartTabs";
+import { DataDictionary } from "./_components/DataDictionary";
+import { CodeBlock } from "./_components/CodeBlock";
 
 export const metadata: Metadata = {
-  title: "Documentation API",
+  title: "Documentation API — données ouvertes Poligraph",
   description:
-    "Documentation interactive de l'API publique Poligraph : politiques, votes, affaires, élections et plus.",
+    "Guide complet pour utiliser les données publiques Poligraph (affaires judiciaires, politiques, fact-checks, votes) en Python, R ou curl. Exports CSV, pagination, dictionnaire des données et identifiants stables poligraphId.",
 };
+
+export const revalidate = 3600; // 1 hour — doc content is static, refresh hourly
 
 export default function ApiDocsPage() {
   return (
     <div className="min-h-screen bg-background">
-      <div className="container mx-auto py-8">
-        <div className="mb-6">
-          <h1 className="text-3xl font-display font-extrabold tracking-tight">Documentation API</h1>
-          <p className="text-muted-foreground mt-2">
-            Explorez et testez les endpoints de l&apos;API Poligraph
+      <div className="container mx-auto max-w-5xl px-4 py-10">
+        {/* Hero */}
+        <header className="mb-12">
+          <p className="text-sm font-mono text-muted-foreground uppercase tracking-wider mb-2">
+            Documentation API
           </p>
-        </div>
-        <SwaggerUIWrapper />
+          <h1 className="text-4xl font-display font-extrabold tracking-tight mb-4">
+            Données ouvertes Poligraph
+          </h1>
+          <p className="text-lg text-muted-foreground max-w-3xl">
+            Affaires judiciaires, politiques, fact-checks, votes parlementaires et élections. Tout
+            ce que le site affiche est accessible en JSON et en CSV, sans clé API, pour vos
+            recherches, cours et analyses.
+          </p>
+          <nav aria-label="Sommaire" className="mt-6 flex flex-wrap gap-2 text-sm">
+            <a
+              href="#quickstart"
+              className="inline-flex items-center rounded-full border bg-card px-3 py-1 hover:bg-muted transition-colors"
+            >
+              Quickstart
+            </a>
+            <a
+              href="#exports"
+              className="inline-flex items-center rounded-full border bg-card px-3 py-1 hover:bg-muted transition-colors"
+            >
+              Exports CSV
+            </a>
+            <a
+              href="#pagination"
+              className="inline-flex items-center rounded-full border bg-card px-3 py-1 hover:bg-muted transition-colors"
+            >
+              Pagination
+            </a>
+            <a
+              href="#poligraphid"
+              className="inline-flex items-center rounded-full border bg-card px-3 py-1 hover:bg-muted transition-colors"
+            >
+              poligraphId
+            </a>
+            <a
+              href="#dictionary"
+              className="inline-flex items-center rounded-full border bg-card px-3 py-1 hover:bg-muted transition-colors"
+            >
+              Dictionnaire
+            </a>
+            <a
+              href="#editorial"
+              className="inline-flex items-center rounded-full border bg-card px-3 py-1 hover:bg-muted transition-colors"
+            >
+              Règles éditoriales
+            </a>
+            <a
+              href="#licence"
+              className="inline-flex items-center rounded-full border bg-card px-3 py-1 hover:bg-muted transition-colors"
+            >
+              Licence
+            </a>
+            <a
+              href="#swagger"
+              className="inline-flex items-center rounded-full border bg-card px-3 py-1 hover:bg-muted transition-colors"
+            >
+              Explorateur Swagger
+            </a>
+          </nav>
+        </header>
+
+        {/* Quickstart */}
+        <section id="quickstart" className="mb-12 scroll-mt-20">
+          <div className="flex items-center gap-2 mb-3">
+            <BookOpen className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="text-2xl font-display font-bold">Quickstart</h2>
+          </div>
+          <p className="text-muted-foreground mb-4">
+            Les trois exemples ci-dessous récupèrent les 260 affaires judiciaires publiées. Pour un
+            usage pédagogique ou statistique, commencez par les exports CSV : ils contiennent tout
+            en un seul fichier, correctement paginé, avec le poligraphId comme clé de jointure
+            stable.
+          </p>
+          <QuickstartTabs />
+        </section>
+
+        {/* Bulk exports */}
+        <section id="exports" className="mb-12 scroll-mt-20">
+          <div className="flex items-center gap-2 mb-3">
+            <FileDown className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="text-2xl font-display font-bold">Exports CSV</h2>
+          </div>
+          <p className="text-muted-foreground mb-4">
+            Fichiers UTF-8 avec BOM (compatibles Excel et pandas), toutes les colonnes
+            dénormalisées, jusqu{"'"}à 50 000 lignes par requête. Les descriptions sont nettoyées du
+            markdown. Chaque ligne contient un poligraphId stable (voir ci-dessous) pour joindre
+            plusieurs tables sans ambiguïté.
+          </p>
+          <div className="grid gap-4 md:grid-cols-3">
+            <ExportCard
+              title="Affaires judiciaires"
+              href="/api/export/affaires?limit=10000"
+              description="40 colonnes : parti au moment des faits, gravité Sapin II, peine détaillée (amende, prison, inéligibilité), ECLI, description complète."
+            />
+            <ExportCard
+              title="Politiques"
+              href="/api/export/politiques"
+              description="Identité, genre, parti + position politique, mandat en cours, département, prominence, Q-ID Wikidata pour croisement inter-jeux."
+            />
+            <ExportCard
+              title="Fact-checks"
+              href="/api/export/factchecks?limit=10000"
+              description="Dénormalisé par politique mentionné (une ligne par paire). Filtres : verdict, source, politicianSlug."
+            />
+          </div>
+          <div className="mt-4 text-sm text-muted-foreground">
+            Paramètres communs : <code className="font-mono">limit</code> (max 50 000), filtres
+            spécifiques documentés dans chaque endpoint Swagger ci-dessous.
+          </div>
+        </section>
+
+        {/* Pagination */}
+        <section id="pagination" className="mb-12 scroll-mt-20">
+          <div className="flex items-center gap-2 mb-3">
+            <Database className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="text-2xl font-display font-bold">Pagination JSON</h2>
+          </div>
+          <p className="text-muted-foreground mb-4">
+            Toutes les routes JSON paginent à <strong>20 résultats par défaut</strong>, avec un
+            maximum de <strong>100 par page</strong>. La réponse contient toujours un objet{" "}
+            <code className="font-mono">pagination</code> pour savoir quand arrêter la boucle :
+          </p>
+          <CodeBlock
+            language="json"
+            code={`{
+  "data": [ /* ... */ ],
+  "pagination": {
+    "page": 1,
+    "limit": 100,
+    "total": 260,
+    "totalPages": 3
+  }
+}`}
+          />
+          <p className="text-sm text-muted-foreground mt-4">
+            Pour les volumes importants (plus de quelques centaines de lignes), préférez les exports
+            CSV ci-dessus : une seule requête au lieu de N, et Cache-Control optimisé côté serveur.
+          </p>
+        </section>
+
+        {/* poligraphId */}
+        <section id="poligraphid" className="mb-12 scroll-mt-20">
+          <div className="flex items-center gap-2 mb-3">
+            <Link2 className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="text-2xl font-display font-bold">
+              poligraphId — identifiants stables pour citation
+            </h2>
+          </div>
+          <p className="text-muted-foreground mb-4">
+            Chaque entité citable reçoit un identifiant opaque, court et immuable que vous pouvez
+            utiliser dans un article scientifique, un notebook, un export CSV ou un lien entrant.
+            Contrairement aux slugs (qui peuvent changer si un titre est corrigé ou un nom mis à
+            jour), le poligraphId est garanti stable dans le temps.
+          </p>
+          <div className="rounded-lg border bg-card p-4 mb-4">
+            <p className="text-sm font-semibold mb-2">Préfixes</p>
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-2 text-sm">
+              <IdPrefix prefix="PG" label="Politicien" />
+              <IdPrefix prefix="AF" label="Affaire" />
+              <IdPrefix prefix="FC" label="Fact-check" />
+              <IdPrefix prefix="SC" label="Scrutin" />
+              <IdPrefix prefix="PT" label="Parti" />
+              <IdPrefix prefix="EL" label="Élection" />
+              <IdPrefix prefix="MA" label="Mandat" />
+              <IdPrefix prefix="DO" label="Dossier législatif" />
+              <IdPrefix prefix="GP" label="Groupe parlementaire" />
+              <IdPrefix prefix="LM" label="Liste municipale" />
+            </div>
+          </div>
+          <p className="text-muted-foreground mb-4">
+            Format : <code className="font-mono">XX-000542</code> (deux lettres, tiret, entier sur 6
+            chiffres minimum). Tout poligraphId est résoluble via un redirect 308 permanent qui suit
+            les fusions d{"'"}affaires, pour que vos citations externes ne cassent jamais :
+          </p>
+          <CodeBlock
+            language="bash"
+            code={`# URL canonique citable dans un article
+https://poligraph.fr/id/AF-000042
+
+# Exemple d'une jointure côté pandas
+affaires = pd.read_csv("https://poligraph.fr/api/export/affaires?limit=10000")
+politiques = pd.read_csv("https://poligraph.fr/api/export/politiques")
+join = affaires.merge(
+    politiques,
+    left_on="politicianPoligraphId",
+    right_on="poligraphId",
+    suffixes=("_affaire", "_pol"),
+)`}
+          />
+        </section>
+
+        {/* Data dictionary */}
+        <section id="dictionary" className="mb-12 scroll-mt-20">
+          <h2 className="text-2xl font-display font-bold mb-3">Dictionnaire des données</h2>
+          <p className="text-muted-foreground mb-6">
+            Les colonnes <code className="font-mono">XxxCode</code> des exports CSV contiennent les
+            valeurs brutes des énumérations ci-dessous (stables et filtrables), tandis que les
+            colonnes sans suffixe contiennent la traduction française lisible.
+          </p>
+          <DataDictionary />
+        </section>
+
+        {/* Editorial principles */}
+        <section id="editorial" className="mb-12 scroll-mt-20">
+          <div className="flex items-center gap-2 mb-3">
+            <ShieldCheck className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="text-2xl font-display font-bold">
+              Règles éditoriales à connaître avant d{"'"}analyser
+            </h2>
+          </div>
+          <ul className="space-y-3 text-muted-foreground">
+            <li>
+              <strong className="text-foreground">Présomption d{"'"}innocence.</strong> Les affaires
+              en cours sont signalées avec un niveau d{"'"}implication conservateur par défaut.
+              Filtrez par <code className="font-mono">statusCode=CONDAMNATION_DEFINITIVE</code> si
+              vous voulez isoler les condamnations définitives.
+            </li>
+            <li>
+              <strong className="text-foreground">Gravité Sapin II.</strong> La colonne{" "}
+              <code className="font-mono">severity</code> classe les infractions selon la
+              spécificité au mandat (probité {">"} infractions graves {">"} autres), pas selon un
+              jugement moral.
+            </li>
+            <li>
+              <strong className="text-foreground">Implication par défaut.</strong> Les routes JSON
+              filtrent par défaut sur <code className="font-mono">involvement=DIRECT</code>. Passez{" "}
+              <code className="font-mono">involvement=DIRECT,MENTIONED_ONLY,SUSPECTED</code> pour
+              élargir.
+            </li>
+            <li>
+              <strong className="text-foreground">Sources vérifiées.</strong> Chaque affaire publiée
+              a au moins une source journalistique vérifiable. La colonne{" "}
+              <code className="font-mono">sourceCount</code> donne le nombre total,{" "}
+              <code className="font-mono">sourceUrl</code> la première.
+            </li>
+          </ul>
+          <p className="mt-4 text-sm">
+            Méthodologie complète :{" "}
+            <Link href="/sources" className="text-primary hover:underline">
+              /sources
+            </Link>
+          </p>
+        </section>
+
+        {/* Licence */}
+        <section id="licence" className="mb-12 scroll-mt-20">
+          <h2 className="text-2xl font-display font-bold mb-3">Licence et citation</h2>
+          <p className="text-muted-foreground mb-3">
+            Les données publiées sont réutilisables pour des usages pédagogiques, journalistiques et
+            de recherche avec citation de la source. Format recommandé pour un article ou un rapport
+            :
+          </p>
+          <blockquote className="border-l-4 border-primary bg-muted/50 p-4 rounded-r-lg">
+            <p className="italic">
+              Poligraph, observatoire civique des politiques français, poligraph.fr, consulté le{" "}
+              {new Date().toLocaleDateString("fr-FR")}.
+            </p>
+          </blockquote>
+          <p className="text-sm text-muted-foreground mt-4">
+            Pour signaler une erreur ou demander l{"'"}exercice d{"'"}un droit (correction,
+            opposition) :{" "}
+            <Link href="/contact" className="text-primary hover:underline">
+              nous contacter
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* Swagger */}
+        <section id="swagger" className="mb-12 scroll-mt-20">
+          <h2 className="text-2xl font-display font-bold mb-3">Explorateur Swagger complet</h2>
+          <p className="text-muted-foreground mb-4">
+            Spécification OpenAPI interactive : testez chaque route directement depuis le
+            navigateur, voyez les paramètres et les schémas de réponse.
+          </p>
+          <details className="rounded-lg border bg-card">
+            <summary className="cursor-pointer px-4 py-3 font-semibold hover:bg-muted/50 transition-colors rounded-lg">
+              Afficher l{"'"}explorateur interactif
+            </summary>
+            <div className="border-t">
+              <SwaggerUIWrapper />
+            </div>
+          </details>
+        </section>
       </div>
+    </div>
+  );
+}
+
+function ExportCard({
+  title,
+  href,
+  description,
+}: {
+  title: string;
+  href: string;
+  description: string;
+}) {
+  return (
+    <a
+      href={href}
+      className="block rounded-lg border bg-card p-4 hover:border-primary hover:shadow-sm transition-all"
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <h3 className="font-semibold">{title}</h3>
+        <FileDown className="h-4 w-4 text-muted-foreground flex-shrink-0 mt-1" aria-hidden="true" />
+      </div>
+      <p className="text-sm text-muted-foreground">{description}</p>
+      <code className="text-xs font-mono text-primary mt-3 block truncate">{href}</code>
+    </a>
+  );
+}
+
+function IdPrefix({ prefix, label }: { prefix: string; label: string }) {
+  return (
+    <div className="flex items-baseline gap-2 text-sm">
+      <code className="font-mono font-semibold text-primary">{prefix}</code>
+      <span className="text-muted-foreground">{label}</span>
     </div>
   );
 }

--- a/src/app/id/[publicId]/page.tsx
+++ b/src/app/id/[publicId]/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import { notFound, permanentRedirect } from "next/navigation";
+import { resolvePublicId } from "@/lib/public-ids";
+
+/**
+ * Stable poligraphId resolver.
+ *
+ * Accepts any valid poligraphId (PG-000542, AF-004217, FC-002891, etc.) and
+ * 308-redirects to the canonical application URL. Research papers, Wikipedia,
+ * and Wikidata can cite the identifier URL and it will keep resolving even if
+ * the target slug is corrected, the entity is merged, or the taxonomy is
+ * reorganised — because the poligraphId itself is immutable once assigned.
+ *
+ * SEO: this route is `noindex, follow`. A permanent redirect already tells
+ * search engines to index only the canonical slug, but the explicit robots
+ * directive is belt-and-braces against any crawler that mishandles 308s.
+ */
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: true,
+    googleBot: {
+      index: false,
+      follow: true,
+    },
+  },
+};
+
+export const dynamic = "force-dynamic"; // Lookup must run on every request
+
+interface PageProps {
+  params: Promise<{ publicId: string }>;
+}
+
+export default async function PublicIdResolverPage({ params }: PageProps) {
+  const { publicId } = await params;
+  const normalised = decodeURIComponent(publicId).trim().toUpperCase();
+
+  const resolved = await resolvePublicId(normalised);
+
+  if (!resolved) {
+    notFound();
+  }
+
+  // 308 Permanent Redirect. Google follows the redirect and indexes only the
+  // destination; link equity from external citations flows through to the
+  // canonical page. This is how DOI, ORCID, and Wikidata resolvers behave.
+  permanentRedirect(resolved.canonicalPath);
+}

--- a/src/components/politicians/PoliticianCard.test.tsx
+++ b/src/components/politicians/PoliticianCard.test.tsx
@@ -36,6 +36,7 @@ const mockPolitician = {
   currentParty: {
     id: "party-1",
     slug: "lr",
+    publicId: null,
     name: "Les Républicains",
     shortName: "LR",
     description: null,

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -147,6 +147,13 @@ export const INVOLVEMENT_LABELS: Record<Involvement, string> = {
   PLAINTIFF: "Plaignant",
 };
 
+// Affair severity (Sapin II inspired gravity scale)
+export const AFFAIR_SEVERITY_LABELS: Record<AffairSeverity, string> = {
+  CRITIQUE: "Critique",
+  GRAVE: "Grave",
+  SIGNIFICATIF: "Significatif",
+};
+
 export const INVOLVEMENT_COLORS: Record<Involvement, string> = {
   DIRECT:
     "bg-red-100 text-red-800 border-red-300 dark:bg-red-900/40 dark:text-red-300 dark:border-red-700",

--- a/src/lib/__tests__/csv.test.ts
+++ b/src/lib/__tests__/csv.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { stripMarkdownForCSV } from "../csv";
+
+describe("stripMarkdownForCSV", () => {
+  it("returns empty string for empty or nullish input", () => {
+    expect(stripMarkdownForCSV("")).toBe("");
+    expect(stripMarkdownForCSV(null)).toBe("");
+    expect(stripMarkdownForCSV(undefined)).toBe("");
+  });
+
+  it("strips inline links but keeps the anchor text", () => {
+    const input = "[Éric Zemmour](/politiques/eric-zemmour) porte plainte";
+    expect(stripMarkdownForCSV(input)).toBe("Éric Zemmour porte plainte");
+  });
+
+  it("strips multiple links in the same paragraph", () => {
+    const input =
+      "[Éric Zemmour](/politiques/eric-zemmour), dirigeant de [Reconquête](/partis/reconquete), est renvoyé.";
+    expect(stripMarkdownForCSV(input)).toBe("Éric Zemmour, dirigeant de Reconquête, est renvoyé.");
+  });
+
+  it("strips bold and italic emphasis", () => {
+    expect(stripMarkdownForCSV("**Les faits** sont clairs")).toBe("Les faits sont clairs");
+    expect(stripMarkdownForCSV("*en cours*")).toBe("en cours");
+    expect(stripMarkdownForCSV("_important_")).toBe("important");
+    expect(stripMarkdownForCSV("__très__ important")).toBe("très important");
+  });
+
+  it("collapses multiple whitespace runs into single spaces", () => {
+    expect(stripMarkdownForCSV("a  b   c")).toBe("a b c");
+    expect(stripMarkdownForCSV("ligne1\n\nligne2")).toBe("ligne1 ligne2");
+    expect(stripMarkdownForCSV("ligne1\r\n\r\nligne2")).toBe("ligne1 ligne2");
+  });
+
+  it("does not truncate long descriptions", () => {
+    // The bug in the old export was substring(0, 500) mid-sentence.
+    // The new helper must preserve full length.
+    const longText = "a".repeat(2000);
+    expect(stripMarkdownForCSV(longText).length).toBe(2000);
+  });
+
+  it("handles the real Zemmour affair description without corruption", () => {
+    const input = `[Éric Zemmour](/politiques/eric-zemmour), dirigeant de [Reconquête](/partis/reconquete), est renvoyé en mai 2024 devant la XVIIe chambre correctionnelle du tribunal judiciaire de Paris pour des propos tenus entre 2021 et mars 2022 sur le plateau de CNews.
+
+**Les faits**
+
+Les déclarations incriminées portent sur les trafiquants de crack et établissent un lien direct avec une origine géographique. En 2021, [Zemmour](/politiques/eric-zemmour) aurait affirmé que « tous les trafiquants de cracks sont sénégalais ».`;
+
+    const output = stripMarkdownForCSV(input);
+
+    // No markdown link syntax survives
+    expect(output).not.toContain("](");
+    expect(output).not.toContain("[");
+
+    // No bold/italic markers survive
+    expect(output).not.toContain("**");
+
+    // Content is intact
+    expect(output).toContain("Éric Zemmour");
+    expect(output).toContain("Reconquête");
+    expect(output).toContain("Les faits");
+    expect(output).toContain("tous les trafiquants de cracks sont sénégalais");
+
+    // French accents preserved
+    expect(output).toContain("é");
+    expect(output).toContain("ê"); // from "Reconquête"
+
+    // No paragraph breaks remain (collapsed to single spaces)
+    expect(output).not.toContain("\n\n");
+
+    // No mid-sentence truncation like "dépassent pas les li"
+    expect(output.trim().endsWith("sénégalais ».")).toBe(true);
+  });
+
+  it("escapes or preserves commas and quotes so CSV wrapper can handle them", () => {
+    // The CSV wrapper (escapeCSV) handles commas and quotes — this helper
+    // should NOT alter them, just strip markdown.
+    const input = "Il a dit : \"c'est **faux**\", comme d'habitude.";
+    const output = stripMarkdownForCSV(input);
+    expect(output).toContain('"c\'est faux"');
+    expect(output).not.toContain("**");
+  });
+
+  it("leaves plain text with no markdown unchanged", () => {
+    const input = "Affaire classée sans suite le 15 mars 2024.";
+    expect(stripMarkdownForCSV(input)).toBe(input);
+  });
+});

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -63,6 +63,68 @@ export function formatDateTimeForCSV(date: Date | string | null | undefined): st
 }
 
 /**
+ * Strip Markdown syntax from a description so it can be exported as plain
+ * text in a CSV cell. Preserves the human-readable content, drops every
+ * syntactic marker, collapses runs of whitespace, and never truncates.
+ *
+ * Accepts null/undefined for convenience at call sites that read nullable
+ * columns directly from Prisma.
+ *
+ * Handled syntax:
+ *   - inline links:      [text](url)          -> text
+ *   - bold:              **text** / __text__  -> text
+ *   - italic:            *text* / _text_      -> text
+ *   - inline code:       `text`               -> text
+ *   - fenced code:       ```text```           -> text
+ *   - ATX headers:       # Heading            -> Heading
+ *   - blockquote prefix: > quote              -> quote
+ *   - horizontal rule:   --- or ***           -> (removed)
+ *
+ * Runs of whitespace (including newlines and CRLF) collapse to single spaces.
+ */
+export function stripMarkdownForCSV(input: string | null | undefined): string {
+  if (!input) return "";
+
+  let text = input;
+
+  // Fenced code blocks: ```lang\ncode``` -> code
+  text = text.replace(/```[^\n]*\n?([\s\S]*?)```/g, "$1");
+
+  // Inline code: `code` -> code
+  text = text.replace(/`([^`]+)`/g, "$1");
+
+  // Links: [text](url) -> text
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+
+  // Images: ![alt](url) -> alt (already handled above since [alt](url) matches)
+  // Bare reference-style link definitions: [id]: url "title"
+  text = text.replace(/^\s*\[[^\]]+\]:\s*\S+(?:\s+"[^"]*")?\s*$/gm, "");
+
+  // Bold markers: **text** or __text__ -> text (do before italic to avoid
+  // the italic regex chewing one asterisk and leaving the other behind)
+  text = text.replace(/\*\*([^*]+)\*\*/g, "$1");
+  text = text.replace(/__([^_]+)__/g, "$1");
+
+  // Italic markers: *text* or _text_ -> text
+  text = text.replace(/(?<!\*)\*(?!\*)([^*\n]+?)(?<!\*)\*(?!\*)/g, "$1");
+  text = text.replace(/(?<!_)_(?!_)([^_\n]+?)(?<!_)_(?!_)/g, "$1");
+
+  // ATX headers: # Heading, ## Heading, etc.
+  text = text.replace(/^\s{0,3}#{1,6}\s+/gm, "");
+
+  // Blockquote markers at the start of a line
+  text = text.replace(/^\s{0,3}>\s?/gm, "");
+
+  // Horizontal rules
+  text = text.replace(/^\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/gm, "");
+
+  // Collapse every run of whitespace (including \n, \r, \t) into a single space
+  text = text.replace(/\s+/g, " ").trim();
+
+  return text;
+}
+
+/**
  * Create a CSV response with proper headers
  */
 export function createCSVResponse(csv: string, filename: string): Response {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,14 +1,17 @@
 import { PrismaClient } from "@/generated/prisma";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
+import { createPoligraphIdExtension } from "@/lib/public-ids/prisma-extension";
+
+type ExtendedPrismaClient = ReturnType<typeof buildExtendedClient>;
 
 const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
+  prisma: ExtendedPrismaClient | undefined;
   pool: Pool | undefined;
   shutdownRegistered: boolean | undefined;
 };
 
-function createPrismaClient(): PrismaClient {
+function buildExtendedClient() {
   const connectionString = process.env.DATABASE_URL;
 
   if (!connectionString) {
@@ -31,14 +34,18 @@ function createPrismaClient(): PrismaClient {
   // Create the Prisma adapter
   const adapter = new PrismaPg(pool);
 
-  // Create Prisma client with adapter
-  return new PrismaClient({
+  // Create the raw Prisma client (used both directly and as the base for
+  // the publicId extension, which needs a non-extended client to avoid
+  // recursive query hooks when allocating sequence values).
+  const rawClient = new PrismaClient({
     adapter,
     log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
   });
+
+  return rawClient.$extends(createPoligraphIdExtension(rawClient));
 }
 
-export const db = globalForPrisma.prisma ?? createPrismaClient();
+export const db = globalForPrisma.prisma ?? buildExtendedClient();
 
 // Cache in all environments — prevents duplicate pools in serverless (Vercel)
 // and avoids hot-reload duplication in dev

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -63,8 +63,16 @@ Merci de faire un usage raisonnable de l'API.
         description: "Élections et candidatures",
       },
       {
+        name: "Élus locaux",
+        description: "Élus locaux (maires, conseillers municipaux, etc.)",
+      },
+      {
         name: "Affaires",
         description: "Affaires judiciaires documentées avec sources",
+      },
+      {
+        name: "Fact-checks",
+        description: "Fact-checks des déclarations publiques",
       },
       {
         name: "Votes",
@@ -73,6 +81,10 @@ Merci de faire un usage raisonnable de l'API.
       {
         name: "Relations",
         description: "Relations entre représentants politiques",
+      },
+      {
+        name: "Exports",
+        description: "Exports CSV en masse pour l'analyse statistique",
       },
     ],
   },
@@ -83,13 +95,23 @@ Merci de faire un usage raisonnable de l'API.
     "./src/app/api/politiques/[slug]/affaires/route.ts",
     "./src/app/api/politiques/[slug]/votes/route.ts",
     "./src/app/api/politiques/[slug]/relations/route.ts",
+    "./src/app/api/politiques/[slug]/factchecks/route.ts",
     "./src/app/api/affaires/route.ts",
+    "./src/app/api/factchecks/route.ts",
     "./src/app/api/votes/route.ts",
     "./src/app/api/partis/route.ts",
     "./src/app/api/partis/[slug]/route.ts",
     "./src/app/api/mandats/route.ts",
     "./src/app/api/elections/route.ts",
     "./src/app/api/elections/[slug]/route.ts",
+    "./src/app/api/export/affaires/route.ts",
+    "./src/app/api/export/politiques/route.ts",
+    "./src/app/api/export/factchecks/route.ts",
+    "./src/app/api/export/votes/route.ts",
+    "./src/app/api/v1/elus/route.ts",
+    "./src/app/api/v1/elus/[id]/route.ts",
+    "./src/app/api/v1/elus/search/route.ts",
+    "./src/app/api/v1/communes/[codeInsee]/route.ts",
   ],
 };
 

--- a/src/lib/public-ids/__tests__/format.test.ts
+++ b/src/lib/public-ids/__tests__/format.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { formatPublicId, formatPublicIdForEntity, isValidPublicId, parsePublicId } from "../format";
+
+describe("parsePublicId", () => {
+  it("parses a valid politician id", () => {
+    expect(parsePublicId("PG-000542")).toEqual({
+      publicId: "PG-000542",
+      prefix: "PG",
+      entityType: "politician",
+      sequence: 542,
+    });
+  });
+
+  it("parses each supported prefix to the correct entity type", () => {
+    const cases: Array<[string, string]> = [
+      ["PG-000001", "politician"],
+      ["AF-000001", "affair"],
+      ["FC-000001", "factcheck"],
+      ["SC-000001", "scrutin"],
+      ["PT-000001", "party"],
+      ["EL-000001", "election"],
+      ["MA-000001", "mandate"],
+      ["DO-000001", "dossier"],
+      ["GP-000001", "group"],
+      ["LM-000001", "electoralList"],
+    ];
+
+    for (const [id, entityType] of cases) {
+      expect(parsePublicId(id)?.entityType).toBe(entityType);
+    }
+  });
+
+  it("accepts sequences longer than 6 digits (overflow future-proofing)", () => {
+    const parsed = parsePublicId("PG-1234567");
+    expect(parsed?.sequence).toBe(1234567);
+  });
+
+  it("returns null for unknown prefixes", () => {
+    expect(parsePublicId("XX-000001")).toBeNull();
+    expect(parsePublicId("ZZ-999999")).toBeNull();
+  });
+
+  it("returns null for malformed strings", () => {
+    expect(parsePublicId("")).toBeNull();
+    expect(parsePublicId("PG")).toBeNull();
+    expect(parsePublicId("PG-")).toBeNull();
+    expect(parsePublicId("PG-12345")).toBeNull(); // too short
+    expect(parsePublicId("pg-000001")).toBeNull(); // lowercase
+    expect(parsePublicId("PG_000001")).toBeNull(); // wrong separator
+    expect(parsePublicId("PG-00000A")).toBeNull(); // non-digit
+    expect(parsePublicId("eric-zemmour")).toBeNull(); // slug
+    expect(parsePublicId("cmlv85kh0017hemv5muq2gtad")).toBeNull(); // cuid
+  });
+});
+
+describe("formatPublicId", () => {
+  it("zero-pads to 6 digits by default", () => {
+    expect(formatPublicId("AF", 1)).toBe("AF-000001");
+    expect(formatPublicId("AF", 42)).toBe("AF-000042");
+    expect(formatPublicId("AF", 999999)).toBe("AF-999999");
+  });
+
+  it("does not truncate sequences above 999999", () => {
+    expect(formatPublicId("PG", 1000000)).toBe("PG-1000000");
+    expect(formatPublicId("PG", 36419)).toBe("PG-036419");
+  });
+
+  it("rejects non-positive or non-integer sequences", () => {
+    expect(() => formatPublicId("AF", 0)).toThrow();
+    expect(() => formatPublicId("AF", -1)).toThrow();
+    expect(() => formatPublicId("AF", 1.5)).toThrow();
+    expect(() => formatPublicId("AF", Number.NaN)).toThrow();
+  });
+
+  it("round-trips through parsePublicId", () => {
+    const id = formatPublicId("FC", 2891);
+    const parsed = parsePublicId(id);
+    expect(parsed?.sequence).toBe(2891);
+    expect(parsed?.prefix).toBe("FC");
+    expect(parsed?.entityType).toBe("factcheck");
+  });
+});
+
+describe("formatPublicIdForEntity", () => {
+  it("maps entity types to the correct prefix", () => {
+    expect(formatPublicIdForEntity("affair", 1)).toBe("AF-000001");
+    expect(formatPublicIdForEntity("factcheck", 1)).toBe("FC-000001");
+    expect(formatPublicIdForEntity("electoralList", 1)).toBe("LM-000001");
+  });
+});
+
+describe("isValidPublicId", () => {
+  it("returns true for valid identifiers", () => {
+    expect(isValidPublicId("AF-000542")).toBe(true);
+    expect(isValidPublicId("PG-036419")).toBe(true);
+  });
+
+  it("returns false for invalid or unknown identifiers", () => {
+    expect(isValidPublicId("AF-1")).toBe(false);
+    expect(isValidPublicId("xx-000001")).toBe(false);
+    expect(isValidPublicId("ZZ-000001")).toBe(false);
+  });
+});

--- a/src/lib/public-ids/format.ts
+++ b/src/lib/public-ids/format.ts
@@ -1,0 +1,70 @@
+import {
+  PREFIX_TO_ENTITY,
+  PUBLIC_ID_ENTITIES,
+  type PublicIdEntityType,
+  type PublicIdPrefix,
+} from "./types";
+
+const PUBLIC_ID_PATTERN = /^([A-Z]{2})-(\d{6,})$/;
+
+export interface ParsedPublicId {
+  publicId: string;
+  prefix: PublicIdPrefix;
+  entityType: PublicIdEntityType;
+  sequence: number;
+}
+
+/**
+ * Parse a poligraphId into its components. Returns null for invalid format or
+ * unknown prefix. Accepts any sequence length of 6 or more digits.
+ *
+ * @example
+ * parsePublicId("AF-000542") // { prefix: "AF", entityType: "affair", sequence: 542 }
+ * parsePublicId("unknown")    // null
+ * parsePublicId("XX-000001")  // null (unknown prefix)
+ */
+export function parsePublicId(value: string): ParsedPublicId | null {
+  const match = value.match(PUBLIC_ID_PATTERN);
+  if (!match) return null;
+
+  const prefix = match[1] as PublicIdPrefix;
+  const entityType = PREFIX_TO_ENTITY[prefix];
+  if (!entityType) return null;
+
+  return {
+    publicId: value,
+    prefix,
+    entityType,
+    sequence: parseInt(match[2]!, 10),
+  };
+}
+
+/**
+ * Format a sequence integer as a poligraphId with six-digit zero padding.
+ * Sequences above 999999 extend naturally without padding loss.
+ *
+ * @example
+ * formatPublicId("AF", 542)    // "AF-000542"
+ * formatPublicId("PG", 1000000) // "PG-1000000"
+ */
+export function formatPublicId(prefix: PublicIdPrefix, sequence: number): string {
+  if (!Number.isInteger(sequence) || sequence < 1) {
+    throw new Error(`Sequence must be a positive integer, got ${sequence}`);
+  }
+  return `${prefix}-${String(sequence).padStart(6, "0")}`;
+}
+
+/**
+ * Format a sequence integer as a poligraphId for a given entity type.
+ */
+export function formatPublicIdForEntity(entityType: PublicIdEntityType, sequence: number): string {
+  return formatPublicId(PUBLIC_ID_ENTITIES[entityType].prefix, sequence);
+}
+
+/**
+ * Return true if the string is a syntactically valid poligraphId with a
+ * recognised prefix. Does not hit the database.
+ */
+export function isValidPublicId(value: string): boolean {
+  return parsePublicId(value) !== null;
+}

--- a/src/lib/public-ids/generator.ts
+++ b/src/lib/public-ids/generator.ts
@@ -1,0 +1,87 @@
+import { db } from "@/lib/db";
+import { formatPublicIdForEntity } from "./format";
+import { type PublicIdEntityType } from "./types";
+
+/**
+ * Allocate the next poligraphId for an entity type by atomically incrementing
+ * the PostgreSQL sequence that backs it. Safe under concurrent writes: each
+ * call to nextval() is guaranteed to return a unique, monotonically increasing
+ * integer. Gaps from rollbacks are expected and harmless.
+ *
+ * Each branch uses a static query against a literal sequence name so this
+ * function is resistant to accidental SQL injection even though sequence
+ * names are not user-controlled.
+ *
+ * @example
+ * const publicId = await nextPublicId("affair"); // "AF-000543"
+ */
+export async function nextPublicId(entityType: PublicIdEntityType): Promise<string> {
+  const sequence = await fetchNextSequenceValue(entityType);
+  return formatPublicIdForEntity(entityType, sequence);
+}
+
+async function fetchNextSequenceValue(entityType: PublicIdEntityType): Promise<number> {
+  let rows: { nextval: bigint }[];
+  switch (entityType) {
+    case "politician":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_politician_seq') AS nextval
+      `;
+      break;
+    case "affair":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_affair_seq') AS nextval
+      `;
+      break;
+    case "factcheck":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_factcheck_seq') AS nextval
+      `;
+      break;
+    case "scrutin":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_scrutin_seq') AS nextval
+      `;
+      break;
+    case "party":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_party_seq') AS nextval
+      `;
+      break;
+    case "election":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_election_seq') AS nextval
+      `;
+      break;
+    case "mandate":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_mandate_seq') AS nextval
+      `;
+      break;
+    case "dossier":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_dossier_seq') AS nextval
+      `;
+      break;
+    case "group":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_group_seq') AS nextval
+      `;
+      break;
+    case "electoralList":
+      rows = await db.$queryRaw<{ nextval: bigint }[]>`
+        SELECT nextval('poligraph_electoral_list_seq') AS nextval
+      `;
+      break;
+    default: {
+      const exhaustive: never = entityType;
+      throw new Error(`Unknown entity type: ${String(exhaustive)}`);
+    }
+  }
+
+  const raw = rows[0]?.nextval;
+  if (raw === undefined) {
+    throw new Error(`Sequence returned no value for ${entityType}`);
+  }
+  return Number(raw);
+}

--- a/src/lib/public-ids/index.ts
+++ b/src/lib/public-ids/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Public identifier (poligraphId) module.
+ *
+ * Exposes helpers for allocating, parsing, formatting, and resolving the
+ * stable public identifiers that Poligraph assigns to every citable entity.
+ *
+ * See /docs/api (section "poligraphId") for the user-facing specification.
+ */
+
+export {
+  PUBLIC_ID_ENTITIES,
+  PREFIX_TO_ENTITY,
+  type PublicIdEntityType,
+  type PublicIdPrefix,
+  type PublicIdMapping,
+} from "./types";
+
+export {
+  parsePublicId,
+  formatPublicId,
+  formatPublicIdForEntity,
+  isValidPublicId,
+  type ParsedPublicId,
+} from "./format";
+
+export { nextPublicId } from "./generator";
+
+export { resolvePublicId, type ResolvedPublicId } from "./resolver";

--- a/src/lib/public-ids/prisma-extension.ts
+++ b/src/lib/public-ids/prisma-extension.ts
@@ -1,0 +1,145 @@
+import { Prisma, type PrismaClient } from "@/generated/prisma";
+
+/**
+ * Prisma client extension that auto-generates `publicId` (poligraphId) on
+ * every `create` call across the 10 entity types that have a publicId column.
+ *
+ * Pass-through behaviour:
+ *   - If the caller explicitly provides a publicId, it is preserved verbatim.
+ *   - Otherwise, a fresh value is allocated from the entity's PostgreSQL
+ *     sequence and formatted as `<PREFIX>-<6-digit sequence>`.
+ *
+ * Known limitation: only `create` is hooked, not `createMany`. Rows inserted
+ * via `createMany` will have `publicId = NULL` until the next run of
+ * `scripts/backfill-public-ids.ts`. This keeps the extension simple and lets
+ * bulk sync pipelines remain unchanged during the transition window.
+ *
+ * The factory takes the raw (unextended) client so the hooks can call
+ * `$queryRaw` without recursing back through the extension.
+ */
+export function createPoligraphIdExtension(rawClient: PrismaClient) {
+  async function allocate(sequenceSql: Prisma.Sql, prefix: string): Promise<string> {
+    const rows = await rawClient.$queryRaw<{ nextval: bigint }[]>(sequenceSql);
+    const value = rows[0]?.nextval;
+    if (value === undefined) {
+      throw new Error(`Sequence returned no value for prefix ${prefix}`);
+    }
+    return `${prefix}-${String(Number(value)).padStart(6, "0")}`;
+  }
+
+  return Prisma.defineExtension({
+    name: "poligraphId",
+    query: {
+      politician: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_politician_seq') AS nextval`,
+              "PG"
+            );
+          }
+          return query(args);
+        },
+      },
+      affair: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_affair_seq') AS nextval`,
+              "AF"
+            );
+          }
+          return query(args);
+        },
+      },
+      factCheck: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_factcheck_seq') AS nextval`,
+              "FC"
+            );
+          }
+          return query(args);
+        },
+      },
+      scrutin: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_scrutin_seq') AS nextval`,
+              "SC"
+            );
+          }
+          return query(args);
+        },
+      },
+      party: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_party_seq') AS nextval`,
+              "PT"
+            );
+          }
+          return query(args);
+        },
+      },
+      election: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_election_seq') AS nextval`,
+              "EL"
+            );
+          }
+          return query(args);
+        },
+      },
+      mandate: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_mandate_seq') AS nextval`,
+              "MA"
+            );
+          }
+          return query(args);
+        },
+      },
+      legislativeDossier: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_dossier_seq') AS nextval`,
+              "DO"
+            );
+          }
+          return query(args);
+        },
+      },
+      parliamentaryGroup: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_group_seq') AS nextval`,
+              "GP"
+            );
+          }
+          return query(args);
+        },
+      },
+      electoralList: {
+        async create({ args, query }) {
+          if (!args.data.publicId) {
+            args.data.publicId = await allocate(
+              Prisma.sql`SELECT nextval('poligraph_electoral_list_seq') AS nextval`,
+              "LM"
+            );
+          }
+          return query(args);
+        },
+      },
+    },
+  });
+}

--- a/src/lib/public-ids/resolver.ts
+++ b/src/lib/public-ids/resolver.ts
@@ -1,0 +1,166 @@
+import { db } from "@/lib/db";
+import { parsePublicId } from "./format";
+import { type PublicIdEntityType } from "./types";
+
+const MAX_REDIRECT_HOPS = 5;
+
+export interface ResolvedPublicId {
+  publicId: string;
+  entityType: PublicIdEntityType;
+  canonicalPath: string;
+  isRedirect: boolean;
+  redirectedFrom?: string;
+}
+
+/**
+ * Resolve a poligraphId to its canonical application path.
+ *
+ * Returns null when:
+ * - the format is invalid or the prefix is unknown
+ * - no entity currently owns this identifier and no redirect exists
+ * - a redirect chain exceeds MAX_REDIRECT_HOPS (cycle protection)
+ *
+ * Follows PublicIdRedirect entries when the original ID was retired, so a
+ * merged affair still resolves to its canonical survivor. The chain is
+ * bounded to protect against accidental cycles.
+ */
+export async function resolvePublicId(
+  publicId: string,
+  hopsRemaining: number = MAX_REDIRECT_HOPS
+): Promise<ResolvedPublicId | null> {
+  if (hopsRemaining <= 0) return null;
+
+  const parsed = parsePublicId(publicId);
+  if (!parsed) return null;
+
+  const direct = await lookupByPublicId(parsed.entityType, publicId);
+  if (direct) {
+    return {
+      publicId,
+      entityType: parsed.entityType,
+      canonicalPath: direct.canonicalPath,
+      isRedirect: false,
+    };
+  }
+
+  const redirect = await db.publicIdRedirect.findUnique({
+    where: { fromPublicId: publicId },
+  });
+  if (!redirect) return null;
+
+  const target = await resolvePublicId(redirect.toPublicId, hopsRemaining - 1);
+  if (!target) return null;
+
+  return {
+    ...target,
+    isRedirect: true,
+    redirectedFrom: publicId,
+  };
+}
+
+/**
+ * Per-entity lookup. Each case knows how to compute its canonical path,
+ * including context-dependent ones (mandates live under politician pages,
+ * electoral lists live under commune pages).
+ */
+async function lookupByPublicId(
+  entityType: PublicIdEntityType,
+  publicId: string
+): Promise<{ canonicalPath: string } | null> {
+  switch (entityType) {
+    case "politician": {
+      const row = await db.politician.findUnique({
+        where: { publicId },
+        select: { slug: true },
+      });
+      return row ? { canonicalPath: `/politiques/${row.slug}` } : null;
+    }
+    case "affair": {
+      const row = await db.affair.findUnique({
+        where: { publicId },
+        select: { slug: true },
+      });
+      return row ? { canonicalPath: `/affaires/${row.slug}` } : null;
+    }
+    case "factcheck": {
+      const row = await db.factCheck.findUnique({
+        where: { publicId },
+        select: { slug: true },
+      });
+      if (!row) return null;
+      // Factcheck slug is nullable in the schema; fall back to the listing
+      // page when a specific slug cannot be formed.
+      return { canonicalPath: row.slug ? `/factchecks/${row.slug}` : "/factchecks" };
+    }
+    case "scrutin": {
+      const row = await db.scrutin.findUnique({
+        where: { publicId },
+        select: { slug: true },
+      });
+      if (!row) return null;
+      return {
+        canonicalPath: row.slug ? `/parlement/votes/${row.slug}` : "/parlement/votes",
+      };
+    }
+    case "party": {
+      const row = await db.party.findUnique({
+        where: { publicId },
+        select: { slug: true },
+      });
+      if (!row) return null;
+      return { canonicalPath: row.slug ? `/partis/${row.slug}` : "/partis" };
+    }
+    case "election": {
+      const row = await db.election.findUnique({
+        where: { publicId },
+        select: { slug: true },
+      });
+      return row ? { canonicalPath: `/elections/${row.slug}` } : null;
+    }
+    case "mandate": {
+      const row = await db.mandate.findUnique({
+        where: { publicId },
+        select: { politician: { select: { slug: true } } },
+      });
+      return row ? { canonicalPath: `/politiques/${row.politician.slug}#mandats` } : null;
+    }
+    case "dossier": {
+      const row = await db.legislativeDossier.findUnique({
+        where: { publicId },
+        select: { slug: true },
+      });
+      if (!row) return null;
+      return {
+        canonicalPath: row.slug ? `/parlement/dossiers/${row.slug}` : "/parlement/dossiers",
+      };
+    }
+    case "group": {
+      const row = await db.parliamentaryGroup.findUnique({
+        where: { publicId },
+        select: { slug: true },
+      });
+      if (!row) return null;
+      return {
+        canonicalPath: row.slug ? `/parlement/groupes/${row.slug}` : "/parlement/groupes",
+      };
+    }
+    case "electoralList": {
+      const row = await db.electoralList.findUnique({
+        where: { publicId },
+        select: {
+          commune: { select: { id: true } },
+          election: { select: { slug: true } },
+        },
+      });
+      return row
+        ? {
+            canonicalPath: `/elections/${row.election.slug}/communes/${row.commune.id}`,
+          }
+        : null;
+    }
+    default: {
+      const exhaustive: never = entityType;
+      throw new Error(`Unknown entity type: ${String(exhaustive)}`);
+    }
+  }
+}

--- a/src/lib/public-ids/types.ts
+++ b/src/lib/public-ids/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Public identifier (poligraphId) entity types and their prefix conventions.
+ *
+ * Format grammar: `<PREFIX>-<SEQUENCE>` where PREFIX is two uppercase letters
+ * and SEQUENCE is a zero-padded integer of 6+ digits. Sequences are allocated
+ * per-entity-type via PostgreSQL sequences so concurrent writes never collide.
+ *
+ * Never reuse a retired identifier: when entities merge, write a row to
+ * PublicIdRedirect instead so external citations keep resolving.
+ */
+
+export type PublicIdEntityType =
+  | "politician"
+  | "affair"
+  | "factcheck"
+  | "scrutin"
+  | "party"
+  | "election"
+  | "mandate"
+  | "dossier"
+  | "group"
+  | "electoralList";
+
+export type PublicIdPrefix =
+  | "PG" // Politicien
+  | "AF" // Affaire judiciaire
+  | "FC" // Fact-check
+  | "SC" // Scrutin parlementaire
+  | "PT" // Parti politique
+  | "EL" // Élection
+  | "MA" // Mandat
+  | "DO" // Dossier législatif
+  | "GP" // Groupe parlementaire
+  | "LM"; // Liste municipale
+
+export interface PublicIdMapping {
+  entityType: PublicIdEntityType;
+  prefix: PublicIdPrefix;
+  sequenceName: string;
+  frenchLabel: string;
+}
+
+export const PUBLIC_ID_ENTITIES: Record<PublicIdEntityType, PublicIdMapping> = {
+  politician: {
+    entityType: "politician",
+    prefix: "PG",
+    sequenceName: "poligraph_politician_seq",
+    frenchLabel: "Politicien",
+  },
+  affair: {
+    entityType: "affair",
+    prefix: "AF",
+    sequenceName: "poligraph_affair_seq",
+    frenchLabel: "Affaire judiciaire",
+  },
+  factcheck: {
+    entityType: "factcheck",
+    prefix: "FC",
+    sequenceName: "poligraph_factcheck_seq",
+    frenchLabel: "Fact-check",
+  },
+  scrutin: {
+    entityType: "scrutin",
+    prefix: "SC",
+    sequenceName: "poligraph_scrutin_seq",
+    frenchLabel: "Scrutin parlementaire",
+  },
+  party: {
+    entityType: "party",
+    prefix: "PT",
+    sequenceName: "poligraph_party_seq",
+    frenchLabel: "Parti politique",
+  },
+  election: {
+    entityType: "election",
+    prefix: "EL",
+    sequenceName: "poligraph_election_seq",
+    frenchLabel: "Élection",
+  },
+  mandate: {
+    entityType: "mandate",
+    prefix: "MA",
+    sequenceName: "poligraph_mandate_seq",
+    frenchLabel: "Mandat",
+  },
+  dossier: {
+    entityType: "dossier",
+    prefix: "DO",
+    sequenceName: "poligraph_dossier_seq",
+    frenchLabel: "Dossier législatif",
+  },
+  group: {
+    entityType: "group",
+    prefix: "GP",
+    sequenceName: "poligraph_group_seq",
+    frenchLabel: "Groupe parlementaire",
+  },
+  electoralList: {
+    entityType: "electoralList",
+    prefix: "LM",
+    sequenceName: "poligraph_electoral_list_seq",
+    frenchLabel: "Liste municipale",
+  },
+};
+
+/** Reverse lookup: prefix → entity type. Built once at module load. */
+export const PREFIX_TO_ENTITY: Record<PublicIdPrefix, PublicIdEntityType> = Object.fromEntries(
+  Object.values(PUBLIC_ID_ENTITIES).map((e) => [e.prefix, e.entityType])
+) as Record<PublicIdPrefix, PublicIdEntityType>;

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -6,7 +6,7 @@
  */
 
 import { db } from "@/lib/db";
-import type { SourceType } from "@/generated/prisma";
+import { Prisma, type SourceType } from "@/generated/prisma";
 import { findMatchingAffairs, type MatchConfidence } from "./matching";
 
 // ============================================
@@ -141,10 +141,16 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
  */
 export async function mergeAffairs(keepId: string, removeId: string): Promise<void> {
   await db.$transaction(async (tx) => {
-    // Verify both affairs exist
+    // Verify both affairs exist and capture publicIds for redirect bookkeeping.
     const [keep, remove] = await Promise.all([
-      tx.affair.findUnique({ where: { id: keepId }, select: { id: true } }),
-      tx.affair.findUnique({ where: { id: removeId }, select: { id: true } }),
+      tx.affair.findUnique({
+        where: { id: keepId },
+        select: { id: true, publicId: true },
+      }),
+      tx.affair.findUnique({
+        where: { id: removeId },
+        select: { id: true, publicId: true },
+      }),
     ]);
     if (!keep) throw new Error(`Affair to keep not found: ${keepId}`);
     if (!remove) throw new Error(`Affair to remove not found: ${removeId}`);
@@ -203,7 +209,7 @@ export async function mergeAffairs(keepId: string, removeId: string): Promise<vo
       select: { ecli: true, pourvoiNumber: true, caseNumbers: true },
     });
     if (removeAffair && keepAffair) {
-      const updates: Record<string, unknown> = {};
+      const updates: Prisma.AffairUpdateInput = {};
       if (!keepAffair.ecli && removeAffair.ecli) {
         updates.ecli = removeAffair.ecli;
       }
@@ -221,6 +227,25 @@ export async function mergeAffairs(keepId: string, removeId: string): Promise<vo
 
     // Delete the merged affair (cascades sources, events, press links that weren't transferred)
     await tx.affair.delete({ where: { id: removeId } });
+
+    // Preserve the retired poligraphId as a redirect so external citations
+    // keep resolving to the survivor. Written inside the transaction so the
+    // redirect and deletion commit or roll back together.
+    if (remove.publicId && keep.publicId && remove.publicId !== keep.publicId) {
+      await tx.publicIdRedirect.upsert({
+        where: { fromPublicId: remove.publicId },
+        create: {
+          fromPublicId: remove.publicId,
+          toPublicId: keep.publicId,
+          entityType: "affair",
+          reason: "merged",
+        },
+        update: {
+          toPublicId: keep.publicId,
+          reason: "merged",
+        },
+      });
+    }
 
     // Clean up any dismissed duplicates referencing the removed affair
     await tx.dismissedDuplicate.deleteMany({


### PR DESCRIPTION
## Summary

Phase 1 of the public-data improvements triggered by a stats researcher's email. Three logical commits:

1. **`feat(db): poligraphId infrastructure`** — stable public identifier on 9 entity types (PG/AF/FC/SC/PT/EL/MA/DO/GP/LM), PostgreSQL sequences, Prisma client extension auto-generating on `create`, federated resolver with redirect-chain support, `/id/[publicId]` route with 308 + noindex.
2. **`feat(api): richer CSV exports`** — /api/export/affaires rewritten 17→40 columns (severity, involvement, full sentence breakdown, court, ECLI), /api/export/politiques rewritten (gender, Wikidata Q-ID, mandate dates), new /api/export/factchecks endpoint denormalised by mentioned politician. `stripMarkdownForCSV` helper fixes the 500-char mid-sentence truncation and markdown leakage.
3. **`feat(docs): narrative /docs/api guide`** — Python/R/curl quickstart tabs, CSV export cards, pagination explainer, poligraphId citation section, auto-generated data dictionary (7 enum tables), editorial principles callout, licence. Swagger kept in a collapsible at the bottom.

## Context

A statistics teacher-researcher emailed to ask for the data, pointed out that \`/api/affaires\` only returned 20 rows, and said she couldn't find the fact-check endpoint. Investigating revealed:

- The default limit is documented but the \`/docs/api\` page was bare Swagger with no narrative.
- The existing CSV export silently truncated descriptions to 500 chars mid-sentence and leaked raw markdown into cells.
- Stable citation was missing for every entity except Politician (which had \`publicId\` but no resolver URL, no other entities).
- Researchers joining tables had no stable key — slugs change when titles are corrected during moderation.

This PR addresses all of it. After merge + backfill on prod, a researcher can:

\`\`\`python
import pandas as pd
affaires = pd.read_csv(\"https://poligraph.fr/api/export/affaires?limit=10000\")
politiques = pd.read_csv(\"https://poligraph.fr/api/export/politiques\")
affaires.merge(politiques, left_on=\"politicianPoligraphId\", right_on=\"poligraphId\")
\`\`\`

…and cite a specific affair as \`https://poligraph.fr/id/AF-000042\` in a paper, which will 308-redirect forever even if the slug changes.

## poligraphId prefixes

| Prefix | Entity |
|---|---|
| \`PG\` | Politicien (already shipped) |
| \`AF\` | Affaire judiciaire |
| \`FC\` | Fact-check |
| \`SC\` | Scrutin parlementaire |
| \`PT\` | Parti politique |
| \`EL\` | Élection |
| \`MA\` | Mandat |
| \`DO\` | Dossier législatif |
| \`GP\` | Groupe parlementaire |
| \`LM\` | Liste municipale |

Format: \`XX-000542\` (two letters, hyphen, 6-digit zero-padded integer). Extends past 999999 naturally.

## Deployment order (IMPORTANT)

1. **Merge this PR**
2. **Run backfill against prod**: \`npx dotenv -e .env.prod -- npx tsx scripts/backfill-public-ids.ts\` — idempotent, assigns publicIds to the 89k+ existing rows in createdAt order
3. **Verify**: \`curl -s \"https://poligraph.fr/api/export/affaires?limit=3\" | head\` should show \`poligraphId\` in the first column
4. **Optional follow-up PR**: flip \`publicId String?\` → \`publicId String\` (NOT NULL enforcement) after auditing \`createMany\` call sites. Deferred from this PR because the Prisma extension only hooks \`create\`, not \`createMany\`, so bulk sync scripts would insert NULL rows against a NOT NULL constraint.

## Related

- Surfaces ironlam/poligraph#303 (Affair.partyAtTime historical accuracy): the new CSV exposes both \`partyCurrent\` and \`partyAtTime\` columns, making the existing data bug visible to researchers. 48/237 affairs with dated facts have \`partyAtTime\` pointing at a party founded after the facts.

## Test plan

- [x] \`npm run test:run\` — 965 passing, 21 new (12 poligraphId format + 9 CSV stripping)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run format:check\` — clean
- [x] End-to-end smoke test: real affair publicId resolves correctly, markdown strip works on real Jocelyn Dessigny description, generator allocates \`AF-000306\` as next after the 305 backfilled rows, unknown + invalid IDs return null
- [ ] Manual: after deploy, visit \`/docs/api\` in browser and verify all three quickstart tabs work + CSV downloads
- [ ] Manual: after deploy, curl \`/id/PG-000001\` and verify the 308 to the canonical politician page
- [ ] Manual: run prod backfill and spot-check export contents match the researcher's use case