### PR TITLE
perf(votes): drop redundant Vote_politicianId_idx

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -890,7 +890,6 @@ model Vote {
   chamber    Chamber
 
   @@unique([scrutinId, politicianId])
-  @@index([politicianId])
   @@index([politicianId, position])
   @@index([politicianId, votingDate(sort: Desc)], map: "Vote_politicianId_votingDate_idx")
   @@index([politicianId, chamber, votingDate(sort: Desc)], map: "Vote_politicianId_chamber_votingDate_idx")


### PR DESCRIPTION
## Summary

- Removes the single-column `Vote_politicianId_idx` index (25 MB), which is fully covered by the two composite indexes added in Phase 5b (PR #302):
  - `Vote_politicianId_votingDate_idx`
  - `Vote_politicianId_chamber_votingDate_idx`
- Both composites have `politicianId` as their leading column, so any query the old index served is handled by the composites

## Telemetry evidence

After 20h of production traffic (`npm run perf:check`):

| Index | Scans |
|---|---|
| `Vote_politicianId_chamber_votingDate_idx` | 18,005 (climbing) |
| `Vote_politicianId_votingDate_idx` | 3,155 (climbing) |
| `Vote_politicianId_idx` (legacy) | 866,895 (flat, 0 new scans in 20h) |

The legacy index has had **zero new scans** since the Phase 5b composites went live, confirming it is dead.

## Notes

- The `db:push --accept-data-loss` has already been applied to production - the index is already dropped
- This PR just syncs the Prisma schema with the current DB state
- Completes Task 5b.5 from the Phase 5 performance plan

## Test plan

- [x] `npm run perf:check` confirms all queries still use composite indexes
- [x] No code references `Vote_politicianId_idx` by name
- [ ] CI passes (typecheck, lint, tests)