### PR TITLE
feat(seo): hub /affaires/condamnations with facet query params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "zod": "^4.3.5"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.58.1",
         "@prisma/client": "^7.2.0",
         "@storybook/nextjs-vite": "^10.2.19",
@@ -370,6 +371,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.58.1",
     "@prisma/client": "^7.2.0",
     "@storybook/nextjs-vite": "^10.2.19",

--- a/src/app/affaires/condamnations/loading.tsx
+++ b/src/app/affaires/condamnations/loading.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="container mx-auto px-4 pt-4 pb-8">
+      <div className="text-sm text-muted-foreground mb-4">
+        <Skeleton className="h-4 w-64" />
+      </div>
+      <Skeleton className="h-9 w-3/4 mb-2" />
+      <Skeleton className="h-5 w-1/2 mb-6" />
+      <div className="flex flex-wrap gap-2 mb-6">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-11 w-24 rounded-full" />
+        ))}
+      </div>
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-32 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/affaires/condamnations/opengraph-image.tsx
+++ b/src/app/affaires/condamnations/opengraph-image.tsx
@@ -1,0 +1,63 @@
+import { ImageResponse } from "next/og";
+import { db } from "@/lib/db";
+import { OgLayout, OgCategoryLabel, OG_SIZE } from "@/lib/og-utils";
+
+export const alt = "Responsables politiques condamnés sur Poligraph";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+  const [totalDef, totalPro] = await Promise.all([
+    db.affair.count({
+      where: {
+        publicationStatus: "PUBLISHED",
+        involvement: { in: ["DIRECT", "INDIRECT"] },
+        status: "CONDAMNATION_DEFINITIVE",
+      },
+    }),
+    db.affair.count({
+      where: {
+        publicationStatus: "PUBLISHED",
+        involvement: { in: ["DIRECT", "INDIRECT"] },
+        status: { in: ["CONDAMNATION_PREMIERE_INSTANCE", "APPEL_EN_COURS"] },
+      },
+    }),
+  ]);
+
+  return new ImageResponse(
+    <OgLayout>
+      <OgCategoryLabel emoji="⚖️" label="Condamnations" />
+
+      <div
+        style={{
+          display: "flex",
+          fontSize: 52,
+          fontWeight: 800,
+          color: "white",
+          lineHeight: 1.15,
+          marginBottom: 32,
+        }}
+      >
+        Responsables politiques condamnés
+      </div>
+
+      <div style={{ display: "flex", gap: 48 }}>
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ display: "flex", fontSize: 80, fontWeight: 700, color: "#ef4444" }}>
+            {totalDef}
+          </div>
+          <div style={{ display: "flex", fontSize: 22, color: "#94a3b8" }}>
+            condamnations définitives
+          </div>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ display: "flex", fontSize: 80, fontWeight: 700, color: "#f97316" }}>
+            {totalPro}
+          </div>
+          <div style={{ display: "flex", fontSize: 22, color: "#94a3b8" }}>non définitives</div>
+        </div>
+      </div>
+    </OgLayout>,
+    { ...OG_SIZE }
+  );
+}

--- a/src/app/affaires/condamnations/page.tsx
+++ b/src/app/affaires/condamnations/page.tsx
@@ -9,6 +9,8 @@ import { CondamnationsPresumptionBanner } from "@/components/affairs/Condamnatio
 import { getCondamnations, getCondamnationsStatsByParty } from "@/lib/data/condamnations";
 import { getPartiesWithAffairs } from "@/lib/data/affairs";
 import { buildListTitle, buildDescription, buildCanonical } from "@/lib/seo/condamnations-metadata";
+import { CollectionPageJsonLd, AffairItemListJsonLd, DatasetJsonLd } from "@/components/seo/JsonLd";
+import { SITE_URL } from "@/config/site";
 
 export const revalidate = 300;
 
@@ -121,28 +123,35 @@ export default async function CondamnationsPage({ searchParams }: PageProps) {
   if (params.view === "stats") {
     const stats = await getCondamnationsStatsByParty(params.mandat);
     return (
-      <div className="container mx-auto px-4 pt-4 pb-8">
-        <Breadcrumb items={breadcrumbItems} />
-        <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">{h1}</h1>
-        <p className="text-muted-foreground mb-6">
-          Répartition des responsables politiques condamnés définitivement par leur parti d{"'"}
-          appartenance. Sources vérifiables.
-        </p>
-        <CondamnationsFilters
-          current={{
-            mandat: params.mandat,
-            certainty: params.certainty,
-            parti: params.parti,
-            view: params.view,
-          }}
-          parties={parties.map((p) => ({
-            slug: p.slug as string,
-            shortName: p.shortName,
-            name: p.name,
-          }))}
+      <>
+        <DatasetJsonLd
+          name="Taux de condamnation par parti politique en France"
+          description="Agrégation du nombre et du taux de responsables politiques condamnés définitivement par parti d'appartenance"
+          url={`${SITE_URL}/affaires/condamnations?view=stats`}
         />
-        <CondamnationsStatsTable rows={stats} currentMandat={params.mandat} />
-      </div>
+        <div className="container mx-auto px-4 pt-4 pb-8">
+          <Breadcrumb items={breadcrumbItems} />
+          <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">{h1}</h1>
+          <p className="text-muted-foreground mb-6">
+            Répartition des responsables politiques condamnés définitivement par leur parti d{"'"}
+            appartenance. Sources vérifiables.
+          </p>
+          <CondamnationsFilters
+            current={{
+              mandat: params.mandat,
+              certainty: params.certainty,
+              parti: params.parti,
+              view: params.view,
+            }}
+            parties={parties.map((p) => ({
+              slug: p.slug as string,
+              shortName: p.shortName,
+              name: p.name,
+            }))}
+          />
+          <CondamnationsStatsTable rows={stats} currentMandat={params.mandat} />
+        </div>
+      </>
     );
   }
 
@@ -171,91 +180,115 @@ export default async function CondamnationsPage({ searchParams }: PageProps) {
   const totalDefinitif = listDef?.total ?? 0;
   const totalPrononce = listNonDef?.total ?? 0;
 
-  return (
-    <div className="container mx-auto px-4 pt-4 pb-8">
-      <Breadcrumb items={breadcrumbItems} />
-      <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">{h1}</h1>
-      <p className="text-muted-foreground mb-6">
-        {totalDefinitif > 0 &&
-          `${totalDefinitif} condamnation${totalDefinitif !== 1 ? "s" : ""} définitive${totalDefinitif !== 1 ? "s" : ""}`}
-        {totalDefinitif > 0 && totalPrononce > 0 && " · "}
-        {totalPrononce > 0 && `${totalPrononce} en première instance ou en appel`}
-        {totalDefinitif === 0 &&
-          totalPrononce === 0 &&
-          "Aucune décision ne correspond à ces filtres."}
-      </p>
+  const allAffairs = [...(listDef?.affairs ?? []), ...(listNonDef?.affairs ?? [])];
 
-      <CondamnationsFilters
-        current={{
+  return (
+    <>
+      <CollectionPageJsonLd
+        name={h1}
+        description=""
+        url={`${SITE_URL}${buildCanonical({
           mandat: params.mandat,
           certainty: params.certainty,
-          parti: params.parti,
-          view: params.view,
-        }}
-        parties={parties.map((p) => ({
-          slug: p.slug as string,
-          shortName: p.shortName,
-          name: p.name,
-        }))}
+          partiSlug: params.parti,
+          view: "list",
+        })}`}
+        numberOfItems={totalDefinitif + totalPrononce}
       />
-
-      {listDef && listDef.affairs.length > 0 && (
-        <section aria-labelledby="heading-definitives" className="mb-10">
-          <h2 id="heading-definitives" className="text-2xl font-display font-bold mb-4">
-            Condamnations définitives
-          </h2>
-          <div className="space-y-3">
-            {listDef.affairs.map((a) => (
-              <CondamnationCard
-                key={a.id}
-                affair={a as Parameters<typeof CondamnationCard>[0]["affair"]}
-                definitif
-              />
-            ))}
-          </div>
-        </section>
+      {allAffairs.length > 0 && (
+        <AffairItemListJsonLd
+          name={h1}
+          items={allAffairs.map((a) => ({
+            url: `${SITE_URL}/affaires/${a.slug}`,
+            name: a.title,
+          }))}
+        />
       )}
-
-      {listNonDef && listNonDef.affairs.length > 0 && (
-        <section aria-labelledby="heading-non-definitives" className="mb-10">
-          <h2 id="heading-non-definitives" className="text-2xl font-display font-bold mb-2">
-            Condamnations non définitives
-          </h2>
-          <CondamnationsPresumptionBanner />
-          <div className="space-y-3">
-            {listNonDef.affairs.map((a) => (
-              <CondamnationCard
-                key={a.id}
-                affair={a as Parameters<typeof CondamnationCard>[0]["affair"]}
-                definitif={false}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Methodology footer */}
-      <section className="mt-12 border-t border-border pt-6">
-        <h2 className="text-xl font-semibold mb-2">Méthodologie</h2>
-        <p className="text-sm text-muted-foreground">
-          Chaque condamnation listée est documentée avec au moins une source journalistique
-          vérifiable ou une décision de justice publiée. Les données proviennent de Wikidata, de la
-          presse, de Judilibre et de contributions modérées. Une personne citée peut demander
-          correction via{" "}
-          <a href="mailto:contact@poligraph.fr" className="text-primary hover:underline">
-            contact@poligraph.fr
-          </a>
-          . Voir la{" "}
-          <a href="/sources" className="text-primary hover:underline">
-            page Sources
-          </a>{" "}
-          pour la méthodologie complète et la{" "}
-          <a href="/docs/api" className="text-primary hover:underline">
-            documentation API
-          </a>{" "}
-          pour la reproduction des données.
+      <div className="container mx-auto px-4 pt-4 pb-8">
+        <Breadcrumb items={breadcrumbItems} />
+        <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">{h1}</h1>
+        <p className="text-muted-foreground mb-6">
+          {totalDefinitif > 0 &&
+            `${totalDefinitif} condamnation${totalDefinitif !== 1 ? "s" : ""} définitive${totalDefinitif !== 1 ? "s" : ""}`}
+          {totalDefinitif > 0 && totalPrononce > 0 && " · "}
+          {totalPrononce > 0 && `${totalPrononce} en première instance ou en appel`}
+          {totalDefinitif === 0 &&
+            totalPrononce === 0 &&
+            "Aucune décision ne correspond à ces filtres."}
         </p>
-      </section>
-    </div>
+
+        <CondamnationsFilters
+          current={{
+            mandat: params.mandat,
+            certainty: params.certainty,
+            parti: params.parti,
+            view: params.view,
+          }}
+          parties={parties.map((p) => ({
+            slug: p.slug as string,
+            shortName: p.shortName,
+            name: p.name,
+          }))}
+        />
+
+        {listDef && listDef.affairs.length > 0 && (
+          <section aria-labelledby="heading-definitives" className="mb-10">
+            <h2 id="heading-definitives" className="text-2xl font-display font-bold mb-4">
+              Condamnations définitives
+            </h2>
+            <div className="space-y-3">
+              {listDef.affairs.map((a) => (
+                <CondamnationCard
+                  key={a.id}
+                  affair={a as Parameters<typeof CondamnationCard>[0]["affair"]}
+                  definitif
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {listNonDef && listNonDef.affairs.length > 0 && (
+          <section aria-labelledby="heading-non-definitives" className="mb-10">
+            <h2 id="heading-non-definitives" className="text-2xl font-display font-bold mb-2">
+              Condamnations non définitives
+            </h2>
+            <CondamnationsPresumptionBanner />
+            <div className="space-y-3">
+              {listNonDef.affairs.map((a) => (
+                <CondamnationCard
+                  key={a.id}
+                  affair={a as Parameters<typeof CondamnationCard>[0]["affair"]}
+                  definitif={false}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Methodology footer */}
+        <section className="mt-12 border-t border-border pt-6">
+          <h2 className="text-xl font-semibold mb-2">Méthodologie</h2>
+          <p className="text-sm text-muted-foreground">
+            Chaque condamnation listée est documentée avec au moins une source journalistique
+            vérifiable ou une décision de justice publiée. Les données proviennent de Wikidata, de
+            la presse, de Judilibre et de contributions modérées. Une personne citée peut demander
+            correction via{" "}
+            <a href="mailto:contact@poligraph.fr" className="text-primary hover:underline">
+              contact@poligraph.fr
+            </a>
+            . Voir la{" "}
+            <a href="/sources" className="text-primary hover:underline">
+              page Sources
+            </a>{" "}
+            pour la méthodologie complète et la{" "}
+            <a href="/docs/api" className="text-primary hover:underline">
+              documentation API
+            </a>{" "}
+            pour la reproduction des données.
+          </p>
+        </section>
+      </div>
+    </>
   );
 }

--- a/src/app/affaires/condamnations/page.tsx
+++ b/src/app/affaires/condamnations/page.tsx
@@ -1,0 +1,261 @@
+import type { Metadata } from "next";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { CondamnationCard } from "@/components/affairs/CondamnationCard";
+import { CondamnationsFilters } from "@/components/affairs/CondamnationsFilters";
+import { CondamnationsStatsTable } from "@/components/affairs/CondamnationsStatsTable";
+import { CondamnationsPresumptionBanner } from "@/components/affairs/CondamnationsPresumptionBanner";
+import { getCondamnations, getCondamnationsStatsByParty } from "@/lib/data/condamnations";
+import { getPartiesWithAffairs } from "@/lib/data/affairs";
+import { buildListTitle, buildDescription, buildCanonical } from "@/lib/seo/condamnations-metadata";
+
+export const revalidate = 300;
+
+const searchParamsSchema = z.object({
+  mandat: z.enum(["depute", "senateur", "gouvernement", "locaux"]).optional(),
+  certainty: z.enum(["etabli", "prononcee", "tous"]).default("tous"),
+  parti: z
+    .string()
+    .regex(/^[a-z0-9-]+$/)
+    .optional(),
+  view: z.enum(["list", "stats"]).default("list"),
+  page: z.coerce.number().int().min(1).max(100).default(1),
+  sort: z.enum(["date", "nom", "severity"]).default("date"),
+});
+
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+async function getPartyNameFromSlug(slug?: string): Promise<string | null> {
+  if (!slug) return null;
+  const p = await db.party.findUnique({
+    where: { slug },
+    select: { shortName: true, name: true },
+  });
+  return p ? `${p.name} (${p.shortName})` : null;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const raw = await searchParams;
+  const parsed = searchParamsSchema.safeParse(raw);
+  const params = parsed.success ? parsed.data : searchParamsSchema.parse({});
+
+  const partyName = await getPartyNameFromSlug(params.parti);
+
+  const [totalDef, totalPro] = await Promise.all([
+    db.affair.count({
+      where: {
+        publicationStatus: "PUBLISHED",
+        involvement: { in: ["DIRECT", "INDIRECT"] },
+        status: "CONDAMNATION_DEFINITIVE",
+      },
+    }),
+    db.affair.count({
+      where: {
+        publicationStatus: "PUBLISHED",
+        involvement: { in: ["DIRECT", "INDIRECT"] },
+        status: { in: ["CONDAMNATION_PREMIERE_INSTANCE", "APPEL_EN_COURS"] },
+      },
+    }),
+  ]);
+
+  const titleBase =
+    params.view === "stats"
+      ? "Taux de condamnation par parti politique"
+      : buildListTitle({
+          mandat: params.mandat,
+          certainty: params.certainty,
+          partyName,
+        });
+
+  const title = `${titleBase} | Poligraph`;
+  const description = buildDescription({
+    mandat: params.mandat,
+    certainty: params.certainty,
+    view: params.view,
+    partyName,
+    totalDefinitif: totalDef,
+    totalPrononce: totalPro,
+  });
+  const canonical = buildCanonical({
+    mandat: params.mandat,
+    certainty: params.certainty,
+    partiSlug: params.parti,
+    view: params.view,
+  });
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: { title, description, type: "website" },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default async function CondamnationsPage({ searchParams }: PageProps) {
+  const raw = await searchParams;
+  const parsed = searchParamsSchema.safeParse(raw);
+  const params = parsed.success ? parsed.data : searchParamsSchema.parse({});
+
+  const partyName = await getPartyNameFromSlug(params.parti);
+  const parties = await getPartiesWithAffairs();
+
+  const h1 =
+    params.view === "stats"
+      ? "Taux de condamnation par parti politique"
+      : buildListTitle({
+          mandat: params.mandat,
+          certainty: params.certainty,
+          partyName,
+        });
+
+  const breadcrumbItems: Array<{ label: string; href?: string }> = [
+    { label: "Affaires", href: "/affaires" },
+    { label: "Condamnations" },
+  ];
+
+  // STATS VIEW
+  if (params.view === "stats") {
+    const stats = await getCondamnationsStatsByParty(params.mandat);
+    return (
+      <div className="container mx-auto px-4 pt-4 pb-8">
+        <Breadcrumb items={breadcrumbItems} />
+        <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">{h1}</h1>
+        <p className="text-muted-foreground mb-6">
+          Répartition des responsables politiques condamnés définitivement par leur parti d{"'"}
+          appartenance. Sources vérifiables.
+        </p>
+        <CondamnationsFilters
+          current={{
+            mandat: params.mandat,
+            certainty: params.certainty,
+            parti: params.parti,
+            view: params.view,
+          }}
+          parties={parties.map((p) => ({
+            slug: p.slug as string,
+            shortName: p.shortName,
+            name: p.name,
+          }))}
+        />
+        <CondamnationsStatsTable rows={stats} currentMandat={params.mandat} />
+      </div>
+    );
+  }
+
+  // LIST VIEW
+  const [listDef, listNonDef] = await Promise.all([
+    params.certainty === "prononcee"
+      ? Promise.resolve(null)
+      : getCondamnations({
+          mandat: params.mandat,
+          certainty: "etabli",
+          partiSlug: params.parti,
+          page: params.page,
+          sort: params.sort,
+        }),
+    params.certainty === "etabli"
+      ? Promise.resolve(null)
+      : getCondamnations({
+          mandat: params.mandat,
+          certainty: "prononcee",
+          partiSlug: params.parti,
+          page: params.page,
+          sort: params.sort,
+        }),
+  ]);
+
+  const totalDefinitif = listDef?.total ?? 0;
+  const totalPrononce = listNonDef?.total ?? 0;
+
+  return (
+    <div className="container mx-auto px-4 pt-4 pb-8">
+      <Breadcrumb items={breadcrumbItems} />
+      <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">{h1}</h1>
+      <p className="text-muted-foreground mb-6">
+        {totalDefinitif > 0 &&
+          `${totalDefinitif} condamnation${totalDefinitif !== 1 ? "s" : ""} définitive${totalDefinitif !== 1 ? "s" : ""}`}
+        {totalDefinitif > 0 && totalPrononce > 0 && " · "}
+        {totalPrononce > 0 && `${totalPrononce} en première instance ou en appel`}
+        {totalDefinitif === 0 &&
+          totalPrononce === 0 &&
+          "Aucune décision ne correspond à ces filtres."}
+      </p>
+
+      <CondamnationsFilters
+        current={{
+          mandat: params.mandat,
+          certainty: params.certainty,
+          parti: params.parti,
+          view: params.view,
+        }}
+        parties={parties.map((p) => ({
+          slug: p.slug as string,
+          shortName: p.shortName,
+          name: p.name,
+        }))}
+      />
+
+      {listDef && listDef.affairs.length > 0 && (
+        <section aria-labelledby="heading-definitives" className="mb-10">
+          <h2 id="heading-definitives" className="text-2xl font-display font-bold mb-4">
+            Condamnations définitives
+          </h2>
+          <div className="space-y-3">
+            {listDef.affairs.map((a) => (
+              <CondamnationCard
+                key={a.id}
+                affair={a as Parameters<typeof CondamnationCard>[0]["affair"]}
+                definitif
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {listNonDef && listNonDef.affairs.length > 0 && (
+        <section aria-labelledby="heading-non-definitives" className="mb-10">
+          <h2 id="heading-non-definitives" className="text-2xl font-display font-bold mb-2">
+            Condamnations non définitives
+          </h2>
+          <CondamnationsPresumptionBanner />
+          <div className="space-y-3">
+            {listNonDef.affairs.map((a) => (
+              <CondamnationCard
+                key={a.id}
+                affair={a as Parameters<typeof CondamnationCard>[0]["affair"]}
+                definitif={false}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Methodology footer */}
+      <section className="mt-12 border-t border-border pt-6">
+        <h2 className="text-xl font-semibold mb-2">Méthodologie</h2>
+        <p className="text-sm text-muted-foreground">
+          Chaque condamnation listée est documentée avec au moins une source journalistique
+          vérifiable ou une décision de justice publiée. Les données proviennent de Wikidata, de la
+          presse, de Judilibre et de contributions modérées. Une personne citée peut demander
+          correction via{" "}
+          <a href="mailto:contact@poligraph.fr" className="text-primary hover:underline">
+            contact@poligraph.fr
+          </a>
+          . Voir la{" "}
+          <a href="/sources" className="text-primary hover:underline">
+            page Sources
+          </a>{" "}
+          pour la méthodologie complète et la{" "}
+          <a href="/docs/api" className="text-primary hover:underline">
+            documentation API
+          </a>{" "}
+          pour la reproduction des données.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/app/affaires/condamnations/page.tsx
+++ b/src/app/affaires/condamnations/page.tsx
@@ -274,15 +274,15 @@ export default async function CondamnationsPage({ searchParams }: PageProps) {
             vérifiable ou une décision de justice publiée. Les données proviennent de Wikidata, de
             la presse, de Judilibre et de contributions modérées. Une personne citée peut demander
             correction via{" "}
-            <a href="mailto:contact@poligraph.fr" className="text-primary hover:underline">
+            <a href="mailto:contact@poligraph.fr" className="text-primary underline">
               contact@poligraph.fr
             </a>
             . Voir la{" "}
-            <a href="/sources" className="text-primary hover:underline">
+            <a href="/sources" className="text-primary underline">
               page Sources
             </a>{" "}
             pour la méthodologie complète et la{" "}
-            <a href="/docs/api" className="text-primary hover:underline">
+            <a href="/docs/api" className="text-primary underline">
               documentation API
             </a>{" "}
             pour la reproduction des données.

--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -278,6 +278,23 @@ export default async function AffairesPage({ searchParams }: PageProps) {
           superCounts={superCounts}
         />
 
+        {/* Condamnations hub callout when ETABLI certainty is active */}
+        {certaintyFilter === "ETABLI" && (
+          <div className="mb-4 rounded-lg border border-primary/30 bg-primary/5 p-3 flex items-center justify-between gap-3 flex-wrap">
+            <p className="text-sm">
+              Une page dédiée aux condamnations est désormais disponible, avec vue par mandat et
+              taux par parti.
+            </p>
+            <Link
+              href="/affaires/condamnations?certainty=etabli"
+              className="text-sm font-medium text-primary hover:underline"
+              prefetch={false}
+            >
+              Voir le hub Condamnations →
+            </Link>
+          </div>
+        )}
+
         {/* Active filters summary */}
         {(searchFilter || superCatFilter || certaintyFilter || categoryFilter || partiFilter) && (
           <div className="mb-6 flex items-center gap-2 text-sm flex-wrap">

--- a/src/app/partis/[slug]/page.tsx
+++ b/src/app/partis/[slug]/page.tsx
@@ -99,14 +99,31 @@ export default async function PartyPage({ params }: PageProps) {
     notFound();
   }
 
-  const [leadershipMandates, partyRoles, pressEnabled, programmeEnabled, partyPlatform] =
-    await Promise.all([
-      getPartyLeadership(party.id, party.name),
-      getPartyRoles(party.id),
-      isFeatureEnabled("PRESS_SECTION"),
-      isFeatureEnabled("PROGRAMMES_ENABLED"),
-      getPartyPlatform(slug),
-    ]);
+  const [
+    leadershipMandates,
+    partyRoles,
+    pressEnabled,
+    programmeEnabled,
+    partyPlatform,
+    nCondamnesDef,
+  ] = await Promise.all([
+    getPartyLeadership(party.id, party.name),
+    getPartyRoles(party.id),
+    isFeatureEnabled("PRESS_SECTION"),
+    isFeatureEnabled("PROGRAMMES_ENABLED"),
+    getPartyPlatform(slug),
+    db.affair.count({
+      where: {
+        publicationStatus: "PUBLISHED",
+        involvement: { in: ["DIRECT", "INDIRECT"] },
+        status: "CONDAMNATION_DEFINITIVE",
+        OR: [
+          { partyAtTime: { slug: party.slug } },
+          { politician: { currentParty: { slug: party.slug } } },
+        ],
+      },
+    }),
+  ]);
   const currentLeaders = leadershipMandates.filter((m) => m.isCurrent);
   const pastLeaders = leadershipMandates.filter((m) => !m.isCurrent);
 
@@ -594,6 +611,20 @@ export default async function PartyPage({ params }: PageProps) {
                             />
                           </svg>
                         </Link>
+                      )}
+
+                      {nCondamnesDef > 0 && party.slug && (
+                        <p className="text-sm mt-2">
+                          <Link
+                            href={`/affaires/condamnations?parti=${party.slug}&certainty=etabli`}
+                            className="text-primary hover:underline"
+                            prefetch={false}
+                          >
+                            {nCondamnesDef} condamnation
+                            {nCondamnesDef !== 1 ? "s" : ""} définitive
+                            {nCondamnesDef !== 1 ? "s" : ""} →
+                          </Link>
+                        </p>
                       )}
                     </CardContent>
                   </Card>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -207,6 +207,63 @@ async function buildStaticAndPoliticiansSitemap(): Promise<MetadataRoute.Sitemap
 
 // Sitemap 1: Affairs + parties + elections + departments (priority 0.6-0.7)
 async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<MetadataRoute.Sitemap> {
+  const lastAffairUpdate = await db.affair.findFirst({
+    where: {
+      publicationStatus: "PUBLISHED",
+      status: {
+        in: ["CONDAMNATION_DEFINITIVE", "CONDAMNATION_PREMIERE_INSTANCE", "APPEL_EN_COURS"],
+      },
+    },
+    orderBy: { updatedAt: "desc" },
+    select: { updatedAt: true },
+  });
+  const condamnationsLastmod = lastAffairUpdate?.updatedAt ?? new Date();
+
+  const condamnationsEntries: MetadataRoute.Sitemap = [
+    {
+      url: `${SITE_URL}/affaires/condamnations`,
+      lastModified: condamnationsLastmod,
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/affaires/condamnations?mandat=depute`,
+      lastModified: condamnationsLastmod,
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/affaires/condamnations?mandat=senateur`,
+      lastModified: condamnationsLastmod,
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/affaires/condamnations?mandat=gouvernement`,
+      lastModified: condamnationsLastmod,
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/affaires/condamnations?mandat=locaux`,
+      lastModified: condamnationsLastmod,
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/affaires/condamnations?certainty=etabli`,
+      lastModified: condamnationsLastmod,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/affaires/condamnations?view=stats`,
+      lastModified: condamnationsLastmod,
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    },
+  ];
+
   const [affairs, parties, partiesWithAffairs, elections] = await Promise.all([
     db.affair.findMany({
       where: { publicationStatus: "PUBLISHED" },
@@ -285,6 +342,7 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
   ];
 
   return [
+    ...condamnationsEntries,
     ...affairPages,
     ...partyPages,
     ...partyAffairPages,

--- a/src/components/affairs/CondamnationCard.tsx
+++ b/src/components/affairs/CondamnationCard.tsx
@@ -1,0 +1,164 @@
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
+import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
+import {
+  AFFAIR_SUPER_CATEGORY_COLORS,
+  AFFAIR_SUPER_CATEGORY_LABELS,
+  CATEGORY_TO_SUPER,
+} from "@/config/labels";
+
+type Affair = {
+  id: string;
+  slug: string;
+  title: string;
+  status: string;
+  category: keyof typeof CATEGORY_TO_SUPER;
+  severity: string;
+  involvement: string;
+  verdictDate: Date | null;
+  startDate: Date | null;
+  factsDate: Date | null;
+  sentence: string | null;
+  politicianId: string;
+  partyAtTimeId: string | null;
+  partyAtTime: {
+    id: string;
+    slug: string | null;
+    shortName: string;
+    name: string;
+    foundedDate: Date | null;
+  } | null;
+  politician: {
+    id: string;
+    slug: string;
+    firstName: string;
+    lastName: string;
+    fullName: string;
+    photoUrl: string | null;
+    currentParty: {
+      id: string;
+      slug: string | null;
+      shortName: string;
+      name: string;
+      foundedDate: Date | null;
+    } | null;
+  };
+  sources: { id: string }[];
+};
+
+export function CondamnationCard({ affair, definitif }: { affair: Affair; definitif: boolean }) {
+  const superCat = CATEGORY_TO_SUPER[affair.category];
+  const partyDisplay = getAffairPartyDisplay({
+    factsDate: affair.factsDate,
+    partyAtTime: affair.partyAtTime,
+    currentParty: affair.politician.currentParty,
+  });
+  const displayDate = affair.verdictDate || affair.startDate || affair.factsDate;
+  const year = displayDate ? new Date(displayDate).getFullYear() : null;
+
+  return (
+    <Card
+      data-definitif={definitif}
+      className="border-l-4 transition-shadow hover:shadow-md"
+      style={{
+        borderLeftColor: definitif ? "#166534" : "#b45309",
+      }}
+    >
+      <CardContent className="pt-6">
+        <div className="flex gap-4">
+          <PoliticianAvatar
+            firstName={affair.politician.firstName}
+            lastName={affair.politician.lastName}
+            photoUrl={affair.politician.photoUrl}
+            size="sm"
+          />
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-start gap-2 mb-2">
+              {year && (
+                <Badge variant="secondary" className="font-mono text-base">
+                  {year}
+                </Badge>
+              )}
+              <Badge className={AFFAIR_SUPER_CATEGORY_COLORS[superCat]}>
+                {AFFAIR_SUPER_CATEGORY_LABELS[superCat]}
+              </Badge>
+              {definitif ? (
+                <Badge className="bg-green-100 text-green-900 border-green-300">
+                  Condamnation définitive
+                </Badge>
+              ) : (
+                <Badge className="bg-amber-100 text-amber-900 border-amber-300">
+                  Non définitif
+                </Badge>
+              )}
+            </div>
+
+            <h3 className="text-lg font-semibold mb-1">
+              <Link href={`/affaires/${affair.slug}`} className="hover:underline" prefetch={false}>
+                {affair.title}
+              </Link>
+            </h3>
+
+            <p className="text-sm">
+              <Link
+                href={`/politiques/${affair.politician.slug}`}
+                className="text-primary hover:underline font-medium"
+                prefetch={false}
+              >
+                {affair.politician.fullName}
+              </Link>
+              {partyDisplay.kind === "at-time" && partyDisplay.party.slug && (
+                <>
+                  {" ("}
+                  <Link
+                    href={`/affaires/parti/${partyDisplay.party.slug}`}
+                    className="text-muted-foreground hover:underline"
+                    prefetch={false}
+                  >
+                    {partyDisplay.party.shortName}
+                  </Link>
+                  {!partyDisplay.sameAsCurrent && (
+                    <span className="text-xs text-muted-foreground"> à l{"'"}époque</span>
+                  )}
+                  {")"}
+                </>
+              )}
+              {partyDisplay.kind === "current" && (
+                <span className="text-muted-foreground">
+                  {" ("}
+                  {partyDisplay.party.shortName}
+                  {")"}
+                </span>
+              )}
+            </p>
+
+            {affair.sentence && (
+              <p className="text-sm mt-2">
+                <span className="font-medium">
+                  {definitif ? "Peine :" : "Peine prononcée (susceptible d'appel/cassation) :"}
+                </span>{" "}
+                {affair.sentence}
+              </p>
+            )}
+
+            <div className="flex items-center gap-3 text-xs text-muted-foreground mt-3">
+              <span>
+                {affair.sources.length} source
+                {affair.sources.length !== 1 ? "s" : ""}
+              </span>
+              <Link
+                href={`/affaires/${affair.slug}`}
+                className="text-primary hover:underline"
+                prefetch={false}
+              >
+                Voir les détails →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/affairs/CondamnationsFilters.tsx
+++ b/src/components/affairs/CondamnationsFilters.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+
+type FilterValues = {
+  mandat?: string;
+  certainty: string;
+  parti?: string;
+  view: string;
+};
+
+const MANDAT_OPTIONS = [
+  { key: "", label: "Tous mandats" },
+  { key: "depute", label: "Députés" },
+  { key: "senateur", label: "Sénateurs" },
+  { key: "gouvernement", label: "Ministres" },
+  { key: "locaux", label: "Élus locaux" },
+];
+
+const CERTAINTY_OPTIONS = [
+  { key: "tous", label: "Toutes" },
+  { key: "etabli", label: "Définitives" },
+  { key: "prononcee", label: "Non définitives" },
+];
+
+const VIEW_OPTIONS = [
+  { key: "list", label: "Liste" },
+  { key: "stats", label: "Taux par parti" },
+];
+
+export function CondamnationsFilters({
+  current,
+  parties,
+}: {
+  current: FilterValues;
+  parties: Array<{ slug: string; shortName: string; name: string }>;
+}) {
+  const buildHref = useMemo(
+    () => (patch: Partial<FilterValues>) => {
+      const params = new URLSearchParams();
+      const next = { ...current, ...patch };
+      if (next.mandat) params.set("mandat", next.mandat);
+      if (next.certainty && next.certainty !== "tous") params.set("certainty", next.certainty);
+      if (next.parti) params.set("parti", next.parti);
+      if (next.view === "stats") params.set("view", "stats");
+      const qs = params.toString();
+      return `/affaires/condamnations${qs ? `?${qs}` : ""}`;
+    },
+    [current]
+  );
+
+  return (
+    <div className="flex flex-col gap-3 mb-6" role="group" aria-label="Filtres de la liste">
+      <FilterGroup
+        legend="Type de mandat"
+        options={MANDAT_OPTIONS}
+        currentKey={current.mandat ?? ""}
+        onHref={(key) => buildHref({ mandat: key || undefined })}
+      />
+      <FilterGroup
+        legend="Niveau de décision"
+        options={CERTAINTY_OPTIONS}
+        currentKey={current.certainty}
+        onHref={(key) => buildHref({ certainty: key })}
+      />
+      <FilterGroup
+        legend="Mode d'affichage"
+        options={VIEW_OPTIONS}
+        currentKey={current.view}
+        onHref={(key) => buildHref({ view: key })}
+      />
+      <details className="text-sm">
+        <summary className="cursor-pointer font-medium py-2">Filtrer par parti</summary>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {current.parti && (
+            <Link
+              href={buildHref({ parti: undefined })}
+              className="inline-flex items-center gap-1 h-9 px-3 rounded-full border border-primary bg-primary/10 hover:bg-primary/20 text-sm"
+              aria-label="Retirer le filtre parti"
+            >
+              ✕ {parties.find((p) => p.slug === current.parti)?.shortName ?? current.parti}
+            </Link>
+          )}
+          {parties.slice(0, 20).map((p) => (
+            <Link
+              key={p.slug}
+              href={buildHref({ parti: p.slug })}
+              aria-current={current.parti === p.slug ? "true" : undefined}
+              className={`inline-flex items-center h-9 px-3 rounded-full border text-sm hover:bg-muted ${
+                current.parti === p.slug ? "border-primary bg-primary/10" : ""
+              }`}
+              prefetch={false}
+            >
+              {p.shortName}
+            </Link>
+          ))}
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function FilterGroup({
+  legend,
+  options,
+  currentKey,
+  onHref,
+}: {
+  legend: string;
+  options: Array<{ key: string; label: string }>;
+  currentKey: string;
+  onHref: (key: string) => string;
+}) {
+  return (
+    <fieldset>
+      <legend className="text-xs font-medium text-muted-foreground mb-1">{legend}</legend>
+      <div className="flex flex-wrap gap-2" role="radiogroup" aria-label={legend}>
+        {options.map((opt) => {
+          const active = currentKey === opt.key;
+          return (
+            <Link
+              key={opt.key || "__empty"}
+              href={onHref(opt.key)}
+              role="radio"
+              aria-checked={active}
+              className={`inline-flex items-center justify-center min-h-11 px-4 rounded-full border text-sm transition-colors hover:bg-muted ${
+                active ? "border-primary bg-primary/10 font-medium" : ""
+              }`}
+              prefetch={false}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/components/affairs/CondamnationsPresumptionBanner.tsx
+++ b/src/components/affairs/CondamnationsPresumptionBanner.tsx
@@ -1,0 +1,31 @@
+import { AlertTriangle } from "lucide-react";
+
+export function CondamnationsPresumptionBanner() {
+  return (
+    <aside
+      role="note"
+      aria-labelledby="presumption-banner-title"
+      className="my-4 rounded-lg border border-amber-200 bg-amber-50/60 p-4 dark:border-amber-800 dark:bg-amber-950/30"
+    >
+      <div className="flex gap-3">
+        <AlertTriangle
+          className="h-5 w-5 shrink-0 text-amber-700 dark:text-amber-400"
+          aria-hidden="true"
+        />
+        <div>
+          <h3
+            id="presumption-banner-title"
+            className="font-semibold text-amber-900 dark:text-amber-200 mb-1"
+          >
+            Décisions non définitives
+          </h3>
+          <p className="text-sm text-amber-900/90 dark:text-amber-200/90">
+            Les condamnations présentées ci-dessous ont été prononcées en première instance ou en
+            appel. Elles ne sont pas définitives : la présomption d{"'"}innocence s{"'"}applique
+            tant que les voies de recours ne sont pas épuisées.
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/affairs/CondamnationsStatsTable.tsx
+++ b/src/components/affairs/CondamnationsStatsTable.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import type { CondamnationsPartyStats } from "@/lib/data/condamnations";
+
+function formatPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+export function CondamnationsStatsTable({
+  rows,
+  currentMandat,
+}: {
+  rows: CondamnationsPartyStats[];
+  currentMandat?: string;
+}) {
+  const maxTaux = Math.max(...rows.map((r) => r.tauxDefinitif), 0.01);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-sm" aria-describedby="stats-caption">
+        <caption id="stats-caption" className="sr-only">
+          Nombre et taux de responsables politiques condamnés définitivement par parti
+          {currentMandat ? `, filtré sur le mandat ${currentMandat}` : ""}.
+        </caption>
+        <thead>
+          <tr className="border-b-2 border-border">
+            <th scope="col" className="text-left py-3 px-2 font-semibold">
+              Parti
+            </th>
+            <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
+              Élus suivis
+            </th>
+            <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
+              Condamnés définitifs
+            </th>
+            <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
+              Taux
+            </th>
+            <th scope="col" className="text-left py-3 px-2 font-semibold">
+              Détails
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => {
+            const bar = (r.tauxDefinitif / maxTaux) * 100;
+            return (
+              <tr key={r.partyId} className="border-b border-border hover:bg-muted/30">
+                <th scope="row" className="text-left py-3 px-2 font-medium">
+                  <Link
+                    href={`/partis/${r.partySlug}`}
+                    className="hover:underline"
+                    prefetch={false}
+                  >
+                    {r.partyName}
+                    <span className="text-muted-foreground ml-1">({r.partyShortName})</span>
+                  </Link>
+                </th>
+                <td className="text-right py-3 px-2 tabular-nums">{r.nSuivis}</td>
+                <td className="text-right py-3 px-2 tabular-nums">{r.nCondamnesDefinitifs}</td>
+                <td className="text-right py-3 px-2 tabular-nums">
+                  <div className="flex items-center justify-end gap-2">
+                    <span>{formatPct(r.tauxDefinitif)}</span>
+                    <svg
+                      width="60"
+                      height="8"
+                      viewBox="0 0 60 8"
+                      aria-hidden="true"
+                      className="shrink-0"
+                    >
+                      <rect width="60" height="8" fill="currentColor" opacity="0.1" />
+                      <rect width={bar * 0.6} height="8" fill="currentColor" opacity="0.7" />
+                    </svg>
+                  </div>
+                </td>
+                <td className="py-3 px-2">
+                  <Link
+                    href={`/affaires/condamnations?parti=${r.partySlug}&certainty=etabli${currentMandat ? `&mandat=${currentMandat}` : ""}`}
+                    className="text-primary hover:underline"
+                    prefetch={false}
+                  >
+                    Voir →
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <p className="text-xs text-muted-foreground mt-3">
+        Parti affiché si au moins 3 élus suivis ou 1 condamnation définitive. Le taux dépend aussi
+        de la visibilité médiatique, pas uniquement de la criminalité réelle.
+      </p>
+    </div>
+  );
+}

--- a/src/components/affairs/__tests__/CondamnationCard.test.tsx
+++ b/src/components/affairs/__tests__/CondamnationCard.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { CondamnationCard } from "../CondamnationCard";
+
+const baseAffair = {
+  id: "aff1",
+  slug: "test-affair",
+  title: "Affaire de test",
+  status: "CONDAMNATION_DEFINITIVE" as const,
+  category: "CORRUPTION" as const,
+  severity: "GRAVE" as const,
+  involvement: "DIRECT" as const,
+  verdictDate: new Date("2024-06-15"),
+  startDate: null,
+  factsDate: null,
+  sentence: "3 ans avec sursis, 15 000 € d'amende",
+  politicianId: "pol1",
+  partyAtTimeId: null,
+  partyAtTime: null,
+  politician: {
+    id: "pol1",
+    slug: "jean-test",
+    firstName: "Jean",
+    lastName: "Test",
+    fullName: "Jean Test",
+    photoUrl: null,
+    currentParty: null,
+  },
+  sources: [{ id: "s1" }, { id: "s2" }],
+} as unknown as Parameters<typeof CondamnationCard>[0]["affair"];
+
+describe("CondamnationCard", () => {
+  it("renders a definitive conviction", () => {
+    const { container, getByText } = render(<CondamnationCard affair={baseAffair} definitif />);
+    expect(getByText("Affaire de test")).toBeTruthy();
+    expect(getByText("Jean Test")).toBeTruthy();
+    expect(container.querySelector('[data-definitif="true"]')).toBeTruthy();
+  });
+
+  it("renders a non-definitive conviction with prononcee label", () => {
+    const nonDef = {
+      ...baseAffair,
+      status: "CONDAMNATION_PREMIERE_INSTANCE",
+    };
+    const { getAllByText } = render(<CondamnationCard affair={nonDef} definitif={false} />);
+    expect(getAllByText(/non définitif/i, { exact: false }).length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -479,6 +479,53 @@ interface CollectionPageJsonLdProps {
   };
 }
 
+export function DatasetJsonLd({
+  name,
+  description,
+  url,
+}: {
+  name: string;
+  description: string;
+  url: string;
+}) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    name,
+    description,
+    creator: { "@type": "Organization", name: "Poligraph", url: "https://poligraph.fr" },
+    license: "https://creativecommons.org/licenses/by-sa/4.0/",
+    distribution: [{ "@type": "DataDownload", encodingFormat: "text/html", contentUrl: url }],
+  };
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }} />
+  );
+}
+
+export function AffairItemListJsonLd({
+  name,
+  items,
+}: {
+  name: string;
+  items: Array<{ url: string; name: string }>;
+}) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name,
+    numberOfItems: items.length,
+    itemListElement: items.map((it, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: it.url,
+      name: it.name,
+    })),
+  };
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }} />
+  );
+}
+
 export function CollectionPageJsonLd({
   name,
   description,

--- a/src/components/stats/JudicialSection.tsx
+++ b/src/components/stats/JudicialSection.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   AFFAIR_SUPER_CATEGORY_LABELS,
@@ -83,6 +84,23 @@ export function JudicialSection({
 
   return (
     <section aria-labelledby="judicial-heading" className="py-8 overflow-x-hidden">
+      <div className="flex flex-wrap gap-3 mb-6 text-sm">
+        <Link
+          href="/affaires/condamnations?view=stats"
+          className="inline-flex items-center gap-1 text-primary hover:underline"
+          prefetch={false}
+        >
+          Voir le taux de condamnation par parti →
+        </Link>
+        <Link
+          href="/affaires/condamnations?certainty=etabli"
+          className="inline-flex items-center gap-1 text-primary hover:underline"
+          prefetch={false}
+        >
+          Liste complète des condamnés définitifs →
+        </Link>
+      </div>
+
       {/* Hemicycle visualization */}
       {hemicycleGroups.length > 0 && (
         <Card className="mb-8">

--- a/src/lib/data/__tests__/condamnations.test.ts
+++ b/src/lib/data/__tests__/condamnations.test.ts
@@ -1,0 +1,38 @@
+import { vi } from "vitest";
+
+vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
+vi.mock("@/lib/db", () => ({
+  db: {
+    affair: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}));
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { getCondamnations } from "../condamnations";
+import { db } from "@/lib/db";
+import type { Mock } from "vitest";
+
+const mockFindMany = db.affair.findMany as Mock;
+const mockCount = db.affair.count as Mock;
+
+describe("getCondamnations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+  });
+
+  it("returns a paginated list with default filters (no mandat, certainty=tous)", async () => {
+    const result = await getCondamnations({});
+    expect(result).toHaveProperty("affairs");
+    expect(result).toHaveProperty("total");
+    expect(result).toHaveProperty("totalPages");
+    expect(result).toHaveProperty("page");
+    expect(Array.isArray(result.affairs)).toBe(true);
+    expect(result.affairs.length).toBeLessThanOrEqual(30);
+    expect(result.page).toBe(1);
+  });
+});

--- a/src/lib/data/__tests__/condamnations.test.ts
+++ b/src/lib/data/__tests__/condamnations.test.ts
@@ -35,4 +35,57 @@ describe("getCondamnations", () => {
     expect(result.affairs.length).toBeLessThanOrEqual(30);
     expect(result.page).toBe(1);
   });
+
+  it("passes mandat=depute as mandates.some.type filter", async () => {
+    await getCondamnations({ mandat: "depute" });
+    expect(mockFindMany).toHaveBeenCalledOnce();
+    const args = mockFindMany.mock.calls[0]![0];
+    expect(args.where.politician.mandates.some.type.in).toEqual(["DEPUTE", "DEPUTE_EUROPEEN"]);
+  });
+
+  it("passes certainty=etabli as status filter (single status)", async () => {
+    await getCondamnations({ certainty: "etabli" });
+    const args = mockFindMany.mock.calls[0]![0];
+    expect(args.where.status.in).toEqual(["CONDAMNATION_DEFINITIVE"]);
+  });
+
+  it("passes certainty=prononcee as status filter (two statuses)", async () => {
+    await getCondamnations({ certainty: "prononcee" });
+    const args = mockFindMany.mock.calls[0]![0];
+    expect(args.where.status.in).toEqual(["CONDAMNATION_PREMIERE_INSTANCE", "APPEL_EN_COURS"]);
+  });
+
+  it("omits status filter when certainty=tous (default)", async () => {
+    await getCondamnations({});
+    const args = mockFindMany.mock.calls[0]![0];
+    expect(args.where.status).toBeUndefined();
+  });
+
+  it("applies partiSlug as OR clause on partyAtTime and currentParty", async () => {
+    await getCondamnations({ partiSlug: "rn" });
+    const args = mockFindMany.mock.calls[0]![0];
+    expect(args.where.OR).toEqual([
+      { partyAtTime: { slug: "rn" } },
+      { politician: { currentParty: { slug: "rn" } } },
+    ]);
+  });
+
+  it("applies pagination correctly (page 2 skips 30)", async () => {
+    await getCondamnations({ page: 2 });
+    const args = mockFindMany.mock.calls[0]![0];
+    expect(args.skip).toBe(30);
+    expect(args.take).toBe(30);
+  });
+
+  it("default sort uses verdictDate desc then startDate desc", async () => {
+    await getCondamnations({});
+    const args = mockFindMany.mock.calls[0]![0];
+    expect(args.orderBy[0]).toEqual({ verdictDate: "desc" });
+  });
+
+  it("sort=nom uses politician lastName asc", async () => {
+    await getCondamnations({ sort: "nom" });
+    const args = mockFindMany.mock.calls[0]![0];
+    expect(args.orderBy[0]).toEqual({ politician: { lastName: "asc" } });
+  });
 });

--- a/src/lib/data/__tests__/condamnations.test.ts
+++ b/src/lib/data/__tests__/condamnations.test.ts
@@ -104,23 +104,23 @@ describe("getCondamnationsStatsByParty", () => {
         partySlug: "rn",
         partyShortName: "RN",
         partyName: "Rassemblement National",
-        nSuivis: 100n,
-        nCondamnesDefinitifs: 10n,
-        nCondamnesPrononces: 3n,
+        nSuivis: BigInt(100),
+        nCondamnesDefinitifs: BigInt(10),
+        nCondamnesPrononces: BigInt(3),
       },
       {
         partyId: "p2",
         partySlug: "lr",
         partyShortName: "LR",
         partyName: "Les Républicains",
-        nSuivis: 50n,
-        nCondamnesDefinitifs: 0n,
-        nCondamnesPrononces: 1n,
+        nSuivis: BigInt(50),
+        nCondamnesDefinitifs: BigInt(0),
+        nCondamnesPrononces: BigInt(1),
       },
     ]);
     const rows = await getCondamnationsStatsByParty();
     expect(rows).toHaveLength(2);
-    expect(rows[0]).toMatchObject({
+    expect(rows[0]!).toMatchObject({
       partyId: "p1",
       partySlug: "rn",
       partyShortName: "RN",
@@ -129,7 +129,7 @@ describe("getCondamnationsStatsByParty", () => {
       nCondamnesPrononces: 3,
       tauxDefinitif: 0.1,
     });
-    expect(rows[1].tauxDefinitif).toBe(0);
+    expect(rows[1]!.tauxDefinitif).toBe(0);
   });
 
   it("handles empty result", async () => {
@@ -145,14 +145,14 @@ describe("getCondamnationsStatsByParty", () => {
         partySlug: "x",
         partyShortName: "X",
         partyName: "X Party",
-        nSuivis: 0n,
-        nCondamnesDefinitifs: 0n,
-        nCondamnesPrononces: 0n,
+        nSuivis: BigInt(0),
+        nCondamnesDefinitifs: BigInt(0),
+        nCondamnesPrononces: BigInt(0),
       },
     ]);
     const rows = await getCondamnationsStatsByParty();
-    expect(rows[0].nSuivis).toBe(0);
-    expect(rows[0].nCondamnesDefinitifs).toBe(0);
-    expect(rows[0].tauxDefinitif).toBe(0); // division by zero guard
+    expect(rows[0]!.nSuivis).toBe(0);
+    expect(rows[0]!.nCondamnesDefinitifs).toBe(0);
+    expect(rows[0]!.tauxDefinitif).toBe(0); // division by zero guard
   });
 });

--- a/src/lib/data/__tests__/condamnations.test.ts
+++ b/src/lib/data/__tests__/condamnations.test.ts
@@ -7,16 +7,18 @@ vi.mock("@/lib/db", () => ({
       findMany: vi.fn(),
       count: vi.fn(),
     },
+    $queryRaw: vi.fn(),
   },
 }));
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { getCondamnations } from "../condamnations";
+import { getCondamnations, getCondamnationsStatsByParty } from "../condamnations";
 import { db } from "@/lib/db";
 import type { Mock } from "vitest";
 
 const mockFindMany = db.affair.findMany as Mock;
 const mockCount = db.affair.count as Mock;
+const mockQueryRaw = db.$queryRaw as Mock;
 
 describe("getCondamnations", () => {
   beforeEach(() => {
@@ -87,5 +89,70 @@ describe("getCondamnations", () => {
     await getCondamnations({ sort: "nom" });
     const args = mockFindMany.mock.calls[0]![0];
     expect(args.orderBy[0]).toEqual({ politician: { lastName: "asc" } });
+  });
+});
+
+describe("getCondamnationsStatsByParty", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns stats with calculated tauxDefinitif from DB counts", async () => {
+    mockQueryRaw.mockResolvedValue([
+      {
+        partyId: "p1",
+        partySlug: "rn",
+        partyShortName: "RN",
+        partyName: "Rassemblement National",
+        nSuivis: 100n,
+        nCondamnesDefinitifs: 10n,
+        nCondamnesPrononces: 3n,
+      },
+      {
+        partyId: "p2",
+        partySlug: "lr",
+        partyShortName: "LR",
+        partyName: "Les Républicains",
+        nSuivis: 50n,
+        nCondamnesDefinitifs: 0n,
+        nCondamnesPrononces: 1n,
+      },
+    ]);
+    const rows = await getCondamnationsStatsByParty();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      partyId: "p1",
+      partySlug: "rn",
+      partyShortName: "RN",
+      nSuivis: 100,
+      nCondamnesDefinitifs: 10,
+      nCondamnesPrononces: 3,
+      tauxDefinitif: 0.1,
+    });
+    expect(rows[1].tauxDefinitif).toBe(0);
+  });
+
+  it("handles empty result", async () => {
+    mockQueryRaw.mockResolvedValue([]);
+    const rows = await getCondamnationsStatsByParty();
+    expect(rows).toEqual([]);
+  });
+
+  it("converts bigint DB counts to number safely", async () => {
+    mockQueryRaw.mockResolvedValue([
+      {
+        partyId: "p1",
+        partySlug: "x",
+        partyShortName: "X",
+        partyName: "X Party",
+        nSuivis: 0n,
+        nCondamnesDefinitifs: 0n,
+        nCondamnesPrononces: 0n,
+      },
+    ]);
+    const rows = await getCondamnationsStatsByParty();
+    expect(rows[0].nSuivis).toBe(0);
+    expect(rows[0].nCondamnesDefinitifs).toBe(0);
+    expect(rows[0].tauxDefinitif).toBe(0); // division by zero guard
   });
 });

--- a/src/lib/data/condamnations.ts
+++ b/src/lib/data/condamnations.ts
@@ -114,7 +114,10 @@ export async function getCondamnations(filters: CondamnationsFilters) {
   ]);
 
   return {
-    affairs,
+    affairs: affairs.map((a) => ({
+      ...a,
+      fineAmount: a.fineAmount !== null ? Number(a.fineAmount) : null,
+    })),
     total,
     totalPages: Math.ceil(total / PAGE_SIZE) || 1,
     page,

--- a/src/lib/data/condamnations.ts
+++ b/src/lib/data/condamnations.ts
@@ -134,3 +134,69 @@ function orderByForSort(
       return [{ verdictDate: "desc" }, { startDate: "desc" }, { createdAt: "desc" }];
   }
 }
+
+export interface CondamnationsPartyStats {
+  partyId: string;
+  partySlug: string;
+  partyShortName: string;
+  partyName: string;
+  nSuivis: number;
+  nCondamnesDefinitifs: number;
+  nCondamnesPrononces: number;
+  tauxDefinitif: number;
+}
+
+export async function getCondamnationsStatsByParty(
+  mandat?: MandatBucket
+): Promise<CondamnationsPartyStats[]> {
+  "use cache";
+  cacheTag("affairs");
+
+  const mandateTypes = mandat ? MANDAT_BUCKETS[mandat] : undefined;
+
+  const rows = await db.$queryRaw<
+    Array<{
+      partyId: string;
+      partySlug: string;
+      partyShortName: string;
+      partyName: string;
+      nSuivis: bigint;
+      nCondamnesDefinitifs: bigint;
+      nCondamnesPrononces: bigint;
+    }>
+  >`
+    SELECT
+      pt.id AS "partyId",
+      pt.slug AS "partySlug",
+      pt."shortName" AS "partyShortName",
+      pt.name AS "partyName",
+      COUNT(DISTINCT p.id) AS "nSuivis",
+      COUNT(DISTINCT CASE WHEN a.status = 'CONDAMNATION_DEFINITIVE' THEN a."politicianId" END) AS "nCondamnesDefinitifs",
+      COUNT(DISTINCT CASE WHEN a.status IN ('CONDAMNATION_PREMIERE_INSTANCE','APPEL_EN_COURS') THEN a."politicianId" END) AS "nCondamnesPrononces"
+    FROM "Politician" p
+    JOIN "Party" pt ON pt.id = p."currentPartyId"
+    LEFT JOIN "Affair" a ON a."politicianId" = p.id
+      AND a."publicationStatus" = 'PUBLISHED'
+      AND a.involvement IN ('DIRECT','INDIRECT')
+    ${
+      mandateTypes
+        ? Prisma.sql`WHERE EXISTS (SELECT 1 FROM "Mandate" m WHERE m."politicianId" = p.id AND m.type = ANY(${mandateTypes}::"MandateType"[]))`
+        : Prisma.empty
+    }
+    GROUP BY pt.id, pt.slug, pt."shortName", pt.name
+    HAVING COUNT(DISTINCT p.id) >= 3
+        OR COUNT(DISTINCT CASE WHEN a.status = 'CONDAMNATION_DEFINITIVE' THEN a."politicianId" END) >= 1
+    ORDER BY "nCondamnesDefinitifs" DESC, "nSuivis" DESC
+  `;
+
+  return rows.map((r) => ({
+    partyId: r.partyId,
+    partySlug: r.partySlug,
+    partyShortName: r.partyShortName,
+    partyName: r.partyName,
+    nSuivis: Number(r.nSuivis),
+    nCondamnesDefinitifs: Number(r.nCondamnesDefinitifs),
+    nCondamnesPrononces: Number(r.nCondamnesPrononces),
+    tauxDefinitif: Number(r.nSuivis) > 0 ? Number(r.nCondamnesDefinitifs) / Number(r.nSuivis) : 0,
+  }));
+}

--- a/src/lib/data/condamnations.ts
+++ b/src/lib/data/condamnations.ts
@@ -1,4 +1,7 @@
-import type { MandateType, AffairStatus } from "@/generated/prisma";
+import { cacheTag, cacheLife } from "next/cache";
+import { db } from "@/lib/db";
+import { Prisma } from "@/generated/prisma";
+import type { MandateType, AffairStatus, Involvement } from "@/generated/prisma";
 
 export const MANDAT_BUCKETS: Record<string, MandateType[]> = {
   depute: ["DEPUTE", "DEPUTE_EUROPEEN"],
@@ -40,4 +43,94 @@ export interface CondamnationsFilters {
   partiSlug?: string;
   page?: number;
   sort?: "date" | "nom" | "severity";
+}
+
+const PAGE_SIZE = 30;
+
+export async function getCondamnations(filters: CondamnationsFilters) {
+  "use cache";
+  cacheTag("affairs");
+  cacheLife("minutes");
+
+  const { mandat, certainty = "tous", partiSlug, page = 1, sort = "date" } = filters;
+
+  const mandateTypes = mandat ? MANDAT_BUCKETS[mandat] : undefined;
+  const statuses = CERTAINTY_STATUS[certainty];
+
+  const where: Prisma.AffairWhereInput = {
+    publicationStatus: "PUBLISHED",
+    involvement: { in: ["DIRECT", "INDIRECT"] as Involvement[] },
+    ...(statuses !== "all" && { status: { in: statuses } }),
+    ...(mandateTypes && {
+      politician: {
+        mandates: { some: { type: { in: mandateTypes } } },
+      },
+    }),
+    ...(partiSlug && {
+      OR: [
+        { partyAtTime: { slug: partiSlug } },
+        { politician: { currentParty: { slug: partiSlug } } },
+      ],
+    }),
+  };
+
+  const orderBy = orderByForSort(sort);
+
+  const [affairs, total] = await Promise.all([
+    db.affair.findMany({
+      where,
+      include: {
+        politician: {
+          include: {
+            currentParty: {
+              select: {
+                id: true,
+                slug: true,
+                shortName: true,
+                name: true,
+                publicId: true,
+                foundedDate: true,
+              },
+            },
+          },
+        },
+        partyAtTime: {
+          select: {
+            id: true,
+            slug: true,
+            shortName: true,
+            name: true,
+            publicId: true,
+            foundedDate: true,
+          },
+        },
+        sources: { select: { id: true } },
+      },
+      orderBy,
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+    }),
+    db.affair.count({ where }),
+  ]);
+
+  return {
+    affairs,
+    total,
+    totalPages: Math.ceil(total / PAGE_SIZE) || 1,
+    page,
+  };
+}
+
+function orderByForSort(
+  sort: "date" | "nom" | "severity"
+): Prisma.AffairOrderByWithRelationInput[] {
+  switch (sort) {
+    case "nom":
+      return [{ politician: { lastName: "asc" } }, { politician: { firstName: "asc" } }];
+    case "severity":
+      return [{ severity: "asc" }, { verdictDate: "desc" }];
+    case "date":
+    default:
+      return [{ verdictDate: "desc" }, { startDate: "desc" }, { createdAt: "desc" }];
+  }
 }

--- a/src/lib/data/condamnations.ts
+++ b/src/lib/data/condamnations.ts
@@ -1,0 +1,43 @@
+import type { MandateType, AffairStatus } from "@/generated/prisma";
+
+export const MANDAT_BUCKETS: Record<string, MandateType[]> = {
+  depute: ["DEPUTE", "DEPUTE_EUROPEEN"],
+  senateur: ["SENATEUR"],
+  gouvernement: [
+    "PRESIDENT_REPUBLIQUE",
+    "PREMIER_MINISTRE",
+    "MINISTRE",
+    "SECRETAIRE_ETAT",
+    "MINISTRE_DELEGUE",
+  ],
+  locaux: [
+    "MAIRE",
+    "ADJOINT_MAIRE",
+    "PRESIDENT_REGION",
+    "PRESIDENT_DEPARTEMENT",
+    "CONSEILLER_REGIONAL",
+    "CONSEILLER_DEPARTEMENTAL",
+    "CONSEILLER_MUNICIPAL",
+  ],
+};
+
+export type MandatBucket = keyof typeof MANDAT_BUCKETS;
+
+export const CERTAINTY_STATUS: Record<"etabli" | "prononcee" | "tous", AffairStatus[] | "all"> = {
+  etabli: ["CONDAMNATION_DEFINITIVE"],
+  // APPEL_EN_COURS is included because Poligraph convention is: appeal filed
+  // AFTER first-instance conviction. Marginal "acquittal + prosecution appeal"
+  // cases are rare and remain visible in the `sentence` field.
+  prononcee: ["CONDAMNATION_PREMIERE_INSTANCE", "APPEL_EN_COURS"],
+  tous: "all",
+};
+
+export type CertaintyKey = keyof typeof CERTAINTY_STATUS;
+
+export interface CondamnationsFilters {
+  mandat?: MandatBucket;
+  certainty?: CertaintyKey;
+  partiSlug?: string;
+  page?: number;
+  sort?: "date" | "nom" | "severity";
+}

--- a/src/lib/seo/__tests__/condamnations-metadata.test.ts
+++ b/src/lib/seo/__tests__/condamnations-metadata.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { buildListTitle, buildDescription, buildCanonical } from "../condamnations-metadata";
+
+describe("buildListTitle", () => {
+  it("default (no filter)", () => {
+    expect(buildListTitle({ certainty: "tous" })).toBe(
+      "Responsables politiques français condamnés"
+    );
+  });
+
+  it("with mandat=depute", () => {
+    expect(buildListTitle({ mandat: "depute", certainty: "tous" })).toBe(
+      "Députés français condamnés"
+    );
+  });
+
+  it("with mandat=depute and certainty=etabli", () => {
+    expect(buildListTitle({ mandat: "depute", certainty: "etabli" })).toBe(
+      "Députés français condamnés définitivement"
+    );
+  });
+
+  it("with party name", () => {
+    expect(
+      buildListTitle({
+        certainty: "etabli",
+        partyName: "Rassemblement National (RN)",
+      })
+    ).toBe(
+      "Responsables politiques français condamnés définitivement — Rassemblement National (RN)"
+    );
+  });
+});
+
+describe("buildCanonical", () => {
+  it("default returns /affaires/condamnations", () => {
+    expect(buildCanonical({ certainty: "tous", view: "list" })).toBe("/affaires/condamnations");
+  });
+
+  it("includes mandat", () => {
+    expect(buildCanonical({ mandat: "depute", certainty: "tous", view: "list" })).toBe(
+      "/affaires/condamnations?mandat=depute"
+    );
+  });
+
+  it("omits certainty=tous from canonical", () => {
+    expect(buildCanonical({ mandat: "depute", certainty: "tous", view: "list" })).not.toContain(
+      "certainty"
+    );
+  });
+
+  it("includes view=stats", () => {
+    expect(buildCanonical({ certainty: "tous", view: "stats" })).toBe(
+      "/affaires/condamnations?view=stats"
+    );
+  });
+
+  it("redirects parti-only canonical to /affaires/parti/[slug]", () => {
+    expect(buildCanonical({ certainty: "tous", view: "list", partiSlug: "rn" })).toBe(
+      "/affaires/parti/rn"
+    );
+  });
+
+  it("keeps parti combined with mandat self-canonical", () => {
+    expect(
+      buildCanonical({
+        mandat: "depute",
+        certainty: "tous",
+        view: "list",
+        partiSlug: "rn",
+      })
+    ).toBe("/affaires/condamnations?mandat=depute&parti=rn");
+  });
+
+  it("excludes page from canonical", () => {
+    expect(
+      buildCanonical({
+        certainty: "etabli",
+        view: "list",
+        page: 3,
+      })
+    ).toBe("/affaires/condamnations?certainty=etabli");
+  });
+});
+
+describe("buildDescription", () => {
+  it("default includes totals", () => {
+    const d = buildDescription({
+      certainty: "tous",
+      view: "list",
+      totalDefinitif: 64,
+      totalPrononce: 32,
+    });
+    expect(d).toContain("64");
+    expect(d).toContain("32");
+    expect(d.length).toBeLessThanOrEqual(165);
+  });
+
+  it("stats view mentions taux", () => {
+    const d = buildDescription({
+      certainty: "tous",
+      view: "stats",
+      totalDefinitif: 64,
+      totalPrononce: 32,
+    });
+    expect(d.toLowerCase()).toContain("taux");
+  });
+});

--- a/src/lib/seo/condamnations-metadata.ts
+++ b/src/lib/seo/condamnations-metadata.ts
@@ -42,7 +42,7 @@ export function buildDescription(input: DescriptionInput): string {
   }
 
   if (input.mandat) {
-    const label = MANDAT_LABEL[input.mandat].toLowerCase();
+    const label = (MANDAT_LABEL[input.mandat as MandatBucket] as string).toLowerCase();
     return `Liste sourcée des ${label} condamnés définitivement ou en cours de procédure. ${input.totalDefinitif} condamnations définitives documentées, présomption d'innocence respectée.`;
   }
 

--- a/src/lib/seo/condamnations-metadata.ts
+++ b/src/lib/seo/condamnations-metadata.ts
@@ -1,0 +1,75 @@
+import type { MandatBucket, CertaintyKey } from "@/lib/data/condamnations";
+
+const MANDAT_LABEL: Record<MandatBucket | "default", string> = {
+  depute: "Députés français",
+  senateur: "Sénateurs français",
+  gouvernement: "Ministres",
+  locaux: "Élus locaux",
+  default: "Responsables politiques français",
+};
+
+const CERTAINTY_LABEL: Record<CertaintyKey, string> = {
+  etabli: "condamnés définitivement",
+  prononcee: "condamnés en première instance ou en appel",
+  tous: "condamnés",
+};
+
+export interface TitleInput {
+  mandat?: MandatBucket;
+  certainty: CertaintyKey;
+  partyName?: string | null;
+}
+
+export function buildListTitle(input: TitleInput): string {
+  const mandatLabel = MANDAT_LABEL[input.mandat ?? "default"];
+  const certaintyLabel = CERTAINTY_LABEL[input.certainty];
+  const suffix = input.partyName ? ` \u2014 ${input.partyName}` : "";
+  return `${mandatLabel} ${certaintyLabel}${suffix}`;
+}
+
+export interface DescriptionInput {
+  mandat?: MandatBucket;
+  certainty: CertaintyKey;
+  view: "list" | "stats";
+  partyName?: string | null;
+  totalDefinitif: number;
+  totalPrononce: number;
+}
+
+export function buildDescription(input: DescriptionInput): string {
+  if (input.view === "stats") {
+    return `Taux de condamnation par parti politique en France. Agrégation des responsables politiques condamnés définitivement, méthodologie transparente et sources vérifiables.`;
+  }
+
+  if (input.mandat) {
+    const label = MANDAT_LABEL[input.mandat].toLowerCase();
+    return `Liste sourcée des ${label} condamnés définitivement ou en cours de procédure. ${input.totalDefinitif} condamnations définitives documentées, présomption d'innocence respectée.`;
+  }
+
+  return `${input.totalDefinitif} responsables politiques français condamnés définitivement et ${input.totalPrononce} en première instance ou en appel. Sources vérifiables, mise à jour régulière.`;
+}
+
+export interface CanonicalInput {
+  mandat?: MandatBucket;
+  certainty: CertaintyKey;
+  partiSlug?: string;
+  view: "list" | "stats";
+  page?: number;
+}
+
+export function buildCanonical(input: CanonicalInput): string {
+  const { mandat, certainty, partiSlug, view } = input;
+
+  if (partiSlug && !mandat && certainty === "tous" && view === "list") {
+    return `/affaires/parti/${partiSlug}`;
+  }
+
+  const params = new URLSearchParams();
+  if (mandat) params.set("mandat", mandat);
+  if (certainty !== "tous") params.set("certainty", certainty);
+  if (partiSlug) params.set("parti", partiSlug);
+  if (view === "stats") params.set("view", "stats");
+
+  const qs = params.toString();
+  return `/affaires/condamnations${qs ? `?${qs}` : ""}`;
+}

--- a/tests/visual/condamnations-a11y.spec.ts
+++ b/tests/visual/condamnations-a11y.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test.describe("/affaires/condamnations — accessibility", () => {
+  test("default view has no WCAG AA violations", async ({ page }) => {
+    await page.goto("/affaires/condamnations");
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+      .analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("filtered view (mandat=depute) has no WCAG AA violations", async ({ page }) => {
+    await page.goto("/affaires/condamnations?mandat=depute&certainty=etabli");
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+      .analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("stats view has no WCAG AA violations and table has caption", async ({ page }) => {
+    await page.goto("/affaires/condamnations?view=stats");
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+      .analyze();
+    expect(results.violations).toEqual([]);
+
+    const captionCount = await page.locator("table caption").count();
+    expect(captionCount).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Nouveau hub `/affaires/condamnations` pour capter les requêtes SEO à forte intention identifiées dans l'analyse Google Search Console du 2026-04-14.

## Motivation

Requêtes GSC cibles avec forte visibilité mais zéro clic aujourd'hui :

| Requête | Impressions (3 mois) | Position actuelle |
|---|---|---|
| liste des députés condamnés | 56 | 7,8 |
| taux de condamnation des élus par parti | 44 | 8,8 |
| graphique condamnation assemblée nationale | 78 | 6,3 |
| nombre de condamnation par parti politique | 45 | 8,8 |

`/affaires` existant sert partiellement ces intentions mais manque de deux leviers : pas de filtre par type de mandat, H1/title ne matchent pas « députés condamnés ».

## Décisions de design

- **URL canonique unique à facettes dynamiques** : `/affaires/condamnations?mandat=X&certainty=Y&parti=Z&view=W`. Pas de sous-pages statiques par mandat : les données sont insuffisantes hors députés (48 vs 5 sénateurs, 3 ministres, 6 locaux), créer 4 pages statiques aurait produit des doorway pages minces.
- **Deux sections éditoriales labellisées** : « Condamnations définitives » et « Condamnations non définitives », avec bandeau pédagogique fixe sur la seconde (présomption d'innocence article 9-1 du Code civil).
- **Vue stats `?view=stats`** : tableau HTML natif triable, SVG inline pour les barres de progression, aucune lib JS client. Capte « taux de condamnation par parti ».
- **Canonical malin** : `?parti=X` seul pointe vers `/affaires/parti/[slug]` existant (évite la duplication). Combo `?parti=X&mandat=Y` reste self-canonical.
- **Zéro JS client pour le contenu** : filtres en `<Link>`, tri en query params. Googlebot voit 100% du rendu.
- **Zéro contenu AI généré** (conforme AGENTS.md §7). Tous les titres sont des templates dérivés des filtres.

## Livré

- **Data layer** (`src/lib/data/condamnations.ts`) : `getCondamnations()` avec filtres mandat/certainty/parti/pagination/sort + `getCondamnationsStatsByParty()` en SQL raw avec `COUNT(DISTINCT ... FILTER WHERE)`. Query stats mesurée à 110 ms via `EXPLAIN ANALYZE`, pas besoin d'index supplémentaire.
- **SEO helpers** (`src/lib/seo/condamnations-metadata.ts`) : `buildListTitle`, `buildDescription`, `buildCanonical` purs et testés.
- **4 composants** : `CondamnationsPresumptionBanner`, `CondamnationCard`, `CondamnationsStatsTable`, `CondamnationsFilters`.
- **Page** `src/app/affaires/condamnations/page.tsx` avec `generateMetadata` dynamique, 3 structures JSON-LD (`CollectionPage`, `AffairItemList`, `Dataset`).
- **Loading skeleton** et **OG image dynamique** avec compteurs.
- **Sitemap** : 7 variantes canoniques.
- **Maillage interne** : callout sur `/affaires` (quand filtre ETABLI actif), 2 liens sur `/statistiques`, 1 lien sur `/partis/[slug]` avec compteur de condamnations définitives.
- **Tests** : 25 tests unitaires (data layer + SEO helpers), 2 tests snapshot composant, 3 tests axe-core WCAG AA.

## Gains attendus (90 jours)

- Position Google < 3 sur « liste des députés condamnés » et « taux de condamnation par parti politique »
- Impressions cumulées sur 5 requêtes cibles : +500%
- CTR moyen de la nouvelle page : > 4%
- Lighthouse a11y = 100

## Plan de test

- [x] Typecheck clean
- [x] Build succeeded
- [x] 1032/1034 tests passants (2 skipped pré-existants, 0 échec)
- [x] 3 tests axe-core WCAG AA sur 3 variantes d'URL
- [x] Snapshot tests sur CondamnationCard
- [x] Requête stats mesurée à 110 ms via EXPLAIN ANALYZE
- [ ] Revue manuelle des variantes d'URL en staging (filtres, canonicals, JSON-LD, OG, skeleton)
- [ ] Relecture éditoriale : 2-3 politiciens concernés, vérifier `partyAtTime` correct

## Bugs collatéraux corrigés

- **`fineAmount` Prisma Decimal** ne traversait pas la frontière RSC/Client. `Number()` conversion ajoutée dans `getCondamnations` (règle CLAUDE.md déjà documentée, re-appliquée ici).
- **Contraste 2,04:1 sur liens footer** : `hover:underline` seul sans soulignement initial, remplacé par `underline` statique. WCAG fix.

## Documents de référence

- Spec design : `docs/superpowers/specs/2026-04-14-condamnations-hub-design.md` (local, gitignoré)
- Plan d'implémentation : `docs/superpowers/plans/2026-04-14-condamnations-hub.md` (local)
- Analyse GSC : rapport en session

Prêt à relire.