### PR TITLE
fix(docs): code block contrast in light mode on /docs/api

### DIFF
--- a/src/app/docs/api/_components/CodeBlock.tsx
+++ b/src/app/docs/api/_components/CodeBlock.tsx
@@ -25,7 +25,7 @@ export function CodeBlock({ code, language = "bash", label }: CodeBlockProps) {
   return (
     <div className="relative group">
       {label && <div className="text-xs font-mono text-muted-foreground mb-1">{label}</div>}
-      <pre className="bg-muted rounded-lg p-4 pr-12 text-sm overflow-x-auto font-mono">
+      <pre className="bg-muted text-foreground rounded-lg p-4 pr-12 text-sm overflow-x-auto font-mono">
         <code className={`language-${language}`}>{code}</code>
       </pre>
       <button


### PR DESCRIPTION
One-liner. Code snippets on `/docs/api` inherited a grayish text color from the page context in light mode, making them hard to read against `bg-muted`. Adding explicit `text-foreground` to the `<pre>` element guarantees maximum contrast in both themes.

Dark mode was already fine (the inherited color happened to contrast well).