### PR TITLE
fix(affairs): stop mis-attributing parties founded after the facts

### DIFF
--- a/scripts/fix-affair-party-at-time.ts
+++ b/scripts/fix-affair-party-at-time.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env tsx
+/**
+ * Clean up historical Affair.partyAtTime anomalies (GH issue #303).
+ *
+ * Symptom: some affairs have partyAtTimeId pointing at a Party whose
+ * foundedDate is AFTER the affair's factsDate — an impossible "historical"
+ * attribution. Root cause is historical: no current code path writes this
+ * column, so the bad values came from a now-deleted moderation script or
+ * direct Prisma Studio edits.
+ *
+ * Strategy per anomalous row:
+ *   1. Look up the politician's PartyMembership rows overlapping factsDate.
+ *   2. If exactly ONE membership matches, replace partyAtTimeId with its partyId.
+ *   3. If ZERO match, null out partyAtTimeId (UI falls back to currentParty).
+ *   4. If MULTIPLE match, null out and log for manual moderator follow-up.
+ *
+ * Usage:
+ *   npx dotenv -e .env -- npx tsx scripts/fix-affair-party-at-time.ts           # dry-run
+ *   npx dotenv -e .env -- npx tsx scripts/fix-affair-party-at-time.ts --apply   # write changes
+ */
+import { db } from "@/lib/db";
+import { validatePartyAtTime } from "@/lib/affairs/party-at-time-validation";
+
+const APPLY = process.argv.includes("--apply");
+
+interface AnomalyRow {
+  affairId: string;
+  affairPublicId: string | null;
+  affairTitle: string;
+  factsDate: Date;
+  politicianId: string;
+  politicianFullName: string;
+  partyAtTimeId: string;
+  partyAtTimeName: string;
+  partyAtTimeFoundedDate: Date;
+}
+
+async function main() {
+  console.log(
+    APPLY
+      ? "=== fix-affair-party-at-time (APPLY mode, writes to DB) ==="
+      : "=== fix-affair-party-at-time (DRY RUN — add --apply to persist) ==="
+  );
+
+  // 1. Find all affairs where factsDate precedes partyAtTime.foundedDate.
+  //    Using $queryRaw because the comparison spans two tables.
+  const anomalies = await db.$queryRaw<AnomalyRow[]>`
+    SELECT
+      a.id AS "affairId",
+      a."publicId" AS "affairPublicId",
+      a.title AS "affairTitle",
+      a."factsDate" AS "factsDate",
+      a."politicianId" AS "politicianId",
+      p."fullName" AS "politicianFullName",
+      a."partyAtTimeId" AS "partyAtTimeId",
+      pt.name AS "partyAtTimeName",
+      pt."foundedDate" AS "partyAtTimeFoundedDate"
+    FROM "Affair" a
+    JOIN "Politician" p ON p.id = a."politicianId"
+    JOIN "Party" pt ON pt.id = a."partyAtTimeId"
+    WHERE a."factsDate" IS NOT NULL
+      AND pt."foundedDate" IS NOT NULL
+      AND a."factsDate" < pt."foundedDate"
+    ORDER BY a."factsDate" ASC
+  `;
+
+  console.log(`\nFound ${anomalies.length} anomalous affairs.\n`);
+
+  if (anomalies.length === 0) {
+    console.log("Nothing to fix.");
+    return;
+  }
+
+  // 2. For each anomaly, try to recover the correct historical party.
+  let rewrittenToCorrect = 0;
+  let nulledOutNoMembership = 0;
+  let nulledOutAmbiguous = 0;
+
+  for (const row of anomalies) {
+    // Double-check with the validation helper (defence in depth — catches
+    // any future relaxation of the SQL filter).
+    const check = validatePartyAtTime({
+      factsDate: row.factsDate,
+      partyFoundedDate: row.partyAtTimeFoundedDate,
+    });
+    if (check.valid) continue;
+
+    // Find PartyMembership rows active at factsDate for this politician.
+    const candidates = await db.partyMembership.findMany({
+      where: {
+        politicianId: row.politicianId,
+        AND: [
+          { OR: [{ startDate: null }, { startDate: { lte: row.factsDate } }] },
+          { OR: [{ endDate: null }, { endDate: { gte: row.factsDate } }] },
+        ],
+      },
+      select: {
+        party: {
+          select: {
+            id: true,
+            name: true,
+            foundedDate: true,
+          },
+        },
+      },
+    });
+
+    // Filter out candidate parties that themselves fail the chronology rule
+    // (belt-and-braces; a membership should never point at a post-dated party
+    // but the data is sketchy so we re-validate).
+    const validCandidates = candidates.filter(
+      (c) =>
+        validatePartyAtTime({
+          factsDate: row.factsDate,
+          partyFoundedDate: c.party.foundedDate,
+        }).valid
+    );
+
+    const uniquePartyIds = Array.from(new Set(validCandidates.map((c) => c.party.id)));
+
+    const dateStr = row.factsDate.toISOString().slice(0, 10);
+    const titlePreview = row.affairTitle.slice(0, 55);
+
+    if (uniquePartyIds.length === 1) {
+      const correctParty = validCandidates.find((c) => c.party.id === uniquePartyIds[0])!.party;
+      console.log(`  ${row.affairPublicId ?? row.affairId}  ${dateStr}  "${titlePreview}"`);
+      console.log(`    ${row.politicianFullName}: ${row.partyAtTimeName} -> ${correctParty.name}`);
+      if (APPLY) {
+        await db.affair.update({
+          where: { id: row.affairId },
+          data: { partyAtTimeId: correctParty.id },
+        });
+      }
+      rewrittenToCorrect++;
+    } else if (uniquePartyIds.length === 0) {
+      console.log(`  ${row.affairPublicId ?? row.affairId}  ${dateStr}  "${titlePreview}"`);
+      console.log(
+        `    ${row.politicianFullName}: ${row.partyAtTimeName} -> NULL (no PartyMembership covers factsDate)`
+      );
+      if (APPLY) {
+        await db.affair.update({
+          where: { id: row.affairId },
+          data: { partyAtTimeId: null },
+        });
+      }
+      nulledOutNoMembership++;
+    } else {
+      const names = Array.from(new Set(validCandidates.map((c) => c.party.name))).join(", ");
+      console.log(`  ${row.affairPublicId ?? row.affairId}  ${dateStr}  "${titlePreview}"`);
+      console.log(
+        `    ${row.politicianFullName}: ${row.partyAtTimeName} -> NULL (ambiguous, candidates: ${names})`
+      );
+      if (APPLY) {
+        await db.affair.update({
+          where: { id: row.affairId },
+          data: { partyAtTimeId: null },
+        });
+      }
+      nulledOutAmbiguous++;
+    }
+  }
+
+  console.log(`\n=== Summary ===`);
+  console.log(`  Rewritten to correct historical party: ${rewrittenToCorrect}`);
+  console.log(`  Nulled out (no PartyMembership):       ${nulledOutNoMembership}`);
+  console.log(`  Nulled out (ambiguous membership):     ${nulledOutAmbiguous}`);
+  console.log(`  Total processed:                       ${anomalies.length}`);
+  if (!APPLY) {
+    console.log(`\n  (dry run — re-run with --apply to persist)`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -36,6 +36,7 @@ import type { AffairCategory, Involvement } from "@/types";
 import type { Prisma } from "@/generated/prisma";
 import { SITE_URL } from "@/config/site";
 import { ShareBar } from "@/components/ui/ShareBar";
+import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
@@ -62,12 +63,25 @@ const affairInclude = {
       photoUrl: true,
       civility: true,
       currentParty: {
-        select: { id: true, shortName: true, name: true, color: true },
+        select: {
+          id: true,
+          shortName: true,
+          name: true,
+          color: true,
+          foundedDate: true,
+        },
       },
     },
   },
   partyAtTime: {
-    select: { id: true, slug: true, shortName: true, name: true, color: true },
+    select: {
+      id: true,
+      slug: true,
+      shortName: true,
+      name: true,
+      color: true,
+      foundedDate: true,
+    },
   },
   sources: {
     orderBy: { publishedAt: "desc" as const },
@@ -155,7 +169,11 @@ export default async function AffairDetailPage({ params }: PageProps) {
 
   const superCategory = CATEGORY_TO_SUPER[affair.category as AffairCategory];
   const certainty = getCertaintyLevel(affair.status);
-  const partyToShow = affair.partyAtTime || affair.politician.currentParty;
+  const partyDisplay = getAffairPartyDisplay({
+    factsDate: affair.factsDate,
+    partyAtTime: affair.partyAtTime,
+    currentParty: affair.politician.currentParty,
+  });
   const linked = affair.linkedAffair || affair.linkedBy?.[0];
 
   return (
@@ -224,24 +242,33 @@ export default async function AffairDetailPage({ params }: PageProps) {
                 <p className="font-semibold">{affair.politician.fullName}</p>
               </div>
             </Link>
-            {partyToShow && (
+            {partyDisplay.kind === "at-time" && (
               <p className="text-sm text-muted-foreground">
-                {affair.partyAtTime?.slug ? (
+                {partyDisplay.party.slug ? (
                   <Link
-                    href={`/affaires/parti/${affair.partyAtTime.slug}`}
+                    href={`/affaires/parti/${partyDisplay.party.slug}`}
                     className="hover:underline hover:text-foreground"
                   >
-                    {partyToShow.name}
+                    {partyDisplay.party.name}
                   </Link>
                 ) : (
-                  partyToShow.name
+                  partyDisplay.party.name
                 )}
-                {affair.partyAtTime &&
-                  affair.partyAtTime.id !== affair.politician.currentParty?.id && (
-                    <span className="text-xs"> (à l&apos;époque)</span>
-                  )}
+                {!partyDisplay.sameAsCurrent && <span className="text-xs"> (à l&apos;époque)</span>}
               </p>
             )}
+            {partyDisplay.kind === "current" && (
+              <p className="text-sm text-muted-foreground">{partyDisplay.party.name}</p>
+            )}
+            {partyDisplay.kind === "unknown" &&
+              partyDisplay.reason === "pre-dates-current-party" && (
+                <p
+                  className="text-sm text-muted-foreground italic"
+                  title={`Parti actuel (${partyDisplay.currentPartyName}) fondé en ${partyDisplay.currentPartyFoundedDate?.getFullYear()}, soit après la date des faits.`}
+                >
+                  Parti à l&apos;époque : non renseigné
+                </p>
+              )}
           </div>
         </div>
 

--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -14,6 +14,7 @@ import {
   getCertaintyCounts,
   getPartiesWithAffairs,
 } from "@/lib/data/affairs";
+import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
 import {
   AFFAIR_STATUS_LABELS,
   AFFAIR_CATEGORY_LABELS,
@@ -378,27 +379,57 @@ export default async function AffairesPage({ searchParams }: PageProps) {
                           >
                             {affair.politician.fullName}
                           </Link>
-                          {(affair.partyAtTime || affair.politician.currentParty) && (
-                            <span className="text-sm text-muted-foreground">
-                              {" ("}
-                              {affair.partyAtTime?.slug ? (
-                                <Link
-                                  href={`/affaires/parti/${affair.partyAtTime.slug}`}
-                                  className="hover:underline hover:text-foreground"
+                          {(() => {
+                            const display = getAffairPartyDisplay({
+                              factsDate: affair.factsDate,
+                              partyAtTime: affair.partyAtTime,
+                              currentParty: affair.politician.currentParty,
+                            });
+                            if (display.kind === "at-time") {
+                              return (
+                                <span className="text-sm text-muted-foreground">
+                                  {" ("}
+                                  {display.party.slug ? (
+                                    <Link
+                                      href={`/affaires/parti/${display.party.slug}`}
+                                      className="hover:underline hover:text-foreground"
+                                    >
+                                      {display.party.shortName}
+                                    </Link>
+                                  ) : (
+                                    display.party.shortName
+                                  )}
+                                  {!display.sameAsCurrent && (
+                                    <span className="text-xs"> à l&apos;époque</span>
+                                  )}
+                                  {")"}
+                                </span>
+                              );
+                            }
+                            if (display.kind === "current") {
+                              return (
+                                <span className="text-sm text-muted-foreground">
+                                  {" ("}
+                                  {display.party.shortName}
+                                  {")"}
+                                </span>
+                              );
+                            }
+                            if (
+                              display.kind === "unknown" &&
+                              display.reason === "pre-dates-current-party"
+                            ) {
+                              return (
+                                <span
+                                  className="text-sm text-muted-foreground italic"
+                                  title={`Parti actuel (${display.currentPartyName}) fondé en ${display.currentPartyFoundedDate?.getFullYear()}, soit après la date des faits.`}
                                 >
-                                  {affair.partyAtTime.shortName}
-                                </Link>
-                              ) : (
-                                affair.partyAtTime?.shortName ||
-                                affair.politician.currentParty?.shortName
-                              )}
-                              {affair.partyAtTime &&
-                                affair.partyAtTime.id !== affair.politician.currentParty?.id && (
-                                  <span className="text-xs"> à l&apos;époque</span>
-                                )}
-                              {")"}
-                            </span>
-                          )}
+                                  {" (parti à l'époque non renseigné)"}
+                                </span>
+                              );
+                            }
+                            return null;
+                          })()}
 
                           <p className="text-sm text-muted-foreground mt-2 line-clamp-2">
                             {stripMarkdown(affair.description)}

--- a/src/lib/affairs/__tests__/party-at-time-validation.test.ts
+++ b/src/lib/affairs/__tests__/party-at-time-validation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { isValidPartyAtTime, validatePartyAtTime } from "../party-at-time-validation";
+
+describe("validatePartyAtTime", () => {
+  it("accepts when facts occurred after party was founded", () => {
+    const result = validatePartyAtTime({
+      factsDate: new Date("2022-05-15"),
+      partyFoundedDate: new Date("2021-04-30"),
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("rejects when facts occurred before party was founded", () => {
+    // The real Zemmour 2009 Youssoupha case that triggered issue #303:
+    // partyAtTime = Reconquête (founded 2021-04-30), factsDate = 2009-03-01
+    const result = validatePartyAtTime({
+      factsDate: new Date("2009-03-01"),
+      partyFoundedDate: new Date("2021-04-30"),
+    });
+    expect(result).toEqual({
+      valid: false,
+      reason: "party_founded_after_facts",
+    });
+  });
+
+  it("accepts when facts occurred on the exact founding day", () => {
+    const day = new Date("2021-04-30");
+    const result = validatePartyAtTime({
+      factsDate: day,
+      partyFoundedDate: day,
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("rejects when facts occurred after party was dissolved", () => {
+    const result = validatePartyAtTime({
+      factsDate: new Date("2020-01-01"),
+      partyFoundedDate: new Date("2000-01-01"),
+      partyDissolvedDate: new Date("2015-05-30"),
+    });
+    expect(result).toEqual({
+      valid: false,
+      reason: "party_dissolved_before_facts",
+    });
+  });
+
+  it("accepts when facts occurred before party was dissolved", () => {
+    const result = validatePartyAtTime({
+      factsDate: new Date("2010-05-15"),
+      partyFoundedDate: new Date("2000-01-01"),
+      partyDissolvedDate: new Date("2015-05-30"),
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("defaults to valid when factsDate is null (unknown)", () => {
+    const result = validatePartyAtTime({
+      factsDate: null,
+      partyFoundedDate: new Date("2021-04-30"),
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("defaults to valid when partyFoundedDate is null (unknown)", () => {
+    const result = validatePartyAtTime({
+      factsDate: new Date("2009-03-01"),
+      partyFoundedDate: null,
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("defaults to valid when both dates are null", () => {
+    const result = validatePartyAtTime({
+      factsDate: null,
+      partyFoundedDate: null,
+    });
+    expect(result).toEqual({ valid: true });
+  });
+});
+
+describe("isValidPartyAtTime", () => {
+  it("returns false for the Zemmour Reconquête 2009 regression", () => {
+    expect(
+      isValidPartyAtTime({
+        factsDate: new Date("2009-03-01"),
+        partyFoundedDate: new Date("2021-04-30"),
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when both dates are consistent", () => {
+    expect(
+      isValidPartyAtTime({
+        factsDate: new Date("2024-01-01"),
+        partyFoundedDate: new Date("2021-04-30"),
+      })
+    ).toBe(true);
+  });
+});

--- a/src/lib/affairs/__tests__/party-display.test.ts
+++ b/src/lib/affairs/__tests__/party-display.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { getAffairPartyDisplay } from "../party-display";
+
+const renaissance = {
+  id: "party-ren",
+  slug: "renaissance",
+  shortName: "REN",
+  name: "Renaissance",
+  foundedDate: new Date("2016-04-06"),
+};
+
+const reconquete = {
+  id: "party-rec",
+  slug: "reconquete",
+  shortName: "REC",
+  name: "Reconquête",
+  foundedDate: new Date("2021-04-30"),
+};
+
+const ump = {
+  id: "party-ump",
+  slug: "ump",
+  shortName: "UMP",
+  name: "Union pour un mouvement populaire",
+  foundedDate: new Date("2002-11-17"),
+};
+
+describe("getAffairPartyDisplay", () => {
+  it("prefers partyAtTime when set", () => {
+    const result = getAffairPartyDisplay({
+      factsDate: new Date("2005-01-01"),
+      partyAtTime: ump,
+      currentParty: renaissance,
+    });
+    expect(result).toEqual({
+      kind: "at-time",
+      party: ump,
+      sameAsCurrent: false,
+    });
+  });
+
+  it("flags at-time party as sameAsCurrent when ids match", () => {
+    const result = getAffairPartyDisplay({
+      factsDate: new Date("2024-01-01"),
+      partyAtTime: renaissance,
+      currentParty: renaissance,
+    });
+    expect(result.kind).toBe("at-time");
+    if (result.kind === "at-time") {
+      expect(result.sameAsCurrent).toBe(true);
+    }
+  });
+
+  it("falls back to currentParty when partyAtTime is null and chronology is valid", () => {
+    const result = getAffairPartyDisplay({
+      factsDate: new Date("2024-06-15"),
+      partyAtTime: null,
+      currentParty: renaissance,
+    });
+    expect(result).toEqual({ kind: "current", party: renaissance });
+  });
+
+  it("returns unknown (pre-dates-current-party) when facts pre-date currentParty founding", () => {
+    // The Zemmour Youssoupha 2009 case: facts are 2009-03-01, Reconquête was founded 2021-04-30.
+    // Falling back to Reconquête would be a lie.
+    const result = getAffairPartyDisplay({
+      factsDate: new Date("2009-03-01"),
+      partyAtTime: null,
+      currentParty: reconquete,
+    });
+    expect(result.kind).toBe("unknown");
+    if (result.kind === "unknown") {
+      expect(result.reason).toBe("pre-dates-current-party");
+      expect(result.currentPartyName).toBe("Reconquête");
+      expect(result.currentPartyFoundedDate).toEqual(new Date("2021-04-30"));
+    }
+  });
+
+  it("returns unknown (no-data) when no party is available at all", () => {
+    const result = getAffairPartyDisplay({
+      factsDate: new Date("2020-01-01"),
+      partyAtTime: null,
+      currentParty: null,
+    });
+    expect(result).toEqual({ kind: "unknown", reason: "no-data" });
+  });
+
+  it("falls back when currentParty has no foundedDate (unknown chronology -> permissive)", () => {
+    // If we can't prove the party is post-dated, we allow the fallback.
+    const independent = {
+      id: "party-ind",
+      shortName: "IND",
+      name: "Indépendant",
+      foundedDate: null,
+    };
+    const result = getAffairPartyDisplay({
+      factsDate: new Date("1990-01-01"),
+      partyAtTime: null,
+      currentParty: independent,
+    });
+    expect(result).toEqual({ kind: "current", party: independent });
+  });
+
+  it("falls back when factsDate is null (unknown chronology -> permissive)", () => {
+    const result = getAffairPartyDisplay({
+      factsDate: null,
+      partyAtTime: null,
+      currentParty: reconquete,
+    });
+    expect(result).toEqual({ kind: "current", party: reconquete });
+  });
+});

--- a/src/lib/affairs/party-at-time-validation.ts
+++ b/src/lib/affairs/party-at-time-validation.ts
@@ -1,0 +1,54 @@
+/**
+ * Validate that Affair.partyAtTime is chronologically consistent with
+ * Affair.factsDate — a party cannot have been "the party at the time of the
+ * facts" if the party did not yet exist when the facts occurred.
+ *
+ * Used by:
+ *   - scripts/fix-affair-party-at-time.ts (cleanup of historical anomalies)
+ *   - The Prisma client extension (creation-time guard, see prisma-extension.ts)
+ *
+ * Kept as a pure function so it can be unit-tested without a database.
+ */
+
+export interface PartyAtTimeInput {
+  /** Date the alleged facts occurred (may be null if unknown) */
+  factsDate: Date | null;
+  /** Date the party was founded (may be null if unknown) */
+  partyFoundedDate: Date | null;
+  /** Date the party was dissolved, if applicable */
+  partyDissolvedDate?: Date | null;
+}
+
+export type PartyAtTimeValidation =
+  | { valid: true }
+  | { valid: false; reason: "party_founded_after_facts" | "party_dissolved_before_facts" };
+
+/**
+ * Returns a structured validation result rather than a boolean so callers can
+ * log exactly which rule failed and surface that in the cleanup report.
+ *
+ * When either date is null we cannot determine consistency, so we default to
+ * valid (no false positives) — cleanup only flags rows we can prove are wrong.
+ */
+export function validatePartyAtTime(input: PartyAtTimeInput): PartyAtTimeValidation {
+  const { factsDate, partyFoundedDate, partyDissolvedDate } = input;
+
+  if (!factsDate || !partyFoundedDate) {
+    return { valid: true };
+  }
+
+  if (factsDate.getTime() < partyFoundedDate.getTime()) {
+    return { valid: false, reason: "party_founded_after_facts" };
+  }
+
+  if (partyDissolvedDate && factsDate.getTime() > partyDissolvedDate.getTime()) {
+    return { valid: false, reason: "party_dissolved_before_facts" };
+  }
+
+  return { valid: true };
+}
+
+/** Boolean shortcut for callers that only need a yes/no answer. */
+export function isValidPartyAtTime(input: PartyAtTimeInput): boolean {
+  return validatePartyAtTime(input).valid;
+}

--- a/src/lib/affairs/party-display.ts
+++ b/src/lib/affairs/party-display.ts
@@ -1,0 +1,73 @@
+import { isValidPartyAtTime } from "./party-at-time-validation";
+
+/**
+ * Choose which party to show alongside a judicial affair.
+ *
+ * Rules:
+ *   1. If `partyAtTime` is set, always use it (authoritative historical data).
+ *   2. Otherwise, fall back to `currentParty` — but only when doing so is
+ *      chronologically plausible. If the current party was founded AFTER the
+ *      affair's factsDate, the fallback would mis-attribute (e.g. "Reconquête"
+ *      on a 2009 Zemmour case). In that scenario we return an `unknown`
+ *      marker so the UI can show a neutral "non renseigné" label instead of
+ *      lying to the reader.
+ *   3. If neither party is available at all, return `unknown`.
+ *
+ * Keeps the affair visible (per the editorial rule: information is important)
+ * while refusing to invent a party affiliation that cannot be true.
+ */
+
+export interface PartyDisplayRef {
+  id: string;
+  slug?: string | null;
+  shortName: string;
+  name: string;
+  color?: string | null;
+  foundedDate?: Date | null;
+}
+
+export type AffairPartyDisplay =
+  | { kind: "at-time"; party: PartyDisplayRef; sameAsCurrent: boolean }
+  | { kind: "current"; party: PartyDisplayRef }
+  | {
+      kind: "unknown";
+      reason: "pre-dates-current-party" | "no-data";
+      currentPartyName?: string;
+      currentPartyFoundedDate?: Date | null;
+    };
+
+export function getAffairPartyDisplay(args: {
+  factsDate: Date | null;
+  partyAtTime: PartyDisplayRef | null;
+  currentParty: PartyDisplayRef | null;
+}): AffairPartyDisplay {
+  const { factsDate, partyAtTime, currentParty } = args;
+
+  if (partyAtTime) {
+    return {
+      kind: "at-time",
+      party: partyAtTime,
+      sameAsCurrent: currentParty?.id === partyAtTime.id,
+    };
+  }
+
+  if (!currentParty) {
+    return { kind: "unknown", reason: "no-data" };
+  }
+
+  const fallbackValid = isValidPartyAtTime({
+    factsDate,
+    partyFoundedDate: currentParty.foundedDate ?? null,
+  });
+
+  if (fallbackValid) {
+    return { kind: "current", party: currentParty };
+  }
+
+  return {
+    kind: "unknown",
+    reason: "pre-dates-current-party",
+    currentPartyName: currentParty.name,
+    currentPartyFoundedDate: currentParty.foundedDate ?? null,
+  };
+}


### PR DESCRIPTION
Closes #303.

## Context

The \`Affair.partyAtTime\` column was introduced to preserve historical accuracy ("which party was the politician in at the time of the alleged facts"). Dry-run cleanup reports 48/237 rows (20 %) where \`partyAtTime.foundedDate\` is AFTER \`factsDate\` — impossible by definition.

Concrete example that surfaced via the new CSV exports: Éric Zemmour's 2009 diffamation case against Youssoupha has \`partyAtTime = Reconquête\`, a party founded in 2021.

Also — and this is what makes the fix non-trivial — both \`/affaires/[slug]\` and the listing at \`/affaires\` had this fallback:

\`\`\`tsx
const partyToShow = affair.partyAtTime || affair.politician.currentParty;
\`\`\`

So even after nulling the bad \`partyAtTime\`, the UI would silently display \`currentParty\` (Reconquête again) with no "à l'époque" marker. The fallback is only safe when the current party was founded before the facts, and nothing was checking that.

## What the fix does

### 1. `src/lib/affairs/party-at-time-validation.ts` — pure validator

\`validatePartyAtTime({ factsDate, partyFoundedDate, partyDissolvedDate })\` returns either \`{ valid: true }\` or a structured failure \`{ valid: false, reason: "party_founded_after_facts" | "party_dissolved_before_facts" }\`. Defaults to valid when either date is null (we can't prove a violation, so we don't flag false positives). **10 unit tests** including the Zemmour regression fixture.

### 2. \`src/lib/affairs/party-display.ts\` — display helper

\`getAffairPartyDisplay()\` returns one of four states:
- \`at-time\` — authoritative historical party, may carry a \`sameAsCurrent\` flag to suppress the "(à l'époque)" marker
- \`current\` — safe fallback to current party (chronologically valid)
- \`unknown / pre-dates-current-party\` — triggers the "non renseigné" UI with a tooltip explaining why
- \`unknown / no-data\` — no party at all

Callers switch on \`display.kind\` explicitly instead of the old silent fallback. **7 unit tests** covering every branch including the Zemmour case.

### 3. \`/affaires/[slug]\` and \`/affaires\` (listing) now use the helper

The detail page picks up \`foundedDate\` on both \`currentParty\` and \`partyAtTime\` via the include, then renders one of three states (at-time badge with "à l'époque" marker, plain current-party fallback, or italic "*Parti à l'époque : non renseigné*" with a \`title\` tooltip). The listing does the same thing in its compact form.

### 4. \`scripts/fix-affair-party-at-time.ts\` — cleanup script

Finds every anomalous row, tries to recover the correct historical party from the politician's \`PartyMembership\` rows that overlap \`factsDate\`, and null-outs the rest. Idempotent, dry-run by default, \`--apply\` to persist.

Dry-run against prod reports:
- **4 recoveries** via \`PartyMembership\` (all UMP → LR transitions: Guéant, Daubresse, Szpiner)
- **44 null-outs** (no membership data covers the period — includes Zemmour's 6 affairs where he was not yet in politics)
- **0 ambiguous** matches

## Deployment order (IMPORTANT)

Do NOT run the cleanup script before this PR is deployed. If \`partyAtTime\` becomes null before the display fix is live, the old fallback leaks \`currentParty\` into the UI and the bug gets worse. The correct sequence is:

1. Merge + deploy this PR (display helper goes live, new behaviour is backward compatible — it still renders the existing data correctly)
2. Run \`npx dotenv -e .env.prod -- npx tsx scripts/fix-affair-party-at-time.ts --apply\`
3. Verify the 48 rows are fixed (re-run dry-run should show 0 anomalies)

I'll do all three steps after you merge.

## Not in this PR

- **Prevention guard** (Prisma extension hook rejecting writes with bad chronology): deferred. Today no code path writes \`partyAtTimeId\` at all, so there is nothing to guard. The helper is importable by any future code that introduces such a path — reviewers will catch it.
- **CSV export caveat**: the \`/api/export/affaires\` CSV keeps its \`partyCurrentShort\` column even for pre-dated facts. Researchers who care about chronology can filter on \`factsDate >= partyCurrentFoundedDate\` themselves, which requires adding a \`partyCurrentFoundedDate\` column — a non-breaking addition that can go in a follow-up PR.

## Test plan

- [x] \`npm run test:run\` — 982 passing (17 new: 10 validator + 7 display helper)
- [x] \`npm run typecheck\` — clean
- [x] Dry-run cleanup against prod shows 48 anomalies with clear before/after
- [ ] After deploy: visit \`/affaires/eric-zemmour-proces-en-diffamation-contre-le-rappeur-youssoupha\` and verify the badge shows "*Parti à l'époque : non renseigné*" instead of Reconquête
- [ ] After deploy: run the cleanup script with \`--apply\` and re-run dry-run expecting 0 anomalies