### PR TITLE
Fix preflight moderation biases (victim scope, dates, draft clusters)

### DIFF
--- a/src/lib/moderation/preflight/index.test.ts
+++ b/src/lib/moderation/preflight/index.test.ts
@@ -41,31 +41,37 @@ describe("runPreflight", () => {
   });
 
   it("aggregates moderation, attribution, and duplicates per draft", async () => {
-    (db.affair.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
-      {
-        id: "a1",
-        title: "Affaire François Fillon",
-        description: "Le député François Fillon...",
-        publicationStatus: "DRAFT",
-        createdAt: new Date("2026-05-13T08:00:00Z"),
-        category: "EMPLOI_FICTIF",
-        status: "INSTRUCTION",
-        involvement: "DIRECT",
-        factsDate: null,
-        startDate: null,
-        verdictDate: null,
-        court: null,
-        sentence: null,
-        politician: {
-          id: "p1",
-          slug: "francois-fillon",
-          fullName: "François Fillon",
-          normalizedLastName: "fillon",
-        },
-        sources: [],
-        events: [],
+    const draftRow = {
+      id: "a1",
+      title: "Affaire François Fillon",
+      description: "Le député François Fillon...",
+      publicationStatus: "DRAFT",
+      createdAt: new Date("2026-05-13T08:00:00Z"),
+      category: "EMPLOI_FICTIF",
+      status: "INSTRUCTION",
+      involvement: "DIRECT",
+      factsDate: null,
+      startDate: null,
+      verdictDate: null,
+      court: null,
+      sentence: null,
+      politicianId: "p1",
+      politician: {
+        id: "p1",
+        slug: "francois-fillon",
+        fullName: "François Fillon",
+        normalizedLastName: "fillon",
       },
-    ]);
+      sources: [],
+      events: [],
+    };
+    // First call loads DRAFT affairs, second call loads PUBLISHED titles
+    (db.affair.findMany as ReturnType<typeof vi.fn>).mockImplementation(
+      async (args: { where?: { publicationStatus?: string } }) =>
+        args?.where?.publicationStatus === "PUBLISHED"
+          ? [{ politicianId: "p1", title: "Affaire déjà publiée" }]
+          : [draftRow]
+    );
     (db.politician.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
       { id: "p1", fullName: "François Fillon", normalizedLastName: "fillon" },
     ]);
@@ -73,6 +79,7 @@ describe("runPreflight", () => {
       recommendation: "PUBLISH",
       issues: [],
       confidence: 90,
+      correctedInvolvement: "VICTIM",
     });
     (findPotentialDuplicates as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
@@ -84,6 +91,13 @@ describe("runPreflight", () => {
     expect(report.drafts[0]!.preflight.attribution.confidence).toBe("STRONG");
     expect(report.drafts[0]!.preflight.duplicateOf).toEqual([]);
     expect(report.stats.autoPublishCandidates).toBe(1);
+
+    // Published titles of the same politician are passed for duplicate detection
+    expect(moderateAffair).toHaveBeenCalledWith(
+      expect.objectContaining({ existingAffairTitles: ["Affaire déjà publiée"] })
+    );
+    // The suggested involvement surfaces in the report
+    expect(report.drafts[0]!.preflight.correctedInvolvement).toBe("VICTIM");
   });
 
   it("links duplicates from findPotentialDuplicates into per-draft duplicateOf", async () => {

--- a/src/lib/moderation/preflight/index.ts
+++ b/src/lib/moderation/preflight/index.ts
@@ -48,6 +48,28 @@ export async function runPreflight(
     normalizedLastName: p.normalizedLastName ?? p.fullName,
   }));
 
+  // Published affairs of the drafted politicians, for duplicate detection
+  // against the existing catalogue (a draft often duplicates an affair
+  // already published from an earlier sync wave).
+  const draftPoliticianIds = [
+    ...new Set(drafts.map((d) => d.politicianId).filter((id): id is string => Boolean(id))),
+  ];
+  const publishedAffairs = draftPoliticianIds.length
+    ? await db.affair.findMany({
+        where: {
+          politicianId: { in: draftPoliticianIds },
+          publicationStatus: "PUBLISHED",
+        },
+        select: { politicianId: true, title: true },
+      })
+    : [];
+  const publishedTitlesByPolitician = new Map<string, string[]>();
+  for (const affair of publishedAffairs) {
+    const list = publishedTitlesByPolitician.get(affair.politicianId) ?? [];
+    list.push(affair.title);
+    publishedTitlesByPolitician.set(affair.politicianId, list);
+  }
+
   const duplicates = await findPotentialDuplicates();
   const duplicateGroups = buildDuplicateGroups(duplicates);
   const duplicatesByAffair = buildDuplicateIndex(duplicates);
@@ -79,6 +101,7 @@ export async function runPreflight(
         verdictDate: draft.verdictDate?.toISOString() ?? null,
         court: draft.court ?? null,
         sentence: draft.sentence ?? null,
+        existingAffairTitles: publishedTitlesByPolitician.get(draft.politicianId) ?? [],
       });
     } catch (err) {
       console.error(`[preflight] moderateAffair failed for draft ${draft.id}:`, err);
@@ -91,6 +114,7 @@ export async function runPreflight(
         correctedDescription: null,
         correctedStatus: null,
         correctedCategory: null,
+        correctedInvolvement: null,
         model: "fallback",
       };
     }
@@ -121,6 +145,7 @@ export async function runPreflight(
       preflight: {
         moderationRecommendation: mapModerationRec(moderation),
         moderationIssues: moderation.issues,
+        correctedInvolvement: moderation.correctedInvolvement,
         attribution,
         duplicateOf: duplicatesByAffair.get(draft.id) ?? [],
       },

--- a/src/services/affair-moderation.test.ts
+++ b/src/services/affair-moderation.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api/anthropic", () => ({
+  callAnthropic: vi.fn(),
+  extractToolUse: vi.fn(),
+}));
+
+import { moderateAffair, type ModerationInput } from "./affair-moderation";
+import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
+
+const mockedCallAnthropic = callAnthropic as ReturnType<typeof vi.fn>;
+const mockedExtractToolUse = extractToolUse as ReturnType<typeof vi.fn>;
+
+const baseToolResult = {
+  recommendation: "PUBLISH",
+  confidence: 90,
+  reasoning: "Sources fiables, données cohérentes.",
+  corrected_title: null,
+  corrected_description: null,
+  corrected_status: null,
+  corrected_category: null,
+  corrected_involvement: null,
+  issues: [],
+};
+
+const baseInput: ModerationInput = {
+  affairId: "a1",
+  title: "Menaces de mort contre un maire",
+  description: "Le maire a été menacé de mort.",
+  status: "ENQUETE_PRELIMINAIRE",
+  category: "MENACE",
+  involvement: "MENTIONED_ONLY",
+  politicianName: "Jean Dupont",
+  politicianSlug: "jean-dupont",
+  sources: [
+    {
+      url: "https://example.org/article",
+      title: "Un maire menacé",
+      publisher: "Presse Régionale",
+      publishedAt: "2026-05-18T00:00:00.000Z",
+    },
+  ],
+  factsDate: "2026-05-18T00:00:00.000Z",
+  startDate: null,
+  verdictDate: null,
+  court: null,
+  sentence: null,
+};
+
+function userMessageContent(): string {
+  const messages = mockedCallAnthropic.mock.calls[0]![0] as { content: string }[];
+  return messages[0]!.content;
+}
+
+function systemPrompt(): string {
+  const options = mockedCallAnthropic.mock.calls[0]![1] as { system: string };
+  return options.system;
+}
+
+describe("moderateAffair", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCallAnthropic.mockResolvedValue({ content: [] });
+    mockedExtractToolUse.mockReturnValue({ ...baseToolResult });
+  });
+
+  it("injects the provided today date into the user message", async () => {
+    await moderateAffair({ ...baseInput, today: "2026-06-05" });
+
+    expect(userMessageContent()).toContain("Date du jour : 2026-06-05");
+  });
+
+  it("defaults today to the current date when not provided", async () => {
+    await moderateAffair(baseInput);
+
+    expect(userMessageContent()).toMatch(/Date du jour : \d{4}-\d{2}-\d{2}/);
+  });
+
+  it("instructs the model to compare dates against the provided today", async () => {
+    await moderateAffair(baseInput);
+
+    expect(systemPrompt()).toContain("Date du jour");
+    expect(systemPrompt()).toContain("JAMAIS à tes connaissances internes");
+  });
+
+  it("declares victim and plaintiff affairs as in scope", async () => {
+    await moderateAffair(baseInput);
+
+    expect(systemPrompt()).toContain("PÉRIMÈTRE ÉDITORIAL");
+    expect(systemPrompt()).toContain("VICTIME ou PLAIGNANT sont AUSSI dans le périmètre");
+  });
+
+  it("exposes corrected_involvement in the tool schema as required", async () => {
+    await moderateAffair(baseInput);
+
+    const options = mockedCallAnthropic.mock.calls[0]![1] as {
+      tools: { input_schema: { properties: Record<string, unknown>; required: string[] } }[];
+    };
+    const schema = options.tools[0]!.input_schema;
+    expect(schema.properties.corrected_involvement).toBeDefined();
+    expect(schema.required).toContain("corrected_involvement");
+  });
+
+  it("returns a valid corrected involvement", async () => {
+    mockedExtractToolUse.mockReturnValue({
+      ...baseToolResult,
+      corrected_involvement: "VICTIM",
+    });
+
+    const result = await moderateAffair(baseInput);
+
+    expect(result.correctedInvolvement).toBe("VICTIM");
+  });
+
+  it("falls back to null on an invalid corrected involvement", async () => {
+    mockedExtractToolUse.mockReturnValue({
+      ...baseToolResult,
+      corrected_involvement: "WITNESS",
+    });
+
+    const result = await moderateAffair(baseInput);
+
+    expect(result.correctedInvolvement).toBeNull();
+  });
+
+  it("still forces NEEDS_REVIEW for sensitive categories", async () => {
+    mockedExtractToolUse.mockReturnValue({ ...baseToolResult, recommendation: "PUBLISH" });
+
+    const result = await moderateAffair({ ...baseInput, category: "AGRESSION_SEXUELLE" });
+
+    expect(result.recommendation).toBe("NEEDS_REVIEW");
+    expect(result.issues.some((i) => i.type === "SENSITIVE_CATEGORY")).toBe(true);
+  });
+});

--- a/src/services/affair-moderation.ts
+++ b/src/services/affair-moderation.ts
@@ -42,6 +42,8 @@ export interface ModerationInput {
   court: string | null;
   sentence: string | null;
   existingAffairTitles?: string[];
+  /** ISO date (YYYY-MM-DD) used as "today" for date checks. Defaults to the current date. */
+  today?: string;
 }
 
 export interface ModerationIssue {
@@ -57,6 +59,7 @@ export interface ModerationResult {
   correctedDescription: string | null;
   correctedStatus: string | null;
   correctedCategory: string | null;
+  correctedInvolvement: string | null;
   issues: ModerationIssue[];
   model: string;
 }
@@ -113,6 +116,14 @@ export const AFFAIR_CATEGORIES = [
   "RECEL",
   "CONFLIT_INTERETS",
   "AUTRE",
+] as const;
+
+export const INVOLVEMENTS = [
+  "DIRECT",
+  "INDIRECT",
+  "MENTIONED_ONLY",
+  "VICTIM",
+  "PLAINTIFF",
 ] as const;
 
 export const ISSUE_TYPES = [
@@ -178,6 +189,12 @@ const MODERATION_TOOL = {
         description:
           "Catégorie juridique corrigée si la catégorie actuelle est incorrecte. null si la catégorie est correcte.",
       },
+      corrected_involvement: {
+        type: ["string", "null"],
+        enum: [...INVOLVEMENTS, null],
+        description:
+          "Implication corrigée si l'implication actuelle est incorrecte au vu des sources. Suggérer VICTIM si le politicien est victime des faits, PLAINTIFF s'il est plaignant. null si l'implication est correcte.",
+      },
       issues: {
         type: "array",
         description: "Liste des problèmes détectés dans l'affaire.",
@@ -206,6 +223,7 @@ const MODERATION_TOOL = {
       "corrected_description",
       "corrected_status",
       "corrected_category",
+      "corrected_involvement",
       "issues",
     ],
   },
@@ -218,6 +236,12 @@ const MODERATION_TOOL = {
 const SYSTEM_PROMPT = `Tu es un modérateur juridique pour Poligraph, un projet citoyen de transparence politique. Tu analyses des affaires judiciaires importées automatiquement pour décider si elles peuvent être publiées.
 
 MISSION : Vérifier la qualité des données, la conformité juridique et la fiabilité de chaque affaire AVANT publication.
+
+PÉRIMÈTRE ÉDITORIAL :
+
+- Les affaires où le politicien est MIS EN CAUSE (prévenu, mis en examen, condamné) sont le cœur du périmètre
+- Les affaires où le politicien est VICTIME ou PLAIGNANT sont AUSSI dans le périmètre éditorial. Ne JAMAIS recommander REJECT au seul motif que le politicien est victime ou plaignant
+- Si l'implication renseignée est incorrecte (ex. MENTIONED_ONLY alors que les sources montrent que le politicien est victime des faits ou a déposé plainte), proposer corrected_involvement (VICTIM ou PLAINTIFF) au lieu de rejeter
 
 RÈGLES STRICTES — SÉCURITÉ JURIDIQUE :
 
@@ -241,7 +265,7 @@ REJECT :
 - Ce n'est pas une vraie affaire judiciaire (rumeur, polémique politique sans dimension judiciaire)
 - Données manifestement insuffisantes (pas de source, description vide ou incohérente)
 - Doublon évident d'une affaire existante
-- Le politicien n'est clairement pas impliqué (simple mention ou homonyme)
+- Le politicien n'est ni mis en cause, ni victime, ni plaignant (simple mention contextuelle ou homonyme)
 
 NEEDS_REVIEW :
 - Catégorie sensible (AGRESSION_SEXUELLE, HARCELEMENT_SEXUEL, VIOLENCE) — TOUJOURS
@@ -265,12 +289,14 @@ NETTOYAGE DE LA DESCRIPTION :
 IMPLICATION DU POLITICIEN :
 - VICTIM et PLAINTIFF : ces affaires présentent MOINS de risque juridique car le politicien n'est pas mis en cause. Être plus souple sur la recommandation PUBLISH pour ces cas
 - DIRECT : risque de diffamation maximal, vérification stricte
-- INDIRECT et MENTIONED_ONLY : vérifier que l'implication est correctement qualifiée
+- INDIRECT et MENTIONED_ONLY : vérifier que l'implication est correctement qualifiée et proposer corrected_involvement si elle est fausse
 
 VÉRIFICATION DES DATES :
-- factsDate doit être antérieure à startDate (les faits précèdent la médiatisation)
+- Le message fournit la « Date du jour » : comparer TOUTE date à cette référence, JAMAIS à tes connaissances internes
+- Une date antérieure ou égale à la date du jour n'est PAS une date future
+- factsDate doit être antérieure ou égale à startDate (les faits précèdent la médiatisation)
 - verdictDate doit être postérieure à factsDate
-- Si les dates sont incohérentes, signaler INVALID_DATES
+- Si les dates sont incohérentes entre elles ou réellement postérieures à la date du jour, signaler INVALID_DATES
 
 DÉTECTION DE DOUBLONS :
 - Si la liste d'affaires existantes du même politicien contient un titre similaire, signaler POSSIBLE_DUPLICATE`;
@@ -284,8 +310,11 @@ DÉTECTION DE DOUBLONS :
  * Returns a structured recommendation (PUBLISH / REJECT / NEEDS_REVIEW).
  */
 export async function moderateAffair(input: ModerationInput): Promise<ModerationResult> {
+  const today = input.today ?? new Date().toISOString().slice(0, 10);
+
   // Build user message with all affair data
-  let userContent = `Modère cette affaire judiciaire :\n`;
+  let userContent = `Date du jour : ${today}\n`;
+  userContent += `\nModère cette affaire judiciaire :\n`;
   userContent += `\nPoliticien : ${input.politicianName} (slug: ${input.politicianSlug})`;
   userContent += `\nTitre : ${input.title}`;
   userContent += `\nDescription : ${input.description}`;
@@ -368,6 +397,13 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
         null as unknown as (typeof AFFAIR_CATEGORIES)[number]
       )
     : null;
+  const correctedInvolvement = result.corrected_involvement
+    ? validateEnum(
+        result.corrected_involvement as string,
+        INVOLVEMENTS,
+        null as unknown as (typeof INVOLVEMENTS)[number]
+      )
+    : null;
 
   const issues: ModerationIssue[] = Array.isArray(result.issues)
     ? result.issues
@@ -410,6 +446,7 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
     correctedDescription,
     correctedStatus,
     correctedCategory,
+    correctedInvolvement,
     issues,
     model: MODEL,
   };

--- a/src/services/affairs/matching.test.ts
+++ b/src/services/affairs/matching.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock db so the module can be imported without a database connection
+// (sameCategoryFamily is pure, but matching.ts imports @/lib/db at module level).
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { sameCategoryFamily } from "./matching";
 
 // We need to test the normalizeAffairTitle function indirectly since it's private.
 // Instead, we test the exported behavior by importing and calling it via a test helper.
@@ -75,5 +81,35 @@ describe("normalizeAffairTitle", () => {
 
   it("works without politician name", () => {
     expect(normalizeAffairTitle("Fraude fiscale")).toBe("fraude fiscale");
+  });
+});
+
+describe("sameCategoryFamily", () => {
+  it("matches identical categories", () => {
+    expect(sameCategoryFamily("MENACE", "MENACE")).toBe(true);
+  });
+
+  it("matches sibling categories within the probity family", () => {
+    expect(sameCategoryFamily("DETOURNEMENT_FONDS_PUBLICS", "FAVORITISME")).toBe(true);
+    expect(sameCategoryFamily("CONFLIT_INTERETS", "PRISE_ILLEGALE_INTERETS")).toBe(true);
+  });
+
+  it("matches sibling categories within the persons family", () => {
+    expect(sameCategoryFamily("VIOLENCE", "MENACE")).toBe(true);
+    expect(sameCategoryFamily("AGRESSION_SEXUELLE", "HARCELEMENT_SEXUEL")).toBe(true);
+  });
+
+  it("treats AUTRE as a wildcard", () => {
+    expect(sameCategoryFamily("AUTRE", "DETOURNEMENT_FONDS_PUBLICS")).toBe(true);
+    expect(sameCategoryFamily("MENACE", "AUTRE")).toBe(true);
+  });
+
+  it("rejects categories from different families", () => {
+    expect(sameCategoryFamily("MENACE", "FRAUDE_FISCALE")).toBe(false);
+    expect(sameCategoryFamily("DIFFAMATION", "VIOLENCE")).toBe(false);
+  });
+
+  it("rejects unknown categories that are not AUTRE", () => {
+    expect(sameCategoryFamily("UNKNOWN_A", "UNKNOWN_B")).toBe(false);
   });
 });

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -11,6 +11,62 @@ import type { AffairCategory } from "@/generated/prisma";
 
 export type MatchConfidence = "CERTAIN" | "HIGH" | "POSSIBLE";
 
+/**
+ * Category families for fuzzy duplicate clustering.
+ * Affairs from the same news event are often imported with sibling categories
+ * (e.g. DETOURNEMENT_FONDS_PUBLICS vs FAVORITISME vs CONFLIT_INTERETS for the
+ * same probity investigation), so duplicate detection compares families
+ * rather than exact categories. AUTRE acts as a wildcard.
+ */
+const CATEGORY_FAMILIES: Record<string, string[]> = {
+  probite: [
+    "CORRUPTION",
+    "CORRUPTION_PASSIVE",
+    "TRAFIC_INFLUENCE",
+    "PRISE_ILLEGALE_INTERETS",
+    "FAVORITISME",
+    "DETOURNEMENT_FONDS_PUBLICS",
+    "EMPLOI_FICTIF",
+    "CONFLIT_INTERETS",
+    "RECEL",
+    "ABUS_BIENS_SOCIAUX",
+    "ABUS_CONFIANCE",
+    "BLANCHIMENT",
+    "FRAUDE_FISCALE",
+    "FINANCEMENT_ILLEGAL_CAMPAGNE",
+    "FINANCEMENT_ILLEGAL_PARTI",
+    "FAUX_ET_USAGE_FAUX",
+  ],
+  personnes: [
+    "VIOLENCE",
+    "MENACE",
+    "AGRESSION_SEXUELLE",
+    "HARCELEMENT_SEXUEL",
+    "HARCELEMENT_MORAL",
+  ],
+  expression: ["DIFFAMATION", "INJURE", "INCITATION_HAINE"],
+};
+
+function categoryFamily(category: string): string | null {
+  for (const [family, categories] of Object.entries(CATEGORY_FAMILIES)) {
+    if (categories.includes(category)) return family;
+  }
+  return null;
+}
+
+/**
+ * Check whether two affair categories belong to the same family.
+ * AUTRE matches any family (imports frequently fall back to AUTRE
+ * when the legal qualification is unclear).
+ */
+export function sameCategoryFamily(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a === "AUTRE" || b === "AUTRE") return true;
+  const familyA = categoryFamily(a);
+  const familyB = categoryFamily(b);
+  return familyA !== null && familyA === familyB;
+}
+
 export interface MatchResult {
   affairId: string;
   confidence: MatchConfidence;

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    affair: { findMany: vi.fn() },
+    dismissedDuplicate: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("./matching", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./matching")>();
+  return { ...actual, findMatchingAffairs: vi.fn() };
+});
+
+import { findPotentialDuplicates } from "./reconciliation";
+import { db } from "@/lib/db";
+import { findMatchingAffairs } from "./matching";
+
+const mockedAffairFindMany = db.affair.findMany as ReturnType<typeof vi.fn>;
+const mockedDismissedFindMany = db.dismissedDuplicate.findMany as ReturnType<typeof vi.fn>;
+const mockedFindMatchingAffairs = findMatchingAffairs as ReturnType<typeof vi.fn>;
+
+function makeDraft(
+  id: string,
+  overrides: Partial<{
+    title: string;
+    category: string;
+    createdAt: Date;
+    publicationStatus: string;
+    politicianId: string;
+  }> = {}
+) {
+  return {
+    id,
+    title: overrides.title ?? `Affaire ${id}`,
+    ecli: null,
+    pourvoiNumber: null,
+    caseNumbers: [],
+    category: overrides.category ?? "AUTRE",
+    verdictDate: null,
+    politicianId: overrides.politicianId ?? "p1",
+    createdAt: overrides.createdAt ?? new Date("2026-05-19T10:00:00Z"),
+    publicationStatus: overrides.publicationStatus ?? "DRAFT",
+    sources: [],
+  };
+}
+
+describe("findPotentialDuplicates — draft window clustering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedDismissedFindMany.mockResolvedValue([]);
+    mockedFindMatchingAffairs.mockResolvedValue([]);
+  });
+
+  it("clusters same-politician drafts created within the window across sibling categories", async () => {
+    // Scénario type cluster Philippe : titres divergents, catégories sœurs, créés à quelques jours
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        title: "Affaire de gestion présumée illégale au Havre",
+        category: "DETOURNEMENT_FONDS_PUBLICS",
+        createdAt: new Date("2026-05-19T19:14:00Z"),
+      }),
+      makeDraft("a2", {
+        title: "Enquête pour favoritisme dans l'attribution d'une convention",
+        category: "FAVORITISME",
+        createdAt: new Date("2026-05-20T12:15:00Z"),
+      }),
+      makeDraft("a3", {
+        title: "Affaire Edouard Philippe au Havre",
+        category: "AUTRE",
+        createdAt: new Date("2026-05-26T05:09:00Z"),
+      }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(3); // a1-a2, a1-a3, a2-a3
+    for (const pair of duplicates) {
+      expect(pair.matchedBy).toBe("politician+category+window");
+      expect(pair.confidence).toBe("POSSIBLE");
+      expect(pair.score).toBe(0.45);
+    }
+  });
+
+  it("does not pair drafts created more than 14 days apart", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { createdAt: new Date("2026-05-01T00:00:00Z") }),
+      makeDraft("a2", { createdAt: new Date("2026-05-20T00:00:00Z") }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("does not pair drafts from incompatible category families", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { category: "MENACE" }),
+      makeDraft("a2", { category: "FRAUDE_FISCALE" }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("ignores non-DRAFT affairs in the window pass", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { publicationStatus: "PUBLISHED" }),
+      makeDraft("a2"),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("does not pair drafts of different politicians", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { politicianId: "p1" }),
+      makeDraft("a2", { politicianId: "p2" }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("respects dismissed pairs", async () => {
+    mockedAffairFindMany.mockResolvedValue([makeDraft("a1"), makeDraft("a2")]);
+    mockedDismissedFindMany.mockResolvedValue([{ affairIdA: "a1", affairIdB: "a2" }]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("does not duplicate pairs already found by identifier matching", async () => {
+    mockedAffairFindMany.mockResolvedValue([makeDraft("a1"), makeDraft("a2")]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.matchedBy).toBe("pourvoiNumber");
+  });
+});

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -7,7 +7,7 @@
 
 import { db } from "@/lib/db";
 import { Prisma, type SourceType } from "@/generated/prisma";
-import { findMatchingAffairs, type MatchConfidence } from "./matching";
+import { findMatchingAffairs, sameCategoryFamily, type MatchConfidence } from "./matching";
 
 // ============================================
 // TYPES
@@ -39,6 +39,12 @@ export interface ReconciliationStats {
 // ============================================
 
 /**
+ * Window (in days) for clustering DRAFT affairs of the same politician.
+ * Press sync waves spread coverage of a single event over up to two weeks.
+ */
+const DRAFT_CLUSTER_WINDOW_DAYS = 14;
+
+/**
  * Find potential duplicate pairs among unverified affairs.
  *
  * Groups affairs by politician, then compares each pair using
@@ -57,6 +63,8 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
       category: true,
       verdictDate: true,
       politicianId: true,
+      createdAt: true,
+      publicationStatus: true,
       sources: { select: { sourceType: true } },
     },
   });
@@ -120,6 +128,52 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
             score: matchForA.score,
           });
         }
+      }
+    }
+  }
+
+  // Second pass — DRAFT clustering by creation window.
+  // Drafts from the same news event are imported over a few days with
+  // divergent titles and sibling categories (e.g. 13 drafts for the same
+  // Le Havre investigation), which the identifier/title matching above
+  // cannot catch. Pair drafts of the same politician created within
+  // DRAFT_CLUSTER_WINDOW_DAYS when their categories share a family.
+  // POSSIBLE only (score 0.45): never auto-merged, surfaced for human review.
+  const foundPairs = new Set(duplicates.map((d) => [d.affairA.id, d.affairB.id].sort().join(":")));
+
+  for (const group of byPolitician.values()) {
+    const draftGroup = group.filter((a) => a.publicationStatus === "DRAFT");
+    if (draftGroup.length < 2) continue;
+
+    for (let i = 0; i < draftGroup.length; i++) {
+      for (let j = i + 1; j < draftGroup.length; j++) {
+        const a = draftGroup[i]!;
+        const b = draftGroup[j]!;
+
+        const pairKey = [a.id, b.id].sort().join(":");
+        if (dismissedSet.has(pairKey) || foundPairs.has(pairKey)) continue;
+
+        const daysApart =
+          Math.abs(a.createdAt.getTime() - b.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+        if (daysApart > DRAFT_CLUSTER_WINDOW_DAYS) continue;
+        if (!sameCategoryFamily(a.category, b.category)) continue;
+
+        foundPairs.add(pairKey);
+        duplicates.push({
+          affairA: {
+            id: a.id,
+            title: a.title,
+            sources: [...new Set(a.sources.map((s) => s.sourceType))],
+          },
+          affairB: {
+            id: b.id,
+            title: b.title,
+            sources: [...new Set(b.sources.map((s) => s.sourceType))],
+          },
+          confidence: "POSSIBLE",
+          matchedBy: "politician+category+window",
+          score: 0.45,
+        });
       }
     }
   }

--- a/src/types/moderation-preflight.ts
+++ b/src/types/moderation-preflight.ts
@@ -36,6 +36,7 @@ export const DraftCandidateSchema = z.object({
   preflight: z.object({
     moderationRecommendation: ModerationRecommendationSchema,
     moderationIssues: z.array(ModerationIssueSchema),
+    correctedInvolvement: z.string().nullable(),
     attribution: AttributionAuditSchema,
     duplicateOf: z.array(z.string()),
   }),


### PR DESCRIPTION
Corrige les trois biais du pipeline preflight identifiés lors de la session de modération du 5 juin (44 drafts). Fixes #359.

## Changements

**1. Élus victimes/plaignants** (`affair-moderation.ts`)
- Nouveau champ `corrected_involvement` dans le tool schema : le modèle peut requalifier (VICTIM/PLAINTIFF) au lieu de rejeter
- Section « Périmètre éditorial » dans le system prompt : les affaires VICTIM/PLAINTIFF sont dans le périmètre (24 publiées en base)
- Critère REJECT reformulé : « ni mis en cause, ni victime, ni plaignant »

**2. Faux positifs INVALID_DATES** (`affair-moderation.ts`)
- `Date du jour : YYYY-MM-DD` injectée dans le message utilisateur (`input.today`, injectable pour les tests)
- Règle explicite : comparer à la date fournie, jamais aux connaissances internes du modèle

**3. Clusters de doublons intra-drafts** (`matching.ts`, `reconciliation.ts`, `preflight/index.ts`)
- `sameCategoryFamily()` : familles de catégories (probité, personnes, expression) avec AUTRE en joker
- Passe de clustering des DRAFT dans `findPotentialDuplicates` : même politicien + fenêtre de 14 jours + famille compatible → paire POSSIBLE (score 0.45, jamais auto-mergée)
- Le preflight passe désormais `existingAffairTitles` (affaires publiées du politicien) à `moderateAffair` → détection des drafts dupliquant une affaire déjà publiée
- `correctedInvolvement` exposé dans le rapport JSON

## Tests

- 32 tests sur les 4 suites touchées (2 nouvelles : `affair-moderation.test.ts`, `reconciliation.test.ts`), dont le scénario de régression « cluster Philippe » (3 drafts, titres divergents, catégories sœurs)
- Suite complète : 1398 passed
- Vérification live (dry-run + appel direct) : plus de faux positif de dates sur des sources de mai 2026, `correctedInvolvement` présent dans la sortie
