### PR TITLE
Plan 6: public rendering of approved policy titles

### DIFF
--- a/src/app/admin/policy-titles/__tests__/actions.test.ts
+++ b/src/app/admin/policy-titles/__tests__/actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { toPublicTitleView } from "@/lib/votes/to-public-title-view";
 
 const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
 
@@ -9,9 +10,10 @@ vi.mock("@/lib/auth", () => ({
   isAuthenticated: () => Promise.resolve(true),
 }));
 
-// revalidatePath throws outside a Next request context; no-op it under vitest.
+// revalidatePath throws outside a Next request context; spy it under vitest so we
+// can assert public revalidation (Plan 6).
 vi.mock("next/cache", () => ({
-  revalidatePath: () => {},
+  revalidatePath: vi.fn(),
 }));
 
 // Mock ONLY generateScrutinPolicyTitle; keep buildInputHashInput real (actions
@@ -404,5 +406,89 @@ describeIfDb("policy-title server actions", () => {
     expect((await db.scrutinPolicyTitle.findUnique({ where: { scrutinId } }))?.status).toBe(
       "REJECTED"
     );
+  });
+
+  // ── Public revalidation + visibility transitions (Plan 6.8) ───────────────
+  async function publicMode(scrutinId: string): Promise<"policy" | "official"> {
+    const s = await db.scrutin.findUnique({
+      where: { id: scrutinId },
+      select: {
+        title: true,
+        votingDate: true,
+        result: true,
+        chamber: true,
+        sourceUrl: true,
+        policyTitle: {
+          select: {
+            status: true,
+            policyTitle: true,
+            policySubtitle: true,
+            officialSourceUrl: true,
+            proceduralLabel: true,
+          },
+        },
+      },
+    });
+    return toPublicTitleView(s!).mode;
+  }
+
+  async function revalidateSpy() {
+    return vi.mocked((await import("next/cache")).revalidatePath);
+  }
+
+  it("DRAFT → APPROVED triggers public revalidation and resolves to policy mode", async () => {
+    const { scrutinId } = await seedRow({
+      suffix: "PUB_APPROVE",
+      policyTitle: "Supprimer une dérogation aux seuils de qualité de l'eau",
+    });
+    const spy = await revalidateSpy();
+    spy.mockClear();
+    await actions.approveScrutinPolicyTitle(scrutinId);
+    expect(spy).toHaveBeenCalledWith("/parlement/votes");
+    expect(await publicMode(scrutinId)).toBe("policy");
+  });
+
+  it("APPROVED → REJECTED triggers public revalidation and reverts to official (hide)", async () => {
+    const { scrutinId } = await seedRow({
+      suffix: "PUB_REJECT",
+      policyTitle: "Supprimer une dérogation aux seuils de qualité de l'eau",
+      status: "APPROVED",
+    });
+    const spy = await revalidateSpy();
+    spy.mockClear();
+    await actions.rejectScrutinPolicyTitle(scrutinId, "raison");
+    expect(spy).toHaveBeenCalledWith("/parlement/votes");
+    expect(await publicMode(scrutinId)).toBe("official");
+  });
+
+  it("APPROVED → edited title triggers public revalidation (stays policy with new text)", async () => {
+    const { scrutinId } = await seedRow({
+      suffix: "PUB_EDIT",
+      policyTitle: "Supprimer une dérogation aux seuils de qualité de l'eau",
+      status: "APPROVED",
+    });
+    const spy = await revalidateSpy();
+    spy.mockClear();
+    await actions.editScrutinPolicyTitle(scrutinId, {
+      policyTitle: "Supprimer une dérogation aux seuils de qualité de l'eau (révisé)",
+      policySubtitle: null,
+    });
+    expect(spy).toHaveBeenCalledWith("/parlement/votes");
+    expect(await publicMode(scrutinId)).toBe("policy");
+  });
+
+  it("APPROVED → regenerate triggers public revalidation and hides (no longer policy)", async () => {
+    const { scrutinId } = await seedRow({
+      suffix: "PUB_REGEN",
+      policyTitle: "Supprimer une dérogation aux seuils de qualité de l'eau",
+      status: "APPROVED",
+    });
+    // Generator mocked: it does not re-write the row, but the action must still
+    // revalidate the public surfaces because the row WAS approved.
+    mockGenerate.mockResolvedValue({ outcome: "generated", written: true });
+    const spy = await revalidateSpy();
+    spy.mockClear();
+    await actions.regenerateScrutinPolicyTitle(scrutinId);
+    expect(spy).toHaveBeenCalledWith("/parlement/votes");
   });
 });

--- a/src/app/admin/policy-titles/actions.ts
+++ b/src/app/admin/policy-titles/actions.ts
@@ -18,6 +18,7 @@ import type {
   SubstanceTextBlock,
 } from "@/services/scrutin-policy-title/types";
 import { queryQueue, type QueueFilters } from "@/app/admin/policy-titles/_data/queue-query";
+import { themeToSlug } from "@/lib/theme-utils";
 import { ApproveBlockedError } from "@/app/admin/policy-titles/errors";
 import type { Prisma, ScrutinPolicyTitle } from "@/generated/prisma";
 
@@ -113,6 +114,27 @@ function revalidate(scrutinId: string): void {
   revalidatePath(`/admin/policy-titles/${scrutinId}`);
 }
 
+/**
+ * Plan 6 V1 (path-based): revalidate the public surfaces a title appears on after
+ * a status/title change, so an approval becomes visible and a reject/regenerate
+ * hides it. Covers vote detail + list + theme + (when spotlight-eligible) home.
+ * Politician vote tabs intentionally refresh on their own ISR interval (V1).
+ */
+async function revalidatePublicForScrutin(scrutinId: string): Promise<void> {
+  const scrutin = await db.scrutin.findUnique({
+    where: { id: scrutinId },
+    select: { slug: true, theme: true, importance: { select: { isKeyVote: true } } },
+  });
+  if (!scrutin) return;
+  if (scrutin.slug) revalidatePath(`/parlement/votes/${scrutin.slug}`);
+  revalidatePath("/parlement/votes");
+  if (scrutin.theme) revalidatePath(`/parlement/votes/themes/${themeToSlug(scrutin.theme)}`);
+  if (scrutin.importance?.isKeyVote) {
+    revalidatePath("/");
+    revalidatePath("/parlement");
+  }
+}
+
 function asJson(value: unknown): Prisma.InputJsonValue {
   return value as unknown as Prisma.InputJsonValue;
 }
@@ -164,6 +186,8 @@ export async function editScrutinPolicyTitle(
   });
 
   revalidate(scrutinId);
+  // An edit to an APPROVED row changes what the public sees.
+  if (row.status === "APPROVED") await revalidatePublicForScrutin(scrutinId);
 }
 
 /** True when the row is REJECTED and its most-recent revision is a rejection. */
@@ -241,6 +265,7 @@ export async function approveScrutinPolicyTitle(scrutinId: string): Promise<void
 
   await persistApproval({ ctx });
   revalidate(scrutinId);
+  await revalidatePublicForScrutin(scrutinId);
 }
 
 /**
@@ -278,6 +303,7 @@ export async function approveWithOverrideScrutinPolicyTitle(
 
   await persistApproval({ ctx, approvalOverride: { reason: trimmed, actor: ACTOR } });
   revalidate(scrutinId);
+  await revalidatePublicForScrutin(scrutinId);
 }
 
 /**
@@ -343,6 +369,8 @@ export async function rejectScrutinPolicyTitle(scrutinId: string, reason: string
   });
 
   revalidate(scrutinId);
+  // A reject can hide a previously-approved title.
+  if (row.status === "APPROVED") await revalidatePublicForScrutin(scrutinId);
 }
 
 /**
@@ -356,6 +384,9 @@ export async function regenerateScrutinPolicyTitle(scrutinId: string): Promise<v
 
   const row = await db.scrutinPolicyTitle.findUnique({ where: { scrutinId } });
   if (!row) throw new Error(`Aucun titre public pour le scrutin ${scrutinId}`);
+  // Regeneration cannot leave a row APPROVED; if it WAS approved, the public title
+  // must be hidden afterwards.
+  const wasApproved = row.status === "APPROVED";
 
   await db.$transaction(async (tx) => {
     await tx.scrutinPolicyTitleRevision.create({
@@ -389,6 +420,7 @@ export async function regenerateScrutinPolicyTitle(scrutinId: string): Promise<v
   }
 
   revalidate(scrutinId);
+  if (wasApproved) await revalidatePublicForScrutin(scrutinId);
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -485,6 +517,7 @@ export async function batchApprove(scrutinIds: string[]): Promise<BatchApproveRe
   for (const ctx of contexts) {
     await persistApproval({ ctx });
     revalidate(ctx.scrutin.id);
+    await revalidatePublicForScrutin(ctx.scrutin.id);
   }
 
   return { approved: contexts.length, failures: [] };

--- a/src/app/parlement/groupes/[slug]/page.tsx
+++ b/src/app/parlement/groupes/[slug]/page.tsx
@@ -131,6 +131,7 @@ export default async function GroupeDetailPage({ params }: PageProps) {
                 result={gp.scrutin.result}
                 sourceUrl={null}
                 theme={gp.scrutin.theme}
+                policy={gp.scrutin.policyTitle}
               />
             ))}
           </div>

--- a/src/app/parlement/votes/[slug]/opengraph-image.tsx
+++ b/src/app/parlement/votes/[slug]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { db } from "@/lib/db";
 import { OgLayout, OgCategoryLabel, OgBadge, OG_SIZE, truncateOg } from "@/lib/og-utils";
+import { toPublicTitleView, displayTitleOf } from "@/lib/votes/to-public-title-view";
 
 export const alt = "Vote parlementaire sur Poligraph";
 export const size = OG_SIZE;
@@ -16,9 +17,20 @@ export default async function Image({ params }: { params: Promise<{ slug: string
       title: true,
       votingDate: true,
       result: true,
+      chamber: true,
+      sourceUrl: true,
       votesFor: true,
       votesAgainst: true,
       votesAbstain: true,
+      policyTitle: {
+        select: {
+          status: true,
+          policyTitle: true,
+          policySubtitle: true,
+          officialSourceUrl: true,
+          proceduralLabel: true,
+        },
+      },
     },
   });
   if (!scrutin) {
@@ -28,9 +40,20 @@ export default async function Image({ params }: { params: Promise<{ slug: string
         title: true,
         votingDate: true,
         result: true,
+        chamber: true,
+        sourceUrl: true,
         votesFor: true,
         votesAgainst: true,
         votesAbstain: true,
+        policyTitle: {
+          select: {
+            status: true,
+            policyTitle: true,
+            policySubtitle: true,
+            officialSourceUrl: true,
+            proceduralLabel: true,
+          },
+        },
       },
     });
   }
@@ -54,6 +77,9 @@ export default async function Image({ params }: { params: Promise<{ slug: string
       { ...OG_SIZE }
     );
   }
+
+  // Public title: policy title iff APPROVED + valid, else official (no leak).
+  const ogTitle = displayTitleOf(toPublicTitleView(scrutin));
 
   const isAdopted = scrutin.result === "ADOPTED";
   const resultLabel = isAdopted ? "Adopté" : "Rejeté";
@@ -84,7 +110,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
           marginBottom: 24,
         }}
       >
-        {truncateOg(scrutin.title, 130)}
+        {truncateOg(ogTitle, 130)}
       </div>
 
       {/* Result badge */}

--- a/src/app/parlement/votes/[slug]/page.tsx
+++ b/src/app/parlement/votes/[slug]/page.tsx
@@ -25,6 +25,7 @@ import { ScrutinContext } from "@/components/votes/ScrutinContext";
 import type { VotePosition } from "@/types";
 import { SITE_URL } from "@/config/site";
 import { ShareBar } from "@/components/ui/ShareBar";
+import { toPublicTitleView } from "@/lib/votes/to-public-title-view";
 
 // Matches bare YYYY-MM-DD (never collides with scrutin slugs which are YYYY-MM-DD-title)
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -199,11 +200,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const total = scrutin.votesFor + scrutin.votesAgainst + scrutin.votesAbstain;
   const isThinContent = !scrutin.summary && total === 0;
 
+  // Public title: policy title iff APPROVED + valid, else official (no leak).
+  const view = toPublicTitleView(scrutin);
+  const displayTitle = view.mode === "policy" ? view.policyTitle : view.officialTitle;
+
   const scrutinNumber = extractScrutinNumber(scrutin.externalId);
   const chamberLabel = scrutin.chamber === "AN" ? "Assemblée nationale" : "Sénat";
   const seoTitle = scrutinNumber
-    ? `Scrutin n° ${scrutinNumber} ${chamberLabel} - ${scrutin.title}`
-    : scrutin.title;
+    ? `Scrutin n° ${scrutinNumber} ${chamberLabel} - ${displayTitle}`
+    : displayTitle;
 
   return {
     title: seoTitle,
@@ -260,7 +265,12 @@ export default async function ScrutinPage({ params, searchParams }: PageProps) {
   const againstPercent = total > 0 ? (scrutin.votesAgainst / total) * 100 : 0;
   const abstainPercent = total > 0 ? (scrutin.votesAbstain / total) * 100 : 0;
 
-  // Motion de censure: special threshold-based display (289 = absolute majority of 577 deputies)
+  // Public title: policy title iff APPROVED + valid, else official (no leak).
+  const view = toPublicTitleView(scrutin);
+  const displayTitle = view.mode === "policy" ? view.policyTitle : view.officialTitle;
+
+  // Motion de censure: special threshold-based display (289 = absolute majority of 577 deputies).
+  // Detected against the OFFICIAL title (logic, not display).
   const isMotionDeCensure = /motion\s+de\s+censure/i.test(scrutin.title);
   const CENSURE_THRESHOLD = 289;
 
@@ -268,7 +278,7 @@ export default async function ScrutinPage({ params, searchParams }: PageProps) {
     <>
       {scrutin.summary && (
         <ArticleJsonLd
-          headline={scrutin.title}
+          headline={displayTitle}
           description={scrutin.citizenImpact?.replace(/\*\*/g, "").split(/[.!?]\s/)[0] || undefined}
           datePublished={scrutin.votingDate.toISOString()}
           url={`${SITE_URL}/parlement/votes/${scrutin.slug}`}
@@ -277,8 +287,8 @@ export default async function ScrutinPage({ params, searchParams }: PageProps) {
       )}
       <ShareBar
         data={{
-          title: scrutin.title,
-          text: `${formatExternalId(scrutin.externalId, scrutin.chamber)} : ${scrutin.title} (${scrutin.result === "ADOPTED" ? "Adopté" : "Rejeté"}, ${scrutin.chamber === "AN" ? "Assemblée nationale" : "Sénat"})`,
+          title: displayTitle,
+          text: `${formatExternalId(scrutin.externalId, scrutin.chamber)} : ${displayTitle} (${scrutin.result === "ADOPTED" ? "Adopté" : "Rejeté"}, ${scrutin.chamber === "AN" ? "Assemblée nationale" : "Sénat"})`,
           url: `${SITE_URL}/parlement/votes/${scrutin.slug}`,
         }}
       />
@@ -302,10 +312,29 @@ export default async function ScrutinPage({ params, searchParams }: PageProps) {
                 {" · "}
                 {scrutin.chamber === "AN" ? "Assemblée nationale" : "Sénat"}
               </span>
-              {scrutin.title}
+              <span className="inline-flex flex-wrap items-center gap-2 align-middle">
+                {displayTitle}
+                {view.mode === "policy" ? (
+                  <Badge variant="accent" className="align-middle text-xs font-medium">
+                    Titre explicatif
+                  </Badge>
+                ) : null}
+              </span>
             </h1>
             <VotingResultBadge result={scrutin.result} />
           </div>
+
+          {view.mode === "policy" ? (
+            <div className="mb-4">
+              {view.policySubtitle ? (
+                <p className="text-base text-muted-foreground">{view.policySubtitle}</p>
+              ) : null}
+              <details className="mt-2 text-sm">
+                <summary className="cursor-pointer text-muted-foreground">Titre officiel</summary>
+                <p className="mt-1">{view.officialTitle}</p>
+              </details>
+            </div>
+          ) : null}
 
           <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
             {scrutin.type && scrutin.type !== "AUTRE" && (

--- a/src/app/parlement/votes/[slug]/page.tsx
+++ b/src/app/parlement/votes/[slug]/page.tsx
@@ -103,6 +103,16 @@ const getScrutinWithRedirect = cache(async function getScrutinWithRedirect(slugO
       },
     },
     importance: { select: { isKeyVote: true } },
+    // Plan 6: public policy title (shown only when APPROVED + valid).
+    policyTitle: {
+      select: {
+        status: true,
+        policyTitle: true,
+        policySubtitle: true,
+        officialSourceUrl: true,
+        proceduralLabel: true,
+      },
+    },
   } as const;
 
   // 1. Try by slug first (canonical URL - most common case)

--- a/src/app/parlement/votes/themes/[theme]/page.tsx
+++ b/src/app/parlement/votes/themes/[theme]/page.tsx
@@ -80,6 +80,18 @@ export default async function ThemePage({
       orderBy: { votingDate: "desc" },
       skip,
       take: PAGE_SIZE,
+      include: {
+        // Plan 6: public policy title (shown only when APPROVED + valid).
+        policyTitle: {
+          select: {
+            status: true,
+            policyTitle: true,
+            policySubtitle: true,
+            officialSourceUrl: true,
+            proceduralLabel: true,
+          },
+        },
+      },
     }),
     db.scrutin.count({ where }),
     db.scrutin.groupBy({
@@ -238,6 +250,7 @@ export default async function ThemePage({
               sourceUrl={scrutin.sourceUrl}
               theme={scrutin.theme}
               type={scrutin.type}
+              policy={scrutin.policyTitle}
             />
           ))}
         </div>

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -72,6 +72,16 @@ async function getVoteStats(politicianId: string) {
             title: true,
             votingDate: true,
             result: true,
+            // Plan 6: public policy title (shown only when APPROVED + valid).
+            policyTitle: {
+              select: {
+                status: true,
+                policyTitle: true,
+                policySubtitle: true,
+                officialSourceUrl: true,
+                proceduralLabel: true,
+              },
+            },
           },
         },
       },

--- a/src/app/politiques/[slug]/votes/page.tsx
+++ b/src/app/politiques/[slug]/votes/page.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { SimplePagination } from "@/components/ui/SimplePagination";
 import { db } from "@/lib/db";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { toPublicTitleView, displayTitleOf } from "@/lib/votes/to-public-title-view";
 import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
 import { VoteStats, VotePositionBadge, VotingResultBadge } from "@/components/votes";
 import { ScrutinTypeTabs } from "@/components/votes/ScrutinTypeTabs";
@@ -232,44 +234,56 @@ export default async function PoliticianVotesPage({ params, searchParams }: Page
         <div className="lg:col-span-2">
           {votes.length > 0 ? (
             <div className="space-y-3">
-              {votes.map((vote) => (
-                <Card key={vote.id} className="hover:shadow-sm transition-shadow">
-                  <CardContent className="p-4">
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="flex-1 min-w-0">
-                        <Link
-                          href={`/parlement/votes/${vote.scrutin.slug || vote.scrutin.id}`}
-                          className="font-medium hover:underline line-clamp-2"
-                        >
-                          {vote.scrutin.title}
-                        </Link>
-                        <div className="flex flex-wrap items-center gap-3 mt-1 text-xs text-muted-foreground">
-                          {vote.scrutin.type && vote.scrutin.type !== "AUTRE" && (
-                            <span
-                              className={`px-1.5 py-0.5 rounded text-xs font-medium ${SCRUTIN_TYPE_COLORS[vote.scrutin.type]}`}
-                            >
-                              {SCRUTIN_TYPE_LABELS[vote.scrutin.type]}
-                            </span>
-                          )}
-                          <span>{formatDate(vote.scrutin.votingDate)}</span>
-                          <VotingResultBadge result={vote.scrutin.result} />
-                          {vote.scrutin.sourceUrl && (
-                            <a
-                              href={vote.scrutin.sourceUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="flex items-center gap-1 hover:text-foreground"
-                            >
-                              <ExternalLink className="h-3 w-3" />
-                            </a>
-                          )}
+              {votes.map((vote) => {
+                // Public title: policy iff APPROVED + valid, else official (no leak).
+                const view = toPublicTitleView(vote.scrutin);
+                return (
+                  <Card key={vote.id} className="hover:shadow-sm transition-shadow">
+                    <CardContent className="p-4">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <Link
+                            href={`/parlement/votes/${vote.scrutin.slug || vote.scrutin.id}`}
+                            className="font-medium hover:underline line-clamp-2"
+                          >
+                            {displayTitleOf(view)}
+                            {view.mode === "policy" && (
+                              <Badge
+                                variant="accent"
+                                className="ml-1.5 align-middle text-[10px] font-medium"
+                              >
+                                Titre explicatif
+                              </Badge>
+                            )}
+                          </Link>
+                          <div className="flex flex-wrap items-center gap-3 mt-1 text-xs text-muted-foreground">
+                            {vote.scrutin.type && vote.scrutin.type !== "AUTRE" && (
+                              <span
+                                className={`px-1.5 py-0.5 rounded text-xs font-medium ${SCRUTIN_TYPE_COLORS[vote.scrutin.type]}`}
+                              >
+                                {SCRUTIN_TYPE_LABELS[vote.scrutin.type]}
+                              </span>
+                            )}
+                            <span>{formatDate(vote.scrutin.votingDate)}</span>
+                            <VotingResultBadge result={vote.scrutin.result} />
+                            {vote.scrutin.sourceUrl && (
+                              <a
+                                href={vote.scrutin.sourceUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center gap-1 hover:text-foreground"
+                              >
+                                <ExternalLink className="h-3 w-3" />
+                              </a>
+                            )}
+                          </div>
                         </div>
+                        <VotePositionBadge position={vote.position} />
                       </div>
-                      <VotePositionBadge position={vote.position} />
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
+                    </CardContent>
+                  </Card>
+                );
+              })}
             </div>
           ) : (
             <Card>

--- a/src/app/politiques/[slug]/votes/page.tsx
+++ b/src/app/politiques/[slug]/votes/page.tsx
@@ -79,7 +79,22 @@ async function getVotes(
   const [votes, total, stats, totalAll, amendmentCount] = await Promise.all([
     db.vote.findMany({
       where,
-      include: { scrutin: true },
+      include: {
+        scrutin: {
+          include: {
+            // Plan 6: public policy title (shown only when APPROVED + valid).
+            policyTitle: {
+              select: {
+                status: true,
+                policyTitle: true,
+                policySubtitle: true,
+                officialSourceUrl: true,
+                proceduralLabel: true,
+              },
+            },
+          },
+        },
+      },
       orderBy: { votingDate: "desc" },
       skip,
       take: limit,

--- a/src/components/parlement/ParlementHub.tsx
+++ b/src/components/parlement/ParlementHub.tsx
@@ -174,6 +174,7 @@ export async function ParlementHub() {
             theme={keyVotes.hero.theme}
             summary={keyVotes.hero.summary}
             citizenImpact={keyVotes.hero.citizenImpact}
+            policy={keyVotes.hero.policyTitle}
           />
         </section>
       )}
@@ -198,6 +199,7 @@ export async function ParlementHub() {
                 summary={s.summary}
                 citizenImpact={s.citizenImpact}
                 isKeyVote
+                policy={s.policyTitle}
               />
             ))}
           </div>

--- a/src/components/parlement/ScrutinsListing.tsx
+++ b/src/components/parlement/ScrutinsListing.tsx
@@ -337,6 +337,7 @@ export async function ScrutinsListing({ searchParams: params }: ScrutinsListingP
                 theme={scrutin.theme}
                 type={scrutin.type}
                 dossier={scrutin.dossierLegislatif}
+                policy={scrutin.policyTitle}
               />
             ))}
           </div>

--- a/src/components/politicians/VotesSection.tsx
+++ b/src/components/politicians/VotesSection.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { VOTE_POSITION_DOT_COLORS } from "@/config/labels";
 import { VotePositionBadge, ParliamentaryCard } from "@/components/votes";
+import {
+  toPublicTitleView,
+  displayTitleOf,
+  type PolicyForView,
+} from "@/lib/votes/to-public-title-view";
+import type { VotingResult } from "@/generated/prisma";
 import type { PoliticianVotingStats } from "@/services/voteStats";
 import type { PoliticianParliamentaryCardData } from "@/services/voteStats";
 import type { PoliticianThemeDistribution } from "@/services/voteStats";
@@ -20,6 +27,7 @@ interface VotesSectionProps {
         title: string;
         votingDate: Date | null;
         result: string | null;
+        policyTitle: PolicyForView | null;
       };
     }[];
   };
@@ -162,21 +170,40 @@ export function VotesSection({
               <div>
                 <p className="text-sm font-medium mb-2">Derniers votes</p>
                 <div className="space-y-2">
-                  {voteData.recentVotes.map((vote) => (
-                    <div key={vote.id} className="flex items-start gap-2 text-sm">
-                      <span
-                        className={`w-2 h-2 mt-1.5 shrink-0 rounded-full ${VOTE_POSITION_DOT_COLORS[vote.position]}`}
-                      />
-                      <Link
-                        href={`/parlement/votes/${vote.scrutin.id}`}
-                        prefetch={false}
-                        className="flex-1 hover:underline"
-                      >
-                        {vote.scrutin.title}
-                      </Link>
-                      <VotePositionBadge position={vote.position} size="sm" />
-                    </div>
-                  ))}
+                  {voteData.recentVotes.map((vote) => {
+                    // Public title: policy iff APPROVED + valid, else official (no leak).
+                    const view = toPublicTitleView({
+                      title: vote.scrutin.title,
+                      votingDate: vote.scrutin.votingDate ?? new Date(0),
+                      result: (vote.scrutin.result as VotingResult) ?? "ADOPTED",
+                      chamber: "AN",
+                      sourceUrl: null,
+                      policyTitle: vote.scrutin.policyTitle,
+                    });
+                    return (
+                      <div key={vote.id} className="flex items-start gap-2 text-sm">
+                        <span
+                          className={`w-2 h-2 mt-1.5 shrink-0 rounded-full ${VOTE_POSITION_DOT_COLORS[vote.position]}`}
+                        />
+                        <Link
+                          href={`/parlement/votes/${vote.scrutin.id}`}
+                          prefetch={false}
+                          className="flex-1 hover:underline"
+                        >
+                          {displayTitleOf(view)}
+                          {view.mode === "policy" && (
+                            <Badge
+                              variant="accent"
+                              className="ml-1.5 align-middle text-[10px] font-medium"
+                            >
+                              Titre explicatif
+                            </Badge>
+                          )}
+                        </Link>
+                        <VotePositionBadge position={vote.position} size="sm" />
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/src/components/votes/DailyVotesPage.tsx
+++ b/src/components/votes/DailyVotesPage.tsx
@@ -190,6 +190,7 @@ function ChamberSection({ chamber, scrutins }: { chamber: Chamber; scrutins: Dai
               sourceUrl={s.sourceUrl}
               theme={s.theme}
               type={s.type}
+              policy={s.policyTitle}
             />
             {s.summary && <SummaryExcerpt summary={s.summary} />}
           </div>

--- a/src/components/votes/HeroSpotlight.tsx
+++ b/src/components/votes/HeroSpotlight.tsx
@@ -1,10 +1,16 @@
 import Link from "next/link";
 import { VotingResultBadge } from "./VoteBadge";
 import { MarkdownText } from "@/components/ui/markdown";
+import { Badge } from "@/components/ui/badge";
 import { THEME_CATEGORY_LABELS, THEME_CATEGORY_COLORS } from "@/config/labels";
 import { Calendar, Users, Star } from "lucide-react";
 import { formatDate } from "@/lib/utils";
 import type { VotingResult, ThemeCategory } from "@/types";
+import {
+  toPublicTitleView,
+  displayTitleOf,
+  type PolicyForView,
+} from "@/lib/votes/to-public-title-view";
 
 interface HeroSpotlightProps {
   slug: string | null;
@@ -18,6 +24,7 @@ interface HeroSpotlightProps {
   theme: ThemeCategory | null;
   summary: string | null;
   citizenImpact: string | null;
+  policy?: PolicyForView | null;
 }
 
 export function HeroSpotlight({
@@ -32,8 +39,20 @@ export function HeroSpotlight({
   theme,
   summary,
   citizenImpact,
+  policy,
 }: HeroSpotlightProps) {
   const href = `/parlement/votes/${slug || id}`;
+  // Public title: policy iff APPROVED + valid, else official (no leak).
+  const view = toPublicTitleView({
+    title,
+    votingDate: new Date(votingDate),
+    result,
+    chamber: "AN",
+    sourceUrl: null,
+    policyTitle: policy ?? null,
+  });
+  const heading = displayTitleOf(view);
+  const isPolicy = view.mode === "policy";
   const total = votesFor + votesAgainst + votesAbstain;
   const forPct = total > 0 ? (votesFor / total) * 100 : 0;
   const againstPct = total > 0 ? (votesAgainst / total) * 100 : 0;
@@ -50,7 +69,15 @@ export function HeroSpotlight({
       </div>
 
       <h2 className="text-xl md:text-2xl font-display font-extrabold tracking-tight mb-3">
-        {title}
+        {heading}
+        {isPolicy && (
+          <Badge
+            variant="accent"
+            className="ml-2 align-middle text-[11px] font-medium uppercase tracking-normal"
+          >
+            Titre explicatif
+          </Badge>
+        )}
       </h2>
 
       {(citizenImpact || summary) && (

--- a/src/components/votes/KeyVoteCard.tsx
+++ b/src/components/votes/KeyVoteCard.tsx
@@ -1,10 +1,16 @@
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { VotingResultBadge } from "./VoteBadge";
 import { THEME_CATEGORY_LABELS, THEME_CATEGORY_COLORS } from "@/config/labels";
 import { Calendar, Star } from "lucide-react";
 import { formatDate } from "@/lib/utils";
 import type { VotingResult, ThemeCategory } from "@/types";
+import {
+  toPublicTitleView,
+  displayTitleOf,
+  type PolicyForView,
+} from "@/lib/votes/to-public-title-view";
 
 interface KeyVoteCardProps {
   id: string;
@@ -19,6 +25,7 @@ interface KeyVoteCardProps {
   summary: string | null;
   citizenImpact: string | null;
   isKeyVote?: boolean;
+  policy?: PolicyForView | null;
 }
 
 export function KeyVoteCard({
@@ -34,8 +41,20 @@ export function KeyVoteCard({
   summary,
   citizenImpact,
   isKeyVote = true,
+  policy,
 }: KeyVoteCardProps) {
   const href = `/parlement/votes/${slug || id}`;
+  // Public title: policy iff APPROVED + valid, else official (no leak).
+  const view = toPublicTitleView({
+    title,
+    votingDate: new Date(votingDate),
+    result,
+    chamber: "AN",
+    sourceUrl: null,
+    policyTitle: policy ?? null,
+  });
+  const heading = displayTitleOf(view);
+  const isPolicy = view.mode === "policy";
   const total = votesFor + votesAgainst + votesAbstain;
   const forPct = total > 0 ? (votesFor / total) * 100 : 0;
   const againstPct = total > 0 ? (votesAgainst / total) * 100 : 0;
@@ -53,7 +72,14 @@ export function KeyVoteCard({
         )}
 
         <Link href={href} prefetch={false} className="hover:underline">
-          <p className="font-medium text-sm line-clamp-2 mb-2">{title}</p>
+          <p className="font-medium text-sm line-clamp-2 mb-2">
+            {heading}
+            {isPolicy && (
+              <Badge variant="accent" className="ml-1.5 align-middle text-[10px] font-medium">
+                Titre explicatif
+              </Badge>
+            )}
+          </p>
         </Link>
 
         {(citizenImpact || summary) && (

--- a/src/components/votes/VoteCard.tsx
+++ b/src/components/votes/VoteCard.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { VotingResultBadge } from "./VoteBadge";
+import {
+  toPublicTitleView,
+  displayTitleOf,
+  type PolicyForView,
+} from "@/lib/votes/to-public-title-view";
 import { formatDate } from "@/lib/utils";
 import type { VotingResult, Chamber, ThemeCategory, ScrutinType } from "@/types";
 import {
@@ -30,6 +36,9 @@ interface VoteCardProps {
   theme?: ThemeCategory | null;
   type?: ScrutinType | null;
   dossier?: { title: string; slug: string | null } | null;
+  /** Plan 6: the joined policy-title row. When APPROVED + valid, the card shows
+   *  the policy title + "Titre explicatif" badge; otherwise the official title. */
+  policy?: PolicyForView | null;
 }
 
 function extractScrutinNumber(externalId: string): string | null {
@@ -57,9 +66,22 @@ export function VoteCard({
   theme,
   type,
   dossier,
+  policy,
 }: VoteCardProps) {
   // Use slug for URL if available, fallback to id
   const href = `/parlement/votes/${slug || id}`;
+  // Public title: policy iff APPROVED + valid, else official (no leak). The card
+  // keeps its own date/result/theme chrome, so no chips are rendered here.
+  const view = toPublicTitleView({
+    title,
+    votingDate: new Date(votingDate),
+    result,
+    chamber: chamber ?? "AN",
+    sourceUrl: sourceUrl ?? null,
+    policyTitle: policy ?? null,
+  });
+  const heading = displayTitleOf(view);
+  const isPolicy = view.mode === "policy";
   const scrutinNumber = extractScrutinNumber(externalId);
   const total = votesFor + votesAgainst + votesAbstain;
   const forPercent = total > 0 ? (votesFor / total) * 100 : 0;
@@ -78,7 +100,12 @@ export function VoteCard({
                     Scrutin n°{scrutinNumber}
                   </span>
                 )}
-                {title}
+                {heading}
+                {isPolicy && (
+                  <Badge variant="accent" className="ml-1.5 align-middle text-[10px] font-medium">
+                    Titre explicatif
+                  </Badge>
+                )}
               </p>
             </Link>
             <div className="flex flex-wrap items-center gap-2 mt-1 text-xs text-muted-foreground">

--- a/src/components/votes/VoteTitleDisplay.tsx
+++ b/src/components/votes/VoteTitleDisplay.tsx
@@ -5,6 +5,11 @@ import type { VotingResult } from "@/generated/prisma";
 interface VoteTitleDisplayProps {
   view: PublicTitleView;
   variant: "card" | "detail" | "preview";
+  /** Host cards already render date/result chrome, so they pass false to avoid
+   *  duplicating the chip row. Default true (detail/preview show chips). */
+  showChips?: boolean;
+  /** The "Titre officiel" disclosure (policy mode only). Default true. */
+  showOfficialDisclosure?: boolean;
 }
 
 function resultLabel(result: VotingResult): string {
@@ -41,7 +46,12 @@ function ChipRow({ chips }: { chips: Chip[] }) {
   );
 }
 
-export function VoteTitleDisplay({ view, variant }: VoteTitleDisplayProps) {
+export function VoteTitleDisplay({
+  view,
+  variant,
+  showChips = true,
+  showOfficialDisclosure = true,
+}: VoteTitleDisplayProps) {
   if (view.mode === "policy") {
     return (
       <div data-variant={variant} data-mode="policy">
@@ -52,11 +62,13 @@ export function VoteTitleDisplay({ view, variant }: VoteTitleDisplayProps) {
         {view.policySubtitle ? (
           <p className="mt-1 text-sm text-muted-foreground">{view.policySubtitle}</p>
         ) : null}
-        <ChipRow chips={view.chips} />
-        <details className="mt-2 text-sm">
-          <summary className="cursor-pointer text-muted-foreground">Titre officiel</summary>
-          <p className="mt-1">{view.officialTitle}</p>
-        </details>
+        {showChips ? <ChipRow chips={view.chips} /> : null}
+        {showOfficialDisclosure ? (
+          <details className="mt-2 text-sm">
+            <summary className="cursor-pointer text-muted-foreground">Titre officiel</summary>
+            <p className="mt-1">{view.officialTitle}</p>
+          </details>
+        ) : null}
       </div>
     );
   }
@@ -64,7 +76,7 @@ export function VoteTitleDisplay({ view, variant }: VoteTitleDisplayProps) {
   return (
     <div data-variant={variant} data-mode="official">
       <h3 className="font-semibold">{view.officialTitle}</h3>
-      <ChipRow chips={view.chips} />
+      {showChips ? <ChipRow chips={view.chips} /> : null}
     </div>
   );
 }

--- a/src/components/votes/__tests__/no-leak.test.tsx
+++ b/src/components/votes/__tests__/no-leak.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { VoteCard } from "@/components/votes/VoteCard";
+import { KeyVoteCard } from "@/components/votes/KeyVoteCard";
+import { HeroSpotlight } from "@/components/votes/HeroSpotlight";
+import type { PolicyForView } from "@/lib/votes/to-public-title-view";
+import type { PolicyTitleStatus } from "@/generated/prisma";
+
+const OFFICIAL = "Titre officiel du scrutin numero 1";
+const LEAK = "FUITE titre non approuve qui ne doit jamais apparaitre";
+const APPROVED_TITLE = "Augmenter le budget de l'education nationale";
+
+function policyOf(status: PolicyTitleStatus, title: string | null): PolicyForView {
+  return {
+    status,
+    policyTitle: title,
+    policySubtitle: null,
+    officialSourceUrl: null,
+    proceduralLabel: "Vote solennel",
+  };
+}
+
+function renderCard(name: string, policy: PolicyForView | null) {
+  if (name === "VoteCard") {
+    return render(
+      <VoteCard
+        id="s1"
+        externalId="VTANR5L17V1"
+        slug="scrutin-1"
+        title={OFFICIAL}
+        votingDate={new Date("2026-01-15T10:00:00Z")}
+        legislature={17}
+        chamber="AN"
+        votesFor={100}
+        votesAgainst={50}
+        votesAbstain={10}
+        result="ADOPTED"
+        sourceUrl={null}
+        theme={null}
+        type={null}
+        policy={policy}
+      />
+    );
+  }
+  if (name === "KeyVoteCard") {
+    return render(
+      <KeyVoteCard
+        id="s1"
+        slug="scrutin-1"
+        title={OFFICIAL}
+        votingDate={new Date("2026-01-15T10:00:00Z")}
+        votesFor={100}
+        votesAgainst={50}
+        votesAbstain={10}
+        result="ADOPTED"
+        theme={null}
+        summary={null}
+        citizenImpact={null}
+        policy={policy}
+      />
+    );
+  }
+  return render(
+    <HeroSpotlight
+      id="s1"
+      slug="scrutin-1"
+      title={OFFICIAL}
+      votingDate={new Date("2026-01-15T10:00:00Z")}
+      votesFor={100}
+      votesAgainst={50}
+      votesAbstain={10}
+      result="ADOPTED"
+      theme={null}
+      summary={null}
+      citizenImpact={null}
+      policy={policy}
+    />
+  );
+}
+
+const SURFACES = ["VoteCard", "KeyVoteCard", "HeroSpotlight"] as const;
+const NON_DISPLAYABLE: PolicyTitleStatus[] = ["DRAFT", "NEEDS_REVIEW", "REJECTED", "STALE"];
+
+describe("public no-leak: vote title cards", () => {
+  for (const surface of SURFACES) {
+    describe(surface, () => {
+      it.each(NON_DISPLAYABLE)("%s + valid title → official only, no leak, no badge", (status) => {
+        const { container, unmount } = renderCard(surface, policyOf(status, LEAK));
+        expect(screen.getByText(new RegExp(OFFICIAL))).toBeTruthy();
+        expect(container.textContent).not.toContain(LEAK);
+        expect(screen.queryByText(/Titre explicatif/i)).toBeNull();
+        unmount();
+      });
+
+      it("APPROVED + null/empty title → official only", () => {
+        const { unmount } = renderCard(surface, policyOf("APPROVED", "   "));
+        expect(screen.getByText(new RegExp(OFFICIAL))).toBeTruthy();
+        expect(screen.queryByText(/Titre explicatif/i)).toBeNull();
+        unmount();
+        const r2 = renderCard(surface, policyOf("APPROVED", null));
+        expect(screen.getByText(new RegExp(OFFICIAL))).toBeTruthy();
+        r2.unmount();
+      });
+
+      it("no policy row → official only", () => {
+        const { unmount } = renderCard(surface, null);
+        expect(screen.getByText(new RegExp(OFFICIAL))).toBeTruthy();
+        expect(screen.queryByText(/Titre explicatif/i)).toBeNull();
+        unmount();
+      });
+
+      it("APPROVED + valid title → policy title shown + badge (the only policy case)", () => {
+        const { container, unmount } = renderCard(surface, policyOf("APPROVED", APPROVED_TITLE));
+        expect(screen.getByText(new RegExp(APPROVED_TITLE))).toBeTruthy();
+        expect(screen.getByText(/Titre explicatif/i)).toBeTruthy();
+        expect(container.textContent).not.toContain(OFFICIAL);
+        unmount();
+      });
+    });
+  }
+});

--- a/src/components/votes/__tests__/vote-title-display.test.tsx
+++ b/src/components/votes/__tests__/vote-title-display.test.tsx
@@ -34,4 +34,28 @@ describe("VoteTitleDisplay", () => {
     expect(screen.queryByText(/Titre explicatif/i)).toBeNull();
     expect(screen.queryByText(/Limiter les dérogations/)).toBeNull();
   });
+
+  it("showChips=false hides the chip row (host card owns chrome), keeps title + badge", () => {
+    render(<VoteTitleDisplay view={policyView} variant="card" showChips={false} />);
+    expect(screen.getByText(/Limiter les dérogations/)).toBeTruthy();
+    expect(screen.getByText(/Titre explicatif/i)).toBeTruthy();
+    expect(screen.queryByText(/Sous-amendement n°2368/)).toBeNull();
+  });
+
+  it("showChips defaults true on detail variant (chip rendered)", () => {
+    render(<VoteTitleDisplay view={policyView} variant="detail" />);
+    expect(screen.getByText(/Sous-amendement n°2368/)).toBeTruthy();
+  });
+
+  it("showOfficialDisclosure=false hides the 'Titre officiel' disclosure in policy mode", () => {
+    render(<VoteTitleDisplay view={policyView} variant="card" showOfficialDisclosure={false} />);
+    expect(screen.queryByText(/Titre officiel/)).toBeNull();
+    expect(screen.getByText(/Limiter les dérogations/)).toBeTruthy();
+  });
+
+  it("official mode with showChips=false renders just the heading", () => {
+    render(<VoteTitleDisplay view={officialView} variant="card" showChips={false} />);
+    expect(screen.getByText(/le sous-amendement n° 2368/)).toBeTruthy();
+    expect(screen.queryByText(/Sous-amendement n°2368/)).toBeNull();
+  });
 });

--- a/src/lib/data/groupes.ts
+++ b/src/lib/data/groupes.ts
@@ -162,6 +162,16 @@ export async function getGroupKeyVotes(groupId: string, limit = 5) {
           votesAbstain: true,
           result: true,
           theme: true,
+          // Plan 6: public policy title (shown only when APPROVED + valid).
+          policyTitle: {
+            select: {
+              status: true,
+              policyTitle: true,
+              policySubtitle: true,
+              officialSourceUrl: true,
+              proceduralLabel: true,
+            },
+          },
         },
       },
     },

--- a/src/lib/data/scrutins.ts
+++ b/src/lib/data/scrutins.ts
@@ -68,6 +68,16 @@ const DAILY_SELECT = {
   type: true,
   summary: true,
   citizenImpact: true,
+  // Plan 6: public policy title (shown only when APPROVED + valid, via resolvePublicTitle).
+  policyTitle: {
+    select: {
+      status: true,
+      policyTitle: true,
+      policySubtitle: true,
+      officialSourceUrl: true,
+      proceduralLabel: true,
+    },
+  },
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/lib/data/scrutins.ts
+++ b/src/lib/data/scrutins.ts
@@ -2,6 +2,7 @@ import { cacheTag, cacheLife } from "next/cache";
 import { db } from "@/lib/db";
 import type { Chamber, VotingResult, ThemeCategory, ScrutinType } from "@/generated/prisma";
 import { KEY_VOTES_HUB_WINDOW_DAYS, KEY_VOTES_GRID_COUNT } from "@/config/scrutin-importance";
+import type { PolicyForView } from "@/lib/votes/to-public-title-view";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,6 +25,7 @@ export interface DailyScrutin {
   type: ScrutinType | null;
   summary: string | null;
   citizenImpact: string | null;
+  policyTitle: PolicyForView | null;
 }
 
 export interface DailyVotesData {

--- a/src/lib/moderation/preflight/index.test.ts
+++ b/src/lib/moderation/preflight/index.test.ts
@@ -41,31 +41,37 @@ describe("runPreflight", () => {
   });
 
   it("aggregates moderation, attribution, and duplicates per draft", async () => {
-    (db.affair.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
-      {
-        id: "a1",
-        title: "Affaire François Fillon",
-        description: "Le député François Fillon...",
-        publicationStatus: "DRAFT",
-        createdAt: new Date("2026-05-13T08:00:00Z"),
-        category: "EMPLOI_FICTIF",
-        status: "INSTRUCTION",
-        involvement: "DIRECT",
-        factsDate: null,
-        startDate: null,
-        verdictDate: null,
-        court: null,
-        sentence: null,
-        politician: {
-          id: "p1",
-          slug: "francois-fillon",
-          fullName: "François Fillon",
-          normalizedLastName: "fillon",
-        },
-        sources: [],
-        events: [],
+    const draftRow = {
+      id: "a1",
+      title: "Affaire François Fillon",
+      description: "Le député François Fillon...",
+      publicationStatus: "DRAFT",
+      createdAt: new Date("2026-05-13T08:00:00Z"),
+      category: "EMPLOI_FICTIF",
+      status: "INSTRUCTION",
+      involvement: "DIRECT",
+      factsDate: null,
+      startDate: null,
+      verdictDate: null,
+      court: null,
+      sentence: null,
+      politicianId: "p1",
+      politician: {
+        id: "p1",
+        slug: "francois-fillon",
+        fullName: "François Fillon",
+        normalizedLastName: "fillon",
       },
-    ]);
+      sources: [],
+      events: [],
+    };
+    // First call loads DRAFT affairs, second call loads PUBLISHED titles
+    (db.affair.findMany as ReturnType<typeof vi.fn>).mockImplementation(
+      async (args: { where?: { publicationStatus?: string } }) =>
+        args?.where?.publicationStatus === "PUBLISHED"
+          ? [{ politicianId: "p1", title: "Affaire déjà publiée" }]
+          : [draftRow]
+    );
     (db.politician.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
       { id: "p1", fullName: "François Fillon", normalizedLastName: "fillon" },
     ]);
@@ -73,6 +79,7 @@ describe("runPreflight", () => {
       recommendation: "PUBLISH",
       issues: [],
       confidence: 90,
+      correctedInvolvement: "VICTIM",
     });
     (findPotentialDuplicates as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
@@ -84,6 +91,13 @@ describe("runPreflight", () => {
     expect(report.drafts[0]!.preflight.attribution.confidence).toBe("STRONG");
     expect(report.drafts[0]!.preflight.duplicateOf).toEqual([]);
     expect(report.stats.autoPublishCandidates).toBe(1);
+
+    // Published titles of the same politician are passed for duplicate detection
+    expect(moderateAffair).toHaveBeenCalledWith(
+      expect.objectContaining({ existingAffairTitles: ["Affaire déjà publiée"] })
+    );
+    // The suggested involvement surfaces in the report
+    expect(report.drafts[0]!.preflight.correctedInvolvement).toBe("VICTIM");
   });
 
   it("links duplicates from findPotentialDuplicates into per-draft duplicateOf", async () => {

--- a/src/lib/moderation/preflight/index.ts
+++ b/src/lib/moderation/preflight/index.ts
@@ -48,6 +48,28 @@ export async function runPreflight(
     normalizedLastName: p.normalizedLastName ?? p.fullName,
   }));
 
+  // Published affairs of the drafted politicians, for duplicate detection
+  // against the existing catalogue (a draft often duplicates an affair
+  // already published from an earlier sync wave).
+  const draftPoliticianIds = [
+    ...new Set(drafts.map((d) => d.politicianId).filter((id): id is string => Boolean(id))),
+  ];
+  const publishedAffairs = draftPoliticianIds.length
+    ? await db.affair.findMany({
+        where: {
+          politicianId: { in: draftPoliticianIds },
+          publicationStatus: "PUBLISHED",
+        },
+        select: { politicianId: true, title: true },
+      })
+    : [];
+  const publishedTitlesByPolitician = new Map<string, string[]>();
+  for (const affair of publishedAffairs) {
+    const list = publishedTitlesByPolitician.get(affair.politicianId) ?? [];
+    list.push(affair.title);
+    publishedTitlesByPolitician.set(affair.politicianId, list);
+  }
+
   const duplicates = await findPotentialDuplicates();
   const duplicateGroups = buildDuplicateGroups(duplicates);
   const duplicatesByAffair = buildDuplicateIndex(duplicates);
@@ -79,6 +101,7 @@ export async function runPreflight(
         verdictDate: draft.verdictDate?.toISOString() ?? null,
         court: draft.court ?? null,
         sentence: draft.sentence ?? null,
+        existingAffairTitles: publishedTitlesByPolitician.get(draft.politicianId) ?? [],
       });
     } catch (err) {
       console.error(`[preflight] moderateAffair failed for draft ${draft.id}:`, err);
@@ -91,6 +114,7 @@ export async function runPreflight(
         correctedDescription: null,
         correctedStatus: null,
         correctedCategory: null,
+        correctedInvolvement: null,
         model: "fallback",
       };
     }
@@ -121,6 +145,7 @@ export async function runPreflight(
       preflight: {
         moderationRecommendation: mapModerationRec(moderation),
         moderationIssues: moderation.issues,
+        correctedInvolvement: moderation.correctedInvolvement,
         attribution,
         duplicateOf: duplicatesByAffair.get(draft.id) ?? [],
       },

--- a/src/lib/votes/__tests__/to-public-title-view.test.ts
+++ b/src/lib/votes/__tests__/to-public-title-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { toPublicTitleView, type ScrutinRowForView } from "../to-public-title-view";
+import { toPublicTitleView, displayTitleOf, type ScrutinRowForView } from "../to-public-title-view";
 
 const base: Omit<ScrutinRowForView, "policyTitle"> = {
   title: "Projet de loi de finances pour 2026",
@@ -104,5 +104,16 @@ describe("toPublicTitleView", () => {
     const v = toPublicTitleView({ ...base, policyTitle: policy({ proceduralLabel: null }) });
     expect(v.mode).toBe("policy");
     expect(hasProceduralChip(v.chips)).toBe(false);
+  });
+
+  describe("displayTitleOf", () => {
+    it("returns the policy title in policy mode", () => {
+      const v = toPublicTitleView({ ...base, policyTitle: policy({}) });
+      expect(displayTitleOf(v)).toBe("Augmenter le budget de l'éducation");
+    });
+    it("returns the official title in official mode (no leak)", () => {
+      const v = toPublicTitleView({ ...base, policyTitle: policy({ status: "DRAFT" }) });
+      expect(displayTitleOf(v)).toBe(base.title);
+    });
   });
 });

--- a/src/lib/votes/__tests__/to-public-title-view.test.ts
+++ b/src/lib/votes/__tests__/to-public-title-view.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { toPublicTitleView, type ScrutinRowForView } from "../to-public-title-view";
+
+const base: Omit<ScrutinRowForView, "policyTitle"> = {
+  title: "Projet de loi de finances pour 2026",
+  votingDate: new Date("2026-01-15T10:00:00Z"),
+  result: "ADOPTED",
+  chamber: "AN",
+  sourceUrl: "https://assemblee.fr/scrutin/1",
+};
+
+function policy(over: Partial<NonNullable<ScrutinRowForView["policyTitle"]>>) {
+  return {
+    status: "APPROVED" as const,
+    policyTitle: "Augmenter le budget de l'éducation",
+    policySubtitle: "Ce que ça change",
+    officialSourceUrl: null,
+    proceduralLabel: "Vote solennel",
+    ...over,
+  };
+}
+
+function hasProceduralChip(chips: { kind: string }[]): boolean {
+  return chips.some((c) => c.kind === "procedural");
+}
+
+describe("toPublicTitleView", () => {
+  it("APPROVED + valid title → policy mode", () => {
+    const v = toPublicTitleView({ ...base, policyTitle: policy({}) });
+    expect(v.mode).toBe("policy");
+    if (v.mode === "policy") expect(v.policyTitle).toBe("Augmenter le budget de l'éducation");
+  });
+
+  it.each(["DRAFT", "NEEDS_REVIEW", "REJECTED", "STALE"] as const)(
+    "%s + valid title → official mode (no leak)",
+    (status) => {
+      const v = toPublicTitleView({ ...base, policyTitle: policy({ status }) });
+      expect(v.mode).toBe("official");
+    }
+  );
+
+  it("no policy row → official mode", () => {
+    const v = toPublicTitleView({ ...base, policyTitle: null });
+    expect(v.mode).toBe("official");
+  });
+
+  it("APPROVED but empty/whitespace title → official mode", () => {
+    expect(toPublicTitleView({ ...base, policyTitle: policy({ policyTitle: "   " }) }).mode).toBe(
+      "official"
+    );
+    expect(toPublicTitleView({ ...base, policyTitle: policy({ policyTitle: null }) }).mode).toBe(
+      "official"
+    );
+  });
+
+  // Source-URL precedence (revision #2)
+  it("uses scrutin.sourceUrl when present", () => {
+    const v = toPublicTitleView({
+      ...base,
+      sourceUrl: "https://primary",
+      policyTitle: policy({ officialSourceUrl: "https://fallback" }),
+    });
+    expect(v.officialSourceUrl).toBe("https://primary");
+  });
+
+  it("falls back to policyTitle.officialSourceUrl when scrutin.sourceUrl is null", () => {
+    const v = toPublicTitleView({
+      ...base,
+      sourceUrl: null,
+      policyTitle: policy({ officialSourceUrl: "https://fallback" }),
+    });
+    expect(v.officialSourceUrl).toBe("https://fallback");
+  });
+
+  it("null when neither source URL is present", () => {
+    const v = toPublicTitleView({
+      ...base,
+      sourceUrl: null,
+      policyTitle: policy({ officialSourceUrl: null }),
+    });
+    expect(v.officialSourceUrl).toBeNull();
+  });
+
+  // Procedural chip sourcing (proceduralLabel lives only on the policy row)
+  it("no policy row → official title, no procedural chip", () => {
+    const v = toPublicTitleView({ ...base, policyTitle: null });
+    expect(v.mode).toBe("official");
+    expect(hasProceduralChip(v.chips)).toBe(false);
+  });
+
+  it("DRAFT policy row with proceduralLabel → official title, procedural chip present", () => {
+    const v = toPublicTitleView({ ...base, policyTitle: policy({ status: "DRAFT" }) });
+    expect(v.mode).toBe("official");
+    expect(hasProceduralChip(v.chips)).toBe(true);
+  });
+
+  it("APPROVED policy row with proceduralLabel → policy title, procedural chip present", () => {
+    const v = toPublicTitleView({ ...base, policyTitle: policy({}) });
+    expect(v.mode).toBe("policy");
+    expect(hasProceduralChip(v.chips)).toBe(true);
+  });
+
+  it("APPROVED policy row without proceduralLabel → policy title, no procedural chip", () => {
+    const v = toPublicTitleView({ ...base, policyTitle: policy({ proceduralLabel: null }) });
+    expect(v.mode).toBe("policy");
+    expect(hasProceduralChip(v.chips)).toBe(false);
+  });
+});

--- a/src/lib/votes/resolve-public-title.ts
+++ b/src/lib/votes/resolve-public-title.ts
@@ -6,7 +6,10 @@ export interface ScrutinForDisplay {
   result: VotingResult;
   chamber: Chamber;
   sourceUrl: string | null;
-  proceduralLabel: string;
+  /** Lives only on ScrutinPolicyTitle, so it is optional here: scrutins without
+   *  a policy row have none, and the procedural chip is then omitted. Sourced by
+   *  toPublicTitleView from the policy relation; never derived from scrutin.type. */
+  proceduralLabel?: string | null;
 }
 export interface PolicyTitleForDisplay {
   status: PolicyTitleStatus;
@@ -30,11 +33,12 @@ export type PublicTitleView =
     };
 
 function buildChips(s: ScrutinForDisplay): Chip[] {
-  return [
-    { kind: "procedural", label: s.proceduralLabel },
-    { kind: "result", result: s.result },
-    { kind: "date", iso: s.votingDate.toISOString() },
-  ];
+  const chips: Chip[] = [];
+  const procedural = s.proceduralLabel?.trim();
+  if (procedural) chips.push({ kind: "procedural", label: procedural });
+  chips.push({ kind: "result", result: s.result });
+  chips.push({ kind: "date", iso: s.votingDate.toISOString() });
+  return chips;
 }
 
 /** The ONLY gate for public display. A generated title is shown publicly IFF the

--- a/src/lib/votes/to-public-title-view.ts
+++ b/src/lib/votes/to-public-title-view.ts
@@ -1,0 +1,56 @@
+import { resolvePublicTitle, type PublicTitleView } from "./resolve-public-title";
+import type { PolicyTitleStatus, VotingResult, Chamber } from "@/generated/prisma";
+
+/** The policy fields a public surface must select alongside its scrutin.
+ *  `proceduralLabel` and `officialSourceUrl` live on the policy row, not the
+ *  scrutin, so they ride here. */
+export interface PolicyForView {
+  status: PolicyTitleStatus;
+  policyTitle: string | null;
+  policySubtitle: string | null;
+  officialSourceUrl: string | null;
+  proceduralLabel: string | null;
+}
+
+/** A scrutin row joined with its (optional) policyTitle relation. The scrutin
+ *  itself carries no proceduralLabel — it is sourced from the policy row. */
+export interface ScrutinRowForView {
+  title: string;
+  votingDate: Date;
+  result: VotingResult;
+  chamber: Chamber;
+  sourceUrl: string | null;
+  policyTitle: PolicyForView | null;
+}
+
+/**
+ * Thin adapter: maps a scrutin row (+ its policyTitle relation) to a
+ * PublicTitleView via the single chokepoint `resolvePublicTitle`. It makes NO
+ * display decision of its own. Two pieces of pass-through wiring live here:
+ *  - source URL coalesce: `scrutin.sourceUrl` is canonical, the policy row's
+ *    `officialSourceUrl` is fallback (Plan 6 revision #2);
+ *  - `proceduralLabel` is sourced from the policy row (it lives only there), so
+ *    a scrutin with no policy row yields no procedural chip.
+ * Every public surface maps through this so field wiring never diverges.
+ */
+export function toPublicTitleView(row: ScrutinRowForView): PublicTitleView {
+  const policy = row.policyTitle;
+  const sourceUrl = row.sourceUrl ?? policy?.officialSourceUrl ?? null;
+  return resolvePublicTitle(
+    {
+      title: row.title,
+      votingDate: row.votingDate,
+      result: row.result,
+      chamber: row.chamber,
+      sourceUrl,
+      proceduralLabel: policy?.proceduralLabel ?? undefined,
+    },
+    policy
+      ? {
+          status: policy.status,
+          policyTitle: policy.policyTitle,
+          policySubtitle: policy.policySubtitle,
+        }
+      : null
+  );
+}

--- a/src/lib/votes/to-public-title-view.ts
+++ b/src/lib/votes/to-public-title-view.ts
@@ -1,6 +1,13 @@
 import { resolvePublicTitle, type PublicTitleView } from "./resolve-public-title";
 import type { PolicyTitleStatus, VotingResult, Chamber } from "@/generated/prisma";
 
+/** The single string to render as the heading for a resolved view: the policy
+ *  title in policy mode, the official title otherwise. Centralizes the choice so
+ *  surfaces (detail h1, OG, cards) never re-derive it. */
+export function displayTitleOf(view: PublicTitleView): string {
+  return view.mode === "policy" ? view.policyTitle : view.officialTitle;
+}
+
 /** The policy fields a public surface must select alongside its scrutin.
  *  `proceduralLabel` and `officialSourceUrl` live on the policy row, not the
  *  scrutin, so they ride here. */

--- a/src/services/affair-moderation.test.ts
+++ b/src/services/affair-moderation.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api/anthropic", () => ({
+  callAnthropic: vi.fn(),
+  extractToolUse: vi.fn(),
+}));
+
+import { moderateAffair, type ModerationInput } from "./affair-moderation";
+import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
+
+const mockedCallAnthropic = callAnthropic as ReturnType<typeof vi.fn>;
+const mockedExtractToolUse = extractToolUse as ReturnType<typeof vi.fn>;
+
+const baseToolResult = {
+  recommendation: "PUBLISH",
+  confidence: 90,
+  reasoning: "Sources fiables, données cohérentes.",
+  corrected_title: null,
+  corrected_description: null,
+  corrected_status: null,
+  corrected_category: null,
+  corrected_involvement: null,
+  issues: [],
+};
+
+const baseInput: ModerationInput = {
+  affairId: "a1",
+  title: "Menaces de mort contre un maire",
+  description: "Le maire a été menacé de mort.",
+  status: "ENQUETE_PRELIMINAIRE",
+  category: "MENACE",
+  involvement: "MENTIONED_ONLY",
+  politicianName: "Jean Dupont",
+  politicianSlug: "jean-dupont",
+  sources: [
+    {
+      url: "https://example.org/article",
+      title: "Un maire menacé",
+      publisher: "Presse Régionale",
+      publishedAt: "2026-05-18T00:00:00.000Z",
+    },
+  ],
+  factsDate: "2026-05-18T00:00:00.000Z",
+  startDate: null,
+  verdictDate: null,
+  court: null,
+  sentence: null,
+};
+
+function userMessageContent(): string {
+  const messages = mockedCallAnthropic.mock.calls[0]![0] as { content: string }[];
+  return messages[0]!.content;
+}
+
+function systemPrompt(): string {
+  const options = mockedCallAnthropic.mock.calls[0]![1] as { system: string };
+  return options.system;
+}
+
+describe("moderateAffair", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCallAnthropic.mockResolvedValue({ content: [] });
+    mockedExtractToolUse.mockReturnValue({ ...baseToolResult });
+  });
+
+  it("injects the provided today date into the user message", async () => {
+    await moderateAffair({ ...baseInput, today: "2026-06-05" });
+
+    expect(userMessageContent()).toContain("Date du jour : 2026-06-05");
+  });
+
+  it("defaults today to the current date when not provided", async () => {
+    await moderateAffair(baseInput);
+
+    expect(userMessageContent()).toMatch(/Date du jour : \d{4}-\d{2}-\d{2}/);
+  });
+
+  it("instructs the model to compare dates against the provided today", async () => {
+    await moderateAffair(baseInput);
+
+    expect(systemPrompt()).toContain("Date du jour");
+    expect(systemPrompt()).toContain("JAMAIS à tes connaissances internes");
+  });
+
+  it("declares victim and plaintiff affairs as in scope", async () => {
+    await moderateAffair(baseInput);
+
+    expect(systemPrompt()).toContain("PÉRIMÈTRE ÉDITORIAL");
+    expect(systemPrompt()).toContain("VICTIME ou PLAIGNANT sont AUSSI dans le périmètre");
+  });
+
+  it("exposes corrected_involvement in the tool schema as required", async () => {
+    await moderateAffair(baseInput);
+
+    const options = mockedCallAnthropic.mock.calls[0]![1] as {
+      tools: { input_schema: { properties: Record<string, unknown>; required: string[] } }[];
+    };
+    const schema = options.tools[0]!.input_schema;
+    expect(schema.properties.corrected_involvement).toBeDefined();
+    expect(schema.required).toContain("corrected_involvement");
+  });
+
+  it("returns a valid corrected involvement", async () => {
+    mockedExtractToolUse.mockReturnValue({
+      ...baseToolResult,
+      corrected_involvement: "VICTIM",
+    });
+
+    const result = await moderateAffair(baseInput);
+
+    expect(result.correctedInvolvement).toBe("VICTIM");
+  });
+
+  it("falls back to null on an invalid corrected involvement", async () => {
+    mockedExtractToolUse.mockReturnValue({
+      ...baseToolResult,
+      corrected_involvement: "WITNESS",
+    });
+
+    const result = await moderateAffair(baseInput);
+
+    expect(result.correctedInvolvement).toBeNull();
+  });
+
+  it("still forces NEEDS_REVIEW for sensitive categories", async () => {
+    mockedExtractToolUse.mockReturnValue({ ...baseToolResult, recommendation: "PUBLISH" });
+
+    const result = await moderateAffair({ ...baseInput, category: "AGRESSION_SEXUELLE" });
+
+    expect(result.recommendation).toBe("NEEDS_REVIEW");
+    expect(result.issues.some((i) => i.type === "SENSITIVE_CATEGORY")).toBe(true);
+  });
+});

--- a/src/services/affair-moderation.ts
+++ b/src/services/affair-moderation.ts
@@ -42,6 +42,8 @@ export interface ModerationInput {
   court: string | null;
   sentence: string | null;
   existingAffairTitles?: string[];
+  /** ISO date (YYYY-MM-DD) used as "today" for date checks. Defaults to the current date. */
+  today?: string;
 }
 
 export interface ModerationIssue {
@@ -57,6 +59,7 @@ export interface ModerationResult {
   correctedDescription: string | null;
   correctedStatus: string | null;
   correctedCategory: string | null;
+  correctedInvolvement: string | null;
   issues: ModerationIssue[];
   model: string;
 }
@@ -113,6 +116,14 @@ export const AFFAIR_CATEGORIES = [
   "RECEL",
   "CONFLIT_INTERETS",
   "AUTRE",
+] as const;
+
+export const INVOLVEMENTS = [
+  "DIRECT",
+  "INDIRECT",
+  "MENTIONED_ONLY",
+  "VICTIM",
+  "PLAINTIFF",
 ] as const;
 
 export const ISSUE_TYPES = [
@@ -178,6 +189,12 @@ const MODERATION_TOOL = {
         description:
           "Catégorie juridique corrigée si la catégorie actuelle est incorrecte. null si la catégorie est correcte.",
       },
+      corrected_involvement: {
+        type: ["string", "null"],
+        enum: [...INVOLVEMENTS, null],
+        description:
+          "Implication corrigée si l'implication actuelle est incorrecte au vu des sources. Suggérer VICTIM si le politicien est victime des faits, PLAINTIFF s'il est plaignant. null si l'implication est correcte.",
+      },
       issues: {
         type: "array",
         description: "Liste des problèmes détectés dans l'affaire.",
@@ -206,6 +223,7 @@ const MODERATION_TOOL = {
       "corrected_description",
       "corrected_status",
       "corrected_category",
+      "corrected_involvement",
       "issues",
     ],
   },
@@ -218,6 +236,12 @@ const MODERATION_TOOL = {
 const SYSTEM_PROMPT = `Tu es un modérateur juridique pour Poligraph, un projet citoyen de transparence politique. Tu analyses des affaires judiciaires importées automatiquement pour décider si elles peuvent être publiées.
 
 MISSION : Vérifier la qualité des données, la conformité juridique et la fiabilité de chaque affaire AVANT publication.
+
+PÉRIMÈTRE ÉDITORIAL :
+
+- Les affaires où le politicien est MIS EN CAUSE (prévenu, mis en examen, condamné) sont le cœur du périmètre
+- Les affaires où le politicien est VICTIME ou PLAIGNANT sont AUSSI dans le périmètre éditorial. Ne JAMAIS recommander REJECT au seul motif que le politicien est victime ou plaignant
+- Si l'implication renseignée est incorrecte (ex. MENTIONED_ONLY alors que les sources montrent que le politicien est victime des faits ou a déposé plainte), proposer corrected_involvement (VICTIM ou PLAINTIFF) au lieu de rejeter
 
 RÈGLES STRICTES — SÉCURITÉ JURIDIQUE :
 
@@ -241,7 +265,7 @@ REJECT :
 - Ce n'est pas une vraie affaire judiciaire (rumeur, polémique politique sans dimension judiciaire)
 - Données manifestement insuffisantes (pas de source, description vide ou incohérente)
 - Doublon évident d'une affaire existante
-- Le politicien n'est clairement pas impliqué (simple mention ou homonyme)
+- Le politicien n'est ni mis en cause, ni victime, ni plaignant (simple mention contextuelle ou homonyme)
 
 NEEDS_REVIEW :
 - Catégorie sensible (AGRESSION_SEXUELLE, HARCELEMENT_SEXUEL, VIOLENCE) — TOUJOURS
@@ -265,12 +289,14 @@ NETTOYAGE DE LA DESCRIPTION :
 IMPLICATION DU POLITICIEN :
 - VICTIM et PLAINTIFF : ces affaires présentent MOINS de risque juridique car le politicien n'est pas mis en cause. Être plus souple sur la recommandation PUBLISH pour ces cas
 - DIRECT : risque de diffamation maximal, vérification stricte
-- INDIRECT et MENTIONED_ONLY : vérifier que l'implication est correctement qualifiée
+- INDIRECT et MENTIONED_ONLY : vérifier que l'implication est correctement qualifiée et proposer corrected_involvement si elle est fausse
 
 VÉRIFICATION DES DATES :
-- factsDate doit être antérieure à startDate (les faits précèdent la médiatisation)
+- Le message fournit la « Date du jour » : comparer TOUTE date à cette référence, JAMAIS à tes connaissances internes
+- Une date antérieure ou égale à la date du jour n'est PAS une date future
+- factsDate doit être antérieure ou égale à startDate (les faits précèdent la médiatisation)
 - verdictDate doit être postérieure à factsDate
-- Si les dates sont incohérentes, signaler INVALID_DATES
+- Si les dates sont incohérentes entre elles ou réellement postérieures à la date du jour, signaler INVALID_DATES
 
 DÉTECTION DE DOUBLONS :
 - Si la liste d'affaires existantes du même politicien contient un titre similaire, signaler POSSIBLE_DUPLICATE`;
@@ -284,8 +310,11 @@ DÉTECTION DE DOUBLONS :
  * Returns a structured recommendation (PUBLISH / REJECT / NEEDS_REVIEW).
  */
 export async function moderateAffair(input: ModerationInput): Promise<ModerationResult> {
+  const today = input.today ?? new Date().toISOString().slice(0, 10);
+
   // Build user message with all affair data
-  let userContent = `Modère cette affaire judiciaire :\n`;
+  let userContent = `Date du jour : ${today}\n`;
+  userContent += `\nModère cette affaire judiciaire :\n`;
   userContent += `\nPoliticien : ${input.politicianName} (slug: ${input.politicianSlug})`;
   userContent += `\nTitre : ${input.title}`;
   userContent += `\nDescription : ${input.description}`;
@@ -368,6 +397,13 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
         null as unknown as (typeof AFFAIR_CATEGORIES)[number]
       )
     : null;
+  const correctedInvolvement = result.corrected_involvement
+    ? validateEnum(
+        result.corrected_involvement as string,
+        INVOLVEMENTS,
+        null as unknown as (typeof INVOLVEMENTS)[number]
+      )
+    : null;
 
   const issues: ModerationIssue[] = Array.isArray(result.issues)
     ? result.issues
@@ -410,6 +446,7 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
     correctedDescription,
     correctedStatus,
     correctedCategory,
+    correctedInvolvement,
     issues,
     model: MODEL,
   };

--- a/src/services/affairs/matching.test.ts
+++ b/src/services/affairs/matching.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock db so the module can be imported without a database connection
+// (sameCategoryFamily is pure, but matching.ts imports @/lib/db at module level).
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { sameCategoryFamily } from "./matching";
 
 // We need to test the normalizeAffairTitle function indirectly since it's private.
 // Instead, we test the exported behavior by importing and calling it via a test helper.
@@ -75,5 +81,35 @@ describe("normalizeAffairTitle", () => {
 
   it("works without politician name", () => {
     expect(normalizeAffairTitle("Fraude fiscale")).toBe("fraude fiscale");
+  });
+});
+
+describe("sameCategoryFamily", () => {
+  it("matches identical categories", () => {
+    expect(sameCategoryFamily("MENACE", "MENACE")).toBe(true);
+  });
+
+  it("matches sibling categories within the probity family", () => {
+    expect(sameCategoryFamily("DETOURNEMENT_FONDS_PUBLICS", "FAVORITISME")).toBe(true);
+    expect(sameCategoryFamily("CONFLIT_INTERETS", "PRISE_ILLEGALE_INTERETS")).toBe(true);
+  });
+
+  it("matches sibling categories within the persons family", () => {
+    expect(sameCategoryFamily("VIOLENCE", "MENACE")).toBe(true);
+    expect(sameCategoryFamily("AGRESSION_SEXUELLE", "HARCELEMENT_SEXUEL")).toBe(true);
+  });
+
+  it("treats AUTRE as a wildcard", () => {
+    expect(sameCategoryFamily("AUTRE", "DETOURNEMENT_FONDS_PUBLICS")).toBe(true);
+    expect(sameCategoryFamily("MENACE", "AUTRE")).toBe(true);
+  });
+
+  it("rejects categories from different families", () => {
+    expect(sameCategoryFamily("MENACE", "FRAUDE_FISCALE")).toBe(false);
+    expect(sameCategoryFamily("DIFFAMATION", "VIOLENCE")).toBe(false);
+  });
+
+  it("rejects unknown categories that are not AUTRE", () => {
+    expect(sameCategoryFamily("UNKNOWN_A", "UNKNOWN_B")).toBe(false);
   });
 });

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -11,6 +11,62 @@ import type { AffairCategory } from "@/generated/prisma";
 
 export type MatchConfidence = "CERTAIN" | "HIGH" | "POSSIBLE";
 
+/**
+ * Category families for fuzzy duplicate clustering.
+ * Affairs from the same news event are often imported with sibling categories
+ * (e.g. DETOURNEMENT_FONDS_PUBLICS vs FAVORITISME vs CONFLIT_INTERETS for the
+ * same probity investigation), so duplicate detection compares families
+ * rather than exact categories. AUTRE acts as a wildcard.
+ */
+const CATEGORY_FAMILIES: Record<string, string[]> = {
+  probite: [
+    "CORRUPTION",
+    "CORRUPTION_PASSIVE",
+    "TRAFIC_INFLUENCE",
+    "PRISE_ILLEGALE_INTERETS",
+    "FAVORITISME",
+    "DETOURNEMENT_FONDS_PUBLICS",
+    "EMPLOI_FICTIF",
+    "CONFLIT_INTERETS",
+    "RECEL",
+    "ABUS_BIENS_SOCIAUX",
+    "ABUS_CONFIANCE",
+    "BLANCHIMENT",
+    "FRAUDE_FISCALE",
+    "FINANCEMENT_ILLEGAL_CAMPAGNE",
+    "FINANCEMENT_ILLEGAL_PARTI",
+    "FAUX_ET_USAGE_FAUX",
+  ],
+  personnes: [
+    "VIOLENCE",
+    "MENACE",
+    "AGRESSION_SEXUELLE",
+    "HARCELEMENT_SEXUEL",
+    "HARCELEMENT_MORAL",
+  ],
+  expression: ["DIFFAMATION", "INJURE", "INCITATION_HAINE"],
+};
+
+function categoryFamily(category: string): string | null {
+  for (const [family, categories] of Object.entries(CATEGORY_FAMILIES)) {
+    if (categories.includes(category)) return family;
+  }
+  return null;
+}
+
+/**
+ * Check whether two affair categories belong to the same family.
+ * AUTRE matches any family (imports frequently fall back to AUTRE
+ * when the legal qualification is unclear).
+ */
+export function sameCategoryFamily(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a === "AUTRE" || b === "AUTRE") return true;
+  const familyA = categoryFamily(a);
+  const familyB = categoryFamily(b);
+  return familyA !== null && familyA === familyB;
+}
+
 export interface MatchResult {
   affairId: string;
   confidence: MatchConfidence;

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    affair: { findMany: vi.fn() },
+    dismissedDuplicate: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("./matching", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./matching")>();
+  return { ...actual, findMatchingAffairs: vi.fn() };
+});
+
+import { findPotentialDuplicates } from "./reconciliation";
+import { db } from "@/lib/db";
+import { findMatchingAffairs } from "./matching";
+
+const mockedAffairFindMany = db.affair.findMany as ReturnType<typeof vi.fn>;
+const mockedDismissedFindMany = db.dismissedDuplicate.findMany as ReturnType<typeof vi.fn>;
+const mockedFindMatchingAffairs = findMatchingAffairs as ReturnType<typeof vi.fn>;
+
+function makeDraft(
+  id: string,
+  overrides: Partial<{
+    title: string;
+    category: string;
+    createdAt: Date;
+    publicationStatus: string;
+    politicianId: string;
+  }> = {}
+) {
+  return {
+    id,
+    title: overrides.title ?? `Affaire ${id}`,
+    ecli: null,
+    pourvoiNumber: null,
+    caseNumbers: [],
+    category: overrides.category ?? "AUTRE",
+    verdictDate: null,
+    politicianId: overrides.politicianId ?? "p1",
+    createdAt: overrides.createdAt ?? new Date("2026-05-19T10:00:00Z"),
+    publicationStatus: overrides.publicationStatus ?? "DRAFT",
+    sources: [],
+  };
+}
+
+describe("findPotentialDuplicates — draft window clustering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedDismissedFindMany.mockResolvedValue([]);
+    mockedFindMatchingAffairs.mockResolvedValue([]);
+  });
+
+  it("clusters same-politician drafts created within the window across sibling categories", async () => {
+    // Scénario type cluster Philippe : titres divergents, catégories sœurs, créés à quelques jours
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        title: "Affaire de gestion présumée illégale au Havre",
+        category: "DETOURNEMENT_FONDS_PUBLICS",
+        createdAt: new Date("2026-05-19T19:14:00Z"),
+      }),
+      makeDraft("a2", {
+        title: "Enquête pour favoritisme dans l'attribution d'une convention",
+        category: "FAVORITISME",
+        createdAt: new Date("2026-05-20T12:15:00Z"),
+      }),
+      makeDraft("a3", {
+        title: "Affaire Edouard Philippe au Havre",
+        category: "AUTRE",
+        createdAt: new Date("2026-05-26T05:09:00Z"),
+      }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(3); // a1-a2, a1-a3, a2-a3
+    for (const pair of duplicates) {
+      expect(pair.matchedBy).toBe("politician+category+window");
+      expect(pair.confidence).toBe("POSSIBLE");
+      expect(pair.score).toBe(0.45);
+    }
+  });
+
+  it("does not pair drafts created more than 14 days apart", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { createdAt: new Date("2026-05-01T00:00:00Z") }),
+      makeDraft("a2", { createdAt: new Date("2026-05-20T00:00:00Z") }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("does not pair drafts from incompatible category families", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { category: "MENACE" }),
+      makeDraft("a2", { category: "FRAUDE_FISCALE" }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("ignores non-DRAFT affairs in the window pass", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { publicationStatus: "PUBLISHED" }),
+      makeDraft("a2"),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("does not pair drafts of different politicians", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { politicianId: "p1" }),
+      makeDraft("a2", { politicianId: "p2" }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("respects dismissed pairs", async () => {
+    mockedAffairFindMany.mockResolvedValue([makeDraft("a1"), makeDraft("a2")]);
+    mockedDismissedFindMany.mockResolvedValue([{ affairIdA: "a1", affairIdB: "a2" }]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("does not duplicate pairs already found by identifier matching", async () => {
+    mockedAffairFindMany.mockResolvedValue([makeDraft("a1"), makeDraft("a2")]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.matchedBy).toBe("pourvoiNumber");
+  });
+});

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -7,7 +7,7 @@
 
 import { db } from "@/lib/db";
 import { Prisma, type SourceType } from "@/generated/prisma";
-import { findMatchingAffairs, type MatchConfidence } from "./matching";
+import { findMatchingAffairs, sameCategoryFamily, type MatchConfidence } from "./matching";
 
 // ============================================
 // TYPES
@@ -39,6 +39,12 @@ export interface ReconciliationStats {
 // ============================================
 
 /**
+ * Window (in days) for clustering DRAFT affairs of the same politician.
+ * Press sync waves spread coverage of a single event over up to two weeks.
+ */
+const DRAFT_CLUSTER_WINDOW_DAYS = 14;
+
+/**
  * Find potential duplicate pairs among unverified affairs.
  *
  * Groups affairs by politician, then compares each pair using
@@ -57,6 +63,8 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
       category: true,
       verdictDate: true,
       politicianId: true,
+      createdAt: true,
+      publicationStatus: true,
       sources: { select: { sourceType: true } },
     },
   });
@@ -120,6 +128,52 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
             score: matchForA.score,
           });
         }
+      }
+    }
+  }
+
+  // Second pass — DRAFT clustering by creation window.
+  // Drafts from the same news event are imported over a few days with
+  // divergent titles and sibling categories (e.g. 13 drafts for the same
+  // Le Havre investigation), which the identifier/title matching above
+  // cannot catch. Pair drafts of the same politician created within
+  // DRAFT_CLUSTER_WINDOW_DAYS when their categories share a family.
+  // POSSIBLE only (score 0.45): never auto-merged, surfaced for human review.
+  const foundPairs = new Set(duplicates.map((d) => [d.affairA.id, d.affairB.id].sort().join(":")));
+
+  for (const group of byPolitician.values()) {
+    const draftGroup = group.filter((a) => a.publicationStatus === "DRAFT");
+    if (draftGroup.length < 2) continue;
+
+    for (let i = 0; i < draftGroup.length; i++) {
+      for (let j = i + 1; j < draftGroup.length; j++) {
+        const a = draftGroup[i]!;
+        const b = draftGroup[j]!;
+
+        const pairKey = [a.id, b.id].sort().join(":");
+        if (dismissedSet.has(pairKey) || foundPairs.has(pairKey)) continue;
+
+        const daysApart =
+          Math.abs(a.createdAt.getTime() - b.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+        if (daysApart > DRAFT_CLUSTER_WINDOW_DAYS) continue;
+        if (!sameCategoryFamily(a.category, b.category)) continue;
+
+        foundPairs.add(pairKey);
+        duplicates.push({
+          affairA: {
+            id: a.id,
+            title: a.title,
+            sources: [...new Set(a.sources.map((s) => s.sourceType))],
+          },
+          affairB: {
+            id: b.id,
+            title: b.title,
+            sources: [...new Set(b.sources.map((s) => s.sourceType))],
+          },
+          confidence: "POSSIBLE",
+          matchedBy: "politician+category+window",
+          score: 0.45,
+        });
       }
     }
   }

--- a/src/types/moderation-preflight.ts
+++ b/src/types/moderation-preflight.ts
@@ -36,6 +36,7 @@ export const DraftCandidateSchema = z.object({
   preflight: z.object({
     moderationRecommendation: ModerationRecommendationSchema,
     moderationIssues: z.array(ModerationIssueSchema),
+    correctedInvolvement: z.string().nullable(),
     attribution: AttributionAuditSchema,
     duplicateOf: z.array(z.string()),
   }),


### PR DESCRIPTION
Affiche le titre citoyen sur les surfaces publiques **uniquement** quand `status = APPROVED` et `policyTitle` valide ; fallback titre officiel partout ailleurs. Point de décision unique : `resolvePublicTitle` (jamais contourné).

## Surfaces câblées (via toPublicTitleView)
- Détail de vote : h1 + badge « Titre explicatif » + repli titre officiel, plus métadonnées SEO, JSON-LD, ShareBar.
- Image OG du vote.
- Cartes liste / quotidien / spotlight (VoteCard, DailyVotesPage, KeyVoteCard, HeroSpotlight) + page thème + votes marquants d'un groupe.
- Onglet votes des fiches politiciens (liste + section résumé).

## Sécurité d'affichage
- APPROVED + valide → titre citoyen ; DRAFT / NEEDS_REVIEW / REJECTED / STALE / null → titre officiel. Aucune fuite (corps, métadonnées, OG, JSON-LD).
- Revalidation publique V1 (path-based) sur approve / reject / edit / regenerate : une approbation s'affiche, un reject/regenerate d'une ligne approuvée la masque. Onglets politiciens : rafraîchis sur leur cycle ISR (suivi tags = follow-up).
- Aucun nouveau chemin d'approbation ; `previewAsApproved` reste réservé à l'admin.

## Vérifications
- Audit grep bidirectionnel : aucun read direct de `policyTitle` hors résolveur ; aucun rendu de titre officiel public qui contourne l'adaptateur.
- `tsc` : 0 ; `next build` : compilé ; suite complète : 1439 tests passés (dont nouvelle suite no-leak 21 + transitions de visibilité 4, validées sur staging).

## Reste à faire après déploiement (Plan 6, étapes 10-11)
- Contrôle d'acceptation sur un scrutin approuvé réel (détail / carte / metadata / JSON-LD / OG) + un non-approuvé en repli.
- Brouillons de communication (NON publiés tant que l'exemple approuvé n'est pas vérifié en prod).
- Audit SEO/accessibilité déployé (Rich Results, Lighthouse, axe).

11 lignes APPROVED en prod (1 + 10 approuvées via le vrai approveGuard).