### PR TITLE
Hotfix RGPD art. 10 : publication, fuites par id, agrégats judiciaires

### DIFF
--- a/src/app/affaires/[slug]/opengraph-image.tsx
+++ b/src/app/affaires/[slug]/opengraph-image.tsx
@@ -35,8 +35,8 @@ const STATUS_COLORS: Partial<Record<AffairStatus, string>> = {
 
 export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
-  const affair = await db.affair.findUnique({
-    where: { slug },
+  const affair = await db.affair.findFirst({
+    where: { slug, publicationStatus: "PUBLISHED" },
     select: {
       title: true,
       status: true,

--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -37,7 +37,7 @@ import type { Prisma } from "@/generated/prisma";
 import { SITE_URL } from "@/config/site";
 import { ShareBar } from "@/components/ui/ShareBar";
 import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
-import { buildPublicAffairLookupWheres } from "@/lib/affairs/affair-lookup";
+import { buildPublicAffairLookupWheres, pickPublicLinkedAffair } from "@/lib/affairs/affair-lookup";
 import { SlappBadge } from "@/components/slapp/SlappBadge";
 import { CriteriaList } from "@/components/slapp/CriteriaList";
 import type { SlappCriteriaPayload } from "@/config/slapp";
@@ -99,15 +99,18 @@ const affairInclude = {
       slug: true,
       title: true,
       involvement: true,
+      publicationStatus: true,
       politician: { select: { fullName: true, slug: true } },
     },
   },
   linkedBy: {
+    where: { publicationStatus: "PUBLISHED" as const },
     select: {
       id: true,
       slug: true,
       title: true,
       involvement: true,
+      publicationStatus: true,
       politician: { select: { fullName: true, slug: true } },
     },
   },
@@ -180,7 +183,7 @@ export default async function AffairDetailPage({ params }: PageProps) {
     partyAtTime: affair.partyAtTime,
     currentParty: affair.politician.currentParty,
   });
-  const linked = affair.linkedAffair || affair.linkedBy?.[0];
+  const linked = pickPublicLinkedAffair(affair.linkedAffair, affair.linkedBy);
 
   return (
     <>

--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -37,6 +37,7 @@ import type { Prisma } from "@/generated/prisma";
 import { SITE_URL } from "@/config/site";
 import { ShareBar } from "@/components/ui/ShareBar";
 import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
+import { buildPublicAffairLookupWheres } from "@/lib/affairs/affair-lookup";
 import { SlappBadge } from "@/components/slapp/SlappBadge";
 import { CriteriaList } from "@/components/slapp/CriteriaList";
 import type { SlappCriteriaPayload } from "@/config/slapp";
@@ -123,16 +124,18 @@ type AffairResult = NonNullable<Awaited<ReturnType<typeof findAffair>>>;
 const getAffairWithRedirect = cache(async function getAffairWithRedirect(
   slugOrId: string
 ): Promise<{ affair: AffairResult | null; redirect: string | null }> {
-  // 1. Try current slug (canonical)
-  let affair = await findAffair({ slug: slugOrId, publicationStatus: "PUBLISHED" });
+  const [bySlug, byOldSlug, byId] = buildPublicAffairLookupWheres(slugOrId);
+
+  // 1. Slug canonique
+  let affair = await findAffair(bySlug);
   if (affair) return { affair, redirect: null };
 
-  // 2. Try old slugs (301 redirect)
-  affair = await findAffair({ oldSlugs: { has: slugOrId }, publicationStatus: "PUBLISHED" });
+  // 2. Ancien slug (redirection 301)
+  affair = await findAffair(byOldSlug);
   if (affair) return { affair, redirect: affair.slug };
 
-  // 3. Try by ID (CUID)
-  affair = await findAffair({ id: slugOrId });
+  // 3. Id (CUID) — filtré PUBLISHED comme les autres voies
+  affair = await findAffair(byId);
   if (affair) return { affair, redirect: affair.slug };
 
   return { affair: null, redirect: null };

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -213,10 +213,11 @@ export default async function PoliticianPage({ params }: PageProps) {
   const condamnationsCount = directAndIndirect.filter(
     (a) => getJudicialMaturity(a.status) === "CONDAMNATION"
   ).length;
-  const proceduresEnCoursCount = directAndIndirect.filter((a) => {
-    const m = getJudicialMaturity(a.status);
-    return m === "PROCEDURE_VALIDEE" || m === "ENQUETE";
-  }).length;
+  // Tier 2 strict : les enquêtes préliminaires ne comptent pas comme
+  // procédure validée par un juge (RGPD art. 10, invariant I4)
+  const proceduresEnCoursCount = directAndIndirect.filter(
+    (a) => getJudicialMaturity(a.status) === "PROCEDURE_VALIDEE"
+  ).length;
 
   // Encart: only condamnations (Tier 1)
   const encartAffairs = directAffairs.filter(
@@ -700,7 +701,7 @@ export default async function PoliticianPage({ params }: PageProps) {
                 )}
                 {proceduresEnCoursCount > 0 && (
                   <div className="flex justify-between">
-                    <span className="text-muted-foreground">Procédures en cours</span>
+                    <span className="text-muted-foreground">Procédures validées en cours</span>
                     <span className="font-semibold">{proceduresEnCoursCount}</span>
                   </div>
                 )}

--- a/src/components/politicians/AffairsSection.tsx
+++ b/src/components/politicians/AffairsSection.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { pickPublicLinkedAffair } from "@/lib/affairs/affair-lookup";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -89,7 +90,7 @@ export function AffairsSection({ affairs, civility }: AffairsSectionProps) {
                     </p>
                     <div className="space-y-6">
                       {levelAffairs.map((affair) => {
-                        const linked = affair.linkedAffair || affair.linkedBy?.[0];
+                        const linked = pickPublicLinkedAffair(affair.linkedAffair, affair.linkedBy);
                         return (
                           <div key={affair.id}>
                             <AffairCard
@@ -211,7 +212,7 @@ export function AffairsSection({ affairs, civility }: AffairsSectionProps) {
           <CardContent>
             <div className="space-y-6">
               {victimAffairs.map((affair) => {
-                const linked = affair.linkedAffair || affair.linkedBy?.[0];
+                const linked = pickPublicLinkedAffair(affair.linkedAffair, affair.linkedBy);
                 return (
                   <div
                     key={affair.id}

--- a/src/components/stats/JudicialSection.tsx
+++ b/src/components/stats/JudicialSection.tsx
@@ -138,8 +138,9 @@ export function JudicialSection({
             </div>
             <div className="text-sm text-muted-foreground mt-1">Élus mis en cause</div>
             <div className="text-xs text-muted-foreground mt-0.5">
-              {maturityCounts.PROCEDURE_VALIDEE + maturityCounts.ENQUETE} procédure
-              {maturityCounts.PROCEDURE_VALIDEE + maturityCounts.ENQUETE !== 1 ? "s" : ""} en cours
+              {maturityCounts.PROCEDURE_VALIDEE} procédure
+              {maturityCounts.PROCEDURE_VALIDEE !== 1 ? "s" : ""} validée
+              {maturityCounts.PROCEDURE_VALIDEE !== 1 ? "s" : ""} par un juge
             </div>
           </CardContent>
         </Card>
@@ -244,9 +245,12 @@ export function JudicialSection({
         Les &laquo;&nbsp;atteintes à la probité&nbsp;&raquo; regroupent les infractions liées à
         l&apos;exercice du mandat public : corruption, trafic d&apos;influence, détournement de
         fonds publics, prise illégale d&apos;intérêts, emplois fictifs, financement illégal de
-        campagne ou de parti, et incitation à la haine. Les compteurs ne prennent en compte que les
-        affaires validées par un juge (condamnations et procédures en cours). Les enquêtes
-        préliminaires ne sont pas comptabilisées.{" "}
+        campagne ou de parti, et incitation à la haine. Les compteurs &laquo;&nbsp;Élus
+        condamnés&nbsp;&raquo; et &laquo;&nbsp;Élus mis en cause&nbsp;&raquo; ne prennent en compte
+        que les affaires validées par un juge : condamnations, mises en examen, instructions,
+        renvois devant un tribunal et procès en cours. Les enquêtes préliminaires, les simples
+        mentions, les personnes victimes ou plaignantes et les procédures closes sans condamnation
+        en sont exclues.{" "}
         <a href="/methodologie#comment-nous-comptons" className="text-primary hover:underline">
           Comment nous comptons
         </a>

--- a/src/config/judicial-maturity.ts
+++ b/src/config/judicial-maturity.ts
@@ -59,6 +59,13 @@ export const CONDAMNATION_STATUSES: AffairStatus[] = Object.entries(STATUS_TO_MA
   .filter(([, tier]) => tier === "CONDAMNATION")
   .map(([status]) => status as AffairStatus);
 
+/** Tier 2 only - procédures validées par un juge, hors enquête préliminaire.
+ *  À utiliser pour tout compteur présenté comme « mis en cause » ou
+ *  « validé par un juge ». */
+export const PROCEDURE_VALIDEE_STATUSES: AffairStatus[] = Object.entries(STATUS_TO_MATURITY)
+  .filter(([, tier]) => tier === "PROCEDURE_VALIDEE")
+  .map(([status]) => status as AffairStatus);
+
 /** Tier 2 + 3 - procedures en cours (for display: groups validated + enquete) */
 export const EN_COURS_STATUSES: AffairStatus[] = Object.entries(STATUS_TO_MATURITY)
   .filter(([, tier]) => tier === "PROCEDURE_VALIDEE" || tier === "ENQUETE")

--- a/src/lib/affairs/__tests__/affair-lookup.test.ts
+++ b/src/lib/affairs/__tests__/affair-lookup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildPublicAffairLookupWheres } from "@/lib/affairs/affair-lookup";
+import { buildPublicAffairLookupWheres, pickPublicLinkedAffair } from "@/lib/affairs/affair-lookup";
 
 describe("buildPublicAffairLookupWheres — contrat no-leak", () => {
   it("chacune des 3 clauses (slug, oldSlugs, id) filtre PUBLISHED", () => {
@@ -13,5 +13,26 @@ describe("buildPublicAffairLookupWheres — contrat no-leak", () => {
   it("la clause id ne résout jamais sans filtre de publication", () => {
     const [, , byId] = buildPublicAffairLookupWheres("cuid_draft");
     expect(byId).toEqual({ id: "cuid_draft", publicationStatus: "PUBLISHED" });
+  });
+});
+
+describe("pickPublicLinkedAffair — contrat no-leak", () => {
+  const published = { slug: "a", title: "A", publicationStatus: "PUBLISHED" as const };
+  const draft = { slug: "b", title: "B", publicationStatus: "DRAFT" as const };
+
+  it("retourne l'affaire liée publiée", () => {
+    expect(pickPublicLinkedAffair(published, [])).toBe(published);
+  });
+
+  it("ne retourne jamais une affaire liée non publiée", () => {
+    expect(pickPublicLinkedAffair(draft, [])).toBeNull();
+  });
+
+  it("retombe sur linkedBy si linkedAffair est non publiée", () => {
+    expect(pickPublicLinkedAffair(draft, [published])).toBe(published);
+  });
+
+  it("retourne null sans aucune affaire liée publiée", () => {
+    expect(pickPublicLinkedAffair(null, [])).toBeNull();
   });
 });

--- a/src/lib/affairs/__tests__/affair-lookup.test.ts
+++ b/src/lib/affairs/__tests__/affair-lookup.test.ts
@@ -17,8 +17,9 @@ describe("buildPublicAffairLookupWheres — contrat no-leak", () => {
 });
 
 describe("pickPublicLinkedAffair — contrat no-leak", () => {
-  const published = { slug: "a", title: "A", publicationStatus: "PUBLISHED" as const };
-  const draft = { slug: "b", title: "B", publicationStatus: "DRAFT" as const };
+  type AffairFixture = { slug: string; title: string; publicationStatus: "PUBLISHED" | "DRAFT" };
+  const published: AffairFixture = { slug: "a", title: "A", publicationStatus: "PUBLISHED" };
+  const draft: AffairFixture = { slug: "b", title: "B", publicationStatus: "DRAFT" };
 
   it("retourne l'affaire liée publiée", () => {
     expect(pickPublicLinkedAffair(published, [])).toBe(published);

--- a/src/lib/affairs/__tests__/affair-lookup.test.ts
+++ b/src/lib/affairs/__tests__/affair-lookup.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { buildPublicAffairLookupWheres } from "@/lib/affairs/affair-lookup";
+
+describe("buildPublicAffairLookupWheres — contrat no-leak", () => {
+  it("chacune des 3 clauses (slug, oldSlugs, id) filtre PUBLISHED", () => {
+    const wheres = buildPublicAffairLookupWheres("abc123");
+    expect(wheres).toHaveLength(3);
+    for (const where of wheres) {
+      expect(where.publicationStatus).toBe("PUBLISHED");
+    }
+  });
+
+  it("la clause id ne résout jamais sans filtre de publication", () => {
+    const [, , byId] = buildPublicAffairLookupWheres("cuid_draft");
+    expect(byId).toEqual({ id: "cuid_draft", publicationStatus: "PUBLISHED" });
+  });
+});

--- a/src/lib/affairs/__tests__/public-filters.test.ts
+++ b/src/lib/affairs/__tests__/public-filters.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  getPublishedAffairWhere,
+  getAdverseAffairWhere,
+  getConvictionOnlyWhere,
+  getMisEnCauseWhere,
+  getFavorableOutcomeWhere,
+} from "@/lib/affairs/public-filters";
+
+/** Statuts qui ne doivent JAMAIS apparaître dans un agrégat à charge. */
+const EXCLUDED_STATUSES = [
+  "ENQUETE_PRELIMINAIRE",
+  "RELAXE",
+  "ACQUITTEMENT",
+  "NON_LIEU",
+  "CLASSEMENT_SANS_SUITE",
+  "PRESCRIPTION",
+] as const;
+
+/** Involvements qui ne doivent JAMAIS être comptés comme mis en cause. */
+const EXCLUDED_INVOLVEMENTS = ["MENTIONED_ONLY", "VICTIM", "PLAINTIFF"] as const;
+
+function statusesOf(where: { status?: unknown }): string[] {
+  return (where.status as { in: string[] }).in;
+}
+
+function involvementsOf(where: { involvement?: unknown }): string[] {
+  return (where.involvement as { in: string[] }).in;
+}
+
+describe("public-filters — contrat des agrégats (RGPD art. 10)", () => {
+  it("tous les builders filtrent PUBLISHED", () => {
+    for (const where of [
+      getPublishedAffairWhere(),
+      getAdverseAffairWhere(),
+      getConvictionOnlyWhere(),
+      getMisEnCauseWhere(),
+      getFavorableOutcomeWhere(),
+    ]) {
+      expect(where.publicationStatus).toBe("PUBLISHED");
+    }
+  });
+
+  it("l'agrégat à charge exclut chaque statut non validé ou favorable", () => {
+    const statuses = statusesOf(getAdverseAffairWhere());
+    for (const excluded of EXCLUDED_STATUSES) {
+      expect(statuses).not.toContain(excluded);
+    }
+  });
+
+  it("l'agrégat à charge exclut mentions, victimes et plaignants", () => {
+    const involvements = involvementsOf(getAdverseAffairWhere());
+    for (const excluded of EXCLUDED_INVOLVEMENTS) {
+      expect(involvements).not.toContain(excluded);
+    }
+    expect(involvements).toEqual(["DIRECT", "INDIRECT"]);
+  });
+
+  it("« condamnés » = statuts de condamnation uniquement", () => {
+    expect(statusesOf(getConvictionOnlyWhere()).sort()).toEqual([
+      "APPEL_EN_COURS",
+      "CONDAMNATION_DEFINITIVE",
+      "CONDAMNATION_PREMIERE_INSTANCE",
+    ]);
+  });
+
+  it("« mis en cause » = Tier 2 strict, sans enquête préliminaire", () => {
+    expect(statusesOf(getMisEnCauseWhere()).sort()).toEqual([
+      "INSTRUCTION",
+      "MISE_EN_EXAMEN",
+      "PROCES_EN_COURS",
+      "RENVOI_TRIBUNAL",
+    ]);
+  });
+
+  it("issues favorables = procédures closes sans condamnation (PRESCRIPTION incluse)", () => {
+    expect(statusesOf(getFavorableOutcomeWhere()).sort()).toEqual([
+      "ACQUITTEMENT",
+      "CLASSEMENT_SANS_SUITE",
+      "NON_LIEU",
+      "PRESCRIPTION",
+      "RELAXE",
+    ]);
+  });
+});

--- a/src/lib/affairs/affair-lookup.ts
+++ b/src/lib/affairs/affair-lookup.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from "@/generated/prisma";
+import type { PublicationStatus } from "@/generated/prisma";
 
 /**
  * Les trois clauses de résolution publique d'une affaire : slug canonique,
@@ -8,6 +9,26 @@ import type { Prisma } from "@/generated/prisma";
  * DRAFT, ARCHIVED, EXCLUDED ou REJECTED ne doit être résolue par aucune voie,
  * y compris par id (RGPD article 10, invariant I7).
  */
+interface LinkedAffairLike {
+  publicationStatus: PublicationStatus;
+}
+
+/**
+ * Sélectionne l'affaire liée à afficher publiquement.
+ *
+ * Prisma ne permet pas de filtrer une relation to-one (`linkedAffair`) par
+ * `where` : le filtre publicationStatus doit donc être appliqué ici. Aucune
+ * affaire liée non publiée ne doit être rendue (titre, slug), même depuis la
+ * page d'une affaire publiée (RGPD article 10, invariant I7).
+ */
+export function pickPublicLinkedAffair<A extends LinkedAffairLike, B extends LinkedAffairLike>(
+  linkedAffair: A | null | undefined,
+  linkedBy: B[] | null | undefined
+): A | B | null {
+  if (linkedAffair && linkedAffair.publicationStatus === "PUBLISHED") return linkedAffair;
+  return linkedBy?.find((a) => a.publicationStatus === "PUBLISHED") ?? null;
+}
+
 export function buildPublicAffairLookupWheres(
   slugOrId: string
 ): [Prisma.AffairWhereInput, Prisma.AffairWhereInput, Prisma.AffairWhereInput] {

--- a/src/lib/affairs/affair-lookup.ts
+++ b/src/lib/affairs/affair-lookup.ts
@@ -1,14 +1,6 @@
 import type { Prisma } from "@/generated/prisma";
 import type { PublicationStatus } from "@/generated/prisma";
 
-/**
- * Les trois clauses de résolution publique d'une affaire : slug canonique,
- * ancien slug (redirection 301), puis id (CUID).
- *
- * Chaque clause DOIT contenir publicationStatus PUBLISHED : aucune affaire
- * DRAFT, ARCHIVED, EXCLUDED ou REJECTED ne doit être résolue par aucune voie,
- * y compris par id (RGPD article 10, invariant I7).
- */
 interface LinkedAffairLike {
   publicationStatus: PublicationStatus;
 }
@@ -30,6 +22,14 @@ export function pickPublicLinkedAffair<T extends LinkedAffairLike>(
   return linkedBy?.find((a) => a.publicationStatus === "PUBLISHED") ?? null;
 }
 
+/**
+ * Les trois clauses de résolution publique d'une affaire : slug canonique,
+ * ancien slug (redirection 301), puis id (CUID).
+ *
+ * Chaque clause DOIT contenir publicationStatus PUBLISHED : aucune affaire
+ * DRAFT, ARCHIVED, EXCLUDED ou REJECTED ne doit être résolue par aucune voie,
+ * y compris par id (RGPD article 10, invariant I7).
+ */
 export function buildPublicAffairLookupWheres(
   slugOrId: string
 ): [Prisma.AffairWhereInput, Prisma.AffairWhereInput, Prisma.AffairWhereInput] {

--- a/src/lib/affairs/affair-lookup.ts
+++ b/src/lib/affairs/affair-lookup.ts
@@ -1,0 +1,19 @@
+import type { Prisma } from "@/generated/prisma";
+
+/**
+ * Les trois clauses de résolution publique d'une affaire : slug canonique,
+ * ancien slug (redirection 301), puis id (CUID).
+ *
+ * Chaque clause DOIT contenir publicationStatus PUBLISHED : aucune affaire
+ * DRAFT, ARCHIVED, EXCLUDED ou REJECTED ne doit être résolue par aucune voie,
+ * y compris par id (RGPD article 10, invariant I7).
+ */
+export function buildPublicAffairLookupWheres(
+  slugOrId: string
+): [Prisma.AffairWhereInput, Prisma.AffairWhereInput, Prisma.AffairWhereInput] {
+  return [
+    { slug: slugOrId, publicationStatus: "PUBLISHED" },
+    { oldSlugs: { has: slugOrId }, publicationStatus: "PUBLISHED" },
+    { id: slugOrId, publicationStatus: "PUBLISHED" },
+  ];
+}

--- a/src/lib/affairs/affair-lookup.ts
+++ b/src/lib/affairs/affair-lookup.ts
@@ -17,14 +17,15 @@ interface LinkedAffairLike {
  * Sélectionne l'affaire liée à afficher publiquement.
  *
  * Prisma ne permet pas de filtrer une relation to-one (`linkedAffair`) par
- * `where` : le filtre publicationStatus doit donc être appliqué ici. Aucune
- * affaire liée non publiée ne doit être rendue (titre, slug), même depuis la
- * page d'une affaire publiée (RGPD article 10, invariant I7).
+ * un `where` imbriqué dans un `select` : le filtre publicationStatus doit
+ * donc être appliqué ici. Aucune affaire liée non publiée ne doit être
+ * rendue (titre, slug), même depuis la page d'une affaire publiée (RGPD
+ * article 10, invariant I7).
  */
-export function pickPublicLinkedAffair<A extends LinkedAffairLike, B extends LinkedAffairLike>(
-  linkedAffair: A | null | undefined,
-  linkedBy: B[] | null | undefined
-): A | B | null {
+export function pickPublicLinkedAffair<T extends LinkedAffairLike>(
+  linkedAffair: T | null | undefined,
+  linkedBy: T[] | null | undefined
+): T | null {
   if (linkedAffair && linkedAffair.publicationStatus === "PUBLISHED") return linkedAffair;
   return linkedBy?.find((a) => a.publicationStatus === "PUBLISHED") ?? null;
 }

--- a/src/lib/affairs/public-filters.ts
+++ b/src/lib/affairs/public-filters.ts
@@ -1,0 +1,70 @@
+import type { Prisma } from "@/generated/prisma";
+import {
+  AGGREGATE_STATUSES,
+  CONDAMNATION_STATUSES,
+  PROCEDURE_VALIDEE_STATUSES,
+  CLOSE_STATUSES,
+} from "@/config/judicial-maturity";
+
+/**
+ * Where-builders centralisés pour toute surface publique exposant ou
+ * comptant des affaires judiciaires (RGPD article 10, invariant I4).
+ *
+ * Règles :
+ * - tout agrégat filtre PUBLISHED ;
+ * - un agrégat à charge ne contient jamais ENQUETE_PRELIMINAIRE, ni une issue
+ *   favorable (RELAXE, ACQUITTEMENT, NON_LIEU, CLASSEMENT_SANS_SUITE,
+ *   PRESCRIPTION), ni MENTIONED_ONLY/VICTIM/PLAINTIFF ;
+ * - « condamnés » n'utilise que les statuts de condamnation ;
+ * - « mis en cause » n'utilise que le Tier 2 (procédures validées par un
+ *   juge), jamais l'enquête préliminaire.
+ */
+
+/** Involvements comptés dans les agrégats à charge. */
+export const ADVERSE_INVOLVEMENTS = ["DIRECT", "INDIRECT"] as const;
+
+export function getPublishedAffairWhere(): Prisma.AffairWhereInput {
+  return { publicationStatus: "PUBLISHED" };
+}
+
+/** Affaires à charge : condamnations + procédures validées par un juge. */
+export function getAdverseAffairWhere(): Prisma.AffairWhereInput {
+  return {
+    publicationStatus: "PUBLISHED",
+    involvement: { in: [...ADVERSE_INVOLVEMENTS] },
+    status: { in: AGGREGATE_STATUSES },
+  };
+}
+
+/** Condamnations uniquement (Tier 1). */
+export function getConvictionOnlyWhere(): Prisma.AffairWhereInput {
+  return {
+    publicationStatus: "PUBLISHED",
+    involvement: { in: [...ADVERSE_INVOLVEMENTS] },
+    status: { in: CONDAMNATION_STATUSES },
+  };
+}
+
+/** Mis en cause : procédures validées par un juge (Tier 2 strict). */
+export function getMisEnCauseWhere(): Prisma.AffairWhereInput {
+  return {
+    publicationStatus: "PUBLISHED",
+    involvement: { in: [...ADVERSE_INVOLVEMENTS] },
+    status: { in: PROCEDURE_VALIDEE_STATUSES },
+  };
+}
+
+/**
+ * Procédures closes sans condamnation (issues favorables, prescription incluse).
+ *
+ * Garde le filtre DIRECT/INDIRECT : ce compteur recense les procédures
+ * concernant une personne mise en cause, pas les cas où elle est victime
+ * ou plaignante.
+ */
+export function getFavorableOutcomeWhere(): Prisma.AffairWhereInput {
+  return {
+    publicationStatus: "PUBLISHED",
+    involvement: { in: [...ADVERSE_INVOLVEMENTS] },
+    status: { in: CLOSE_STATUSES },
+  };
+}

--- a/src/lib/data/affairs.ts
+++ b/src/lib/data/affairs.ts
@@ -399,34 +399,3 @@ export async function getVictimStats() {
     ongoingProcedures,
   };
 }
-
-export async function getLinkedAffair(affairId: string) {
-  const affair = await db.affair.findUnique({
-    where: { id: affairId },
-    select: {
-      linkedAffair: {
-        select: {
-          id: true,
-          slug: true,
-          title: true,
-          involvement: true,
-          politician: { select: { id: true, fullName: true, slug: true } },
-        },
-      },
-      linkedBy: {
-        select: {
-          id: true,
-          slug: true,
-          title: true,
-          involvement: true,
-          politician: { select: { id: true, fullName: true, slug: true } },
-        },
-      },
-    },
-  });
-
-  if (!affair) return null;
-  if (affair.linkedAffair) return affair.linkedAffair;
-  if (affair.linkedBy.length > 0) return affair.linkedBy[0];
-  return null;
-}

--- a/src/lib/data/homepage.ts
+++ b/src/lib/data/homepage.ts
@@ -3,10 +3,10 @@ import { db } from "@/lib/db";
 import { cacheTag, cacheLife } from "next/cache";
 import { FACTCHECK_ALLOWED_SOURCES } from "@/config/labels";
 import {
-  CONDAMNATION_STATUSES,
-  EN_COURS_STATUSES,
-  CLOSE_STATUSES,
-} from "@/config/judicial-maturity";
+  getConvictionOnlyWhere,
+  getMisEnCauseWhere,
+  getFavorableOutcomeWhere,
+} from "@/lib/affairs/public-filters";
 
 export interface HomepageKPIs {
   politiciansCount: number;
@@ -22,11 +22,6 @@ export async function getHomepageKPIs(): Promise<HomepageKPIs> {
   cacheTag("politicians", "affairs", "votes", "factchecks");
   cacheLife("minutes");
 
-  const affairBase = {
-    publicationStatus: "PUBLISHED" as const,
-    involvement: { in: ["DIRECT" as const, "INDIRECT" as const] },
-  };
-
   const [
     politiciansCount,
     condamnationsCount,
@@ -36,15 +31,9 @@ export async function getHomepageKPIs(): Promise<HomepageKPIs> {
     factchecksCount,
   ] = await Promise.all([
     db.politician.count({ where: { publicationStatus: "PUBLISHED" } }),
-    db.affair.count({
-      where: { ...affairBase, status: { in: CONDAMNATION_STATUSES } },
-    }),
-    db.affair.count({
-      where: { ...affairBase, status: { in: EN_COURS_STATUSES } },
-    }),
-    db.affair.count({
-      where: { ...affairBase, status: { in: CLOSE_STATUSES } },
-    }),
+    db.affair.count({ where: getConvictionOnlyWhere() }),
+    db.affair.count({ where: getMisEnCauseWhere() }),
+    db.affair.count({ where: getFavorableOutcomeWhere() }),
     db.scrutin.count(),
     db.factCheck.count({
       where: {

--- a/src/lib/data/politicians.ts
+++ b/src/lib/data/politicians.ts
@@ -37,15 +37,18 @@ export const getPolitician = cache(async function getPolitician(slug: string) {
               slug: true,
               title: true,
               involvement: true,
+              publicationStatus: true,
               politician: { select: { id: true, fullName: true, slug: true } },
             },
           },
           linkedBy: {
+            where: { publicationStatus: "PUBLISHED" as const },
             select: {
               id: true,
               slug: true,
               title: true,
               involvement: true,
+              publicationStatus: true,
               politician: { select: { id: true, fullName: true, slug: true } },
             },
           },

--- a/src/lib/data/statistics.ts
+++ b/src/lib/data/statistics.ts
@@ -7,12 +7,8 @@ import {
   AFFAIR_CATEGORY_LABELS,
   type AffairSuperCategory,
 } from "@/config/labels";
-import {
-  getJudicialMaturity,
-  CONDAMNATION_STATUSES,
-  EN_COURS_STATUSES,
-  type JudicialMaturity,
-} from "@/config/judicial-maturity";
+import { getJudicialMaturity, type JudicialMaturity } from "@/config/judicial-maturity";
+import { getConvictionOnlyWhere, getMisEnCauseWhere } from "@/lib/affairs/public-filters";
 import type { AffairStatus, AffairCategory } from "@/types";
 import type { Chamber } from "@/generated/prisma";
 
@@ -58,13 +54,14 @@ export async function getJudicialData() {
       }),
       // Unique politicians with condamnation (Tier 1)
       db.affair.findMany({
-        where: { ...directFilter, status: { in: CONDAMNATION_STATUSES } },
+        where: getConvictionOnlyWhere(),
         select: { politicianId: true },
         distinct: ["politicianId"],
       }),
-      // Unique politicians with procedures en cours (Tier 2 + 3)
+      // Unique politicians mis en cause (Tier 2 strict : validé par un juge,
+      // les enquêtes préliminaires ne sont pas comptabilisées)
       db.affair.findMany({
-        where: { ...directFilter, status: { in: EN_COURS_STATUSES } },
+        where: getMisEnCauseWhere(),
         select: { politicianId: true },
         distinct: ["politicianId"],
       }),

--- a/src/services/sync/__tests__/discover-affairs-builders.test.ts
+++ b/src/services/sync/__tests__/discover-affairs-builders.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildWikidataDiscoveredAffair,
+  type WikidataDiscoveredAffairInput,
+} from "@/services/sync/discover-affairs-builders";
+
+const baseInput: WikidataDiscoveredAffairInput = {
+  politicianId: "pol_1",
+  politicianName: "Jean Testeur",
+  qid: "Q424242",
+  prop: "P1399",
+  offenseLabel: "corruption",
+  category: "CORRUPTION",
+  status: "CONDAMNATION_DEFINITIVE",
+  penaltyData: {},
+  decisionId: "dec_1",
+};
+
+describe("buildWikidataDiscoveredAffair — invariant I1 (RGPD art. 10)", () => {
+  it("une condamnation P1399 avec infraction connue reste DRAFT", () => {
+    const affair = buildWikidataDiscoveredAffair(baseInput);
+    expect(affair.publicationStatus).toBe("DRAFT");
+  });
+
+  it("une charge P1595 reste DRAFT", () => {
+    const affair = buildWikidataDiscoveredAffair({
+      ...baseInput,
+      prop: "P1595",
+      status: "MISE_EN_EXAMEN",
+    });
+    expect(affair.publicationStatus).toBe("DRAFT");
+  });
+
+  it("conserve le comportement existant hors publication", () => {
+    const conviction = buildWikidataDiscoveredAffair(baseInput);
+    expect(conviction.involvement).toBe("DIRECT");
+    expect(conviction.title).toBe("corruption — Jean Testeur");
+    expect(conviction.confidenceScore).toBe(95);
+    expect(conviction.decisionId).toBe("dec_1");
+
+    const charge = buildWikidataDiscoveredAffair({ ...baseInput, prop: "P1595" });
+    expect(charge.involvement).toBe("MENTIONED_ONLY");
+    expect(charge.title).toBe("[À VÉRIFIER] corruption — Jean Testeur");
+    expect(charge.confidenceScore).toBe(75);
+  });
+
+  it("le type interdit PUBLISHED à la compilation", () => {
+    const affair = buildWikidataDiscoveredAffair(baseInput);
+    // @ts-expect-error publicationStatus est le littéral "DRAFT", PUBLISHED est inassignable
+    affair.publicationStatus = "PUBLISHED";
+  });
+});

--- a/src/services/sync/discover-affairs-builders.ts
+++ b/src/services/sync/discover-affairs-builders.ts
@@ -1,0 +1,107 @@
+/**
+ * Builders purs pour discover-affairs. Volontairement sans import de db,
+ * Wikidata ou IA : testables sans mock.
+ *
+ * Invariant I1 (RGPD article 10) : aucune source automatisée ne publie
+ * directement une affaire pénale, même une condamnation Wikidata P1399.
+ * Le type `publicationStatus: "DRAFT"` rend toute republication automatique
+ * impossible à la compilation. La publication exige une validation humaine
+ * (Phase 2 : publish-guard).
+ */
+
+import { clampConfidenceScore } from "@/services/affairs/confidence";
+import type { AffairCategory, AffairStatus, Involvement } from "@/generated/prisma";
+
+export interface ExtractedPenaltyData {
+  prisonMonths?: number;
+  prisonSuspended?: boolean;
+  hasFine?: boolean;
+  ineligibilityMonths?: number;
+  communityService?: number;
+  otherSentence?: string;
+  verdictDate?: Date;
+  courtQid?: string;
+}
+
+export interface DiscoveredAffair {
+  politicianId: string;
+  politicianName: string;
+  title: string;
+  description: string;
+  category: AffairCategory;
+  status: AffairStatus;
+  involvement: Involvement;
+  factsDate: Date | null;
+  court: string | null;
+  prisonMonths: number | null;
+  prisonSuspended: boolean | null;
+  ineligibilityMonths: number | null;
+  communityService: number | null;
+  otherSentence: string | null;
+  courtQid: string | null;
+  charges: string[];
+  confidenceScore: number;
+  publicationStatus: "DRAFT";
+  /** Décision du resolver (AffairPoliticianDecision.id) à relier à l'affaire créée. */
+  decisionId: string | null;
+  sources: Array<{
+    url: string;
+    title: string;
+    publisher: string;
+    sourceType: "WIKIDATA" | "WIKIPEDIA" | "PRESSE";
+    publishedAt: Date | null;
+  }>;
+  phase: "wikidata" | "wikipedia";
+}
+
+export interface WikidataDiscoveredAffairInput {
+  politicianId: string;
+  politicianName: string;
+  qid: string;
+  prop: "P1399" | "P1595";
+  offenseLabel: string;
+  category: AffairCategory;
+  status: AffairStatus;
+  penaltyData: ExtractedPenaltyData;
+  decisionId: string | null;
+}
+
+export function buildWikidataDiscoveredAffair(
+  input: WikidataDiscoveredAffairInput
+): DiscoveredAffair {
+  const isConviction = input.prop === "P1399";
+  const confidence = isConviction ? 95 : 75;
+  const titlePrefix = isConviction ? "" : "[À VÉRIFIER] ";
+
+  return {
+    politicianId: input.politicianId,
+    politicianName: input.politicianName,
+    title: `${titlePrefix}${input.offenseLabel} — ${input.politicianName}`,
+    description: `${input.offenseLabel} (${isConviction ? "condamnation" : "mise en cause"}) — source Wikidata (${input.qid}, propriété ${input.prop}).`,
+    category: input.category,
+    status: input.status,
+    involvement: isConviction ? "DIRECT" : "MENTIONED_ONLY",
+    factsDate: input.penaltyData.verdictDate ?? null,
+    court: null,
+    prisonMonths: input.penaltyData.prisonMonths ?? null,
+    prisonSuspended: input.penaltyData.prisonSuspended ?? null,
+    ineligibilityMonths: input.penaltyData.ineligibilityMonths ?? null,
+    communityService: input.penaltyData.communityService ?? null,
+    otherSentence: input.penaltyData.otherSentence ?? null,
+    courtQid: input.penaltyData.courtQid ?? null,
+    charges: [input.offenseLabel],
+    confidenceScore: clampConfidenceScore(confidence),
+    publicationStatus: "DRAFT",
+    decisionId: input.decisionId,
+    sources: [
+      {
+        url: `https://www.wikidata.org/wiki/${input.qid}`,
+        title: `Wikidata — ${input.politicianName}`,
+        publisher: "Wikidata",
+        sourceType: "WIKIDATA",
+        publishedAt: null,
+      },
+    ],
+    phase: "wikidata",
+  };
+}

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -11,15 +11,22 @@ import { db } from "@/lib/db";
 import { generateAffairSlug, generateUniqueSlug } from "@/lib/utils";
 import { WikidataService } from "@/lib/api/wikidata";
 import { WD_PROPS } from "@/config/wikidata";
-import { mapWikidataOffense, getOffenseLabel, isKnownOffense } from "@/config/wikidata-affairs";
+import { mapWikidataOffense, getOffenseLabel } from "@/config/wikidata-affairs";
 import { mapWikidataPenalty, parseDurationToMonths } from "@/config/wikidata-penalties";
+import {
+  buildWikidataDiscoveredAffair,
+  type DiscoveredAffair,
+  type ExtractedPenaltyData,
+} from "@/services/sync/discover-affairs-builders";
+
+export type { ExtractedPenaltyData };
 import { wikipediaService } from "@/lib/api/wikipedia";
 import type { WikidataClaim } from "@/lib/api/wikidata";
 import { extractAffairsFromWikipedia } from "@/services/wikipedia-affair-extraction";
 import { findMatchingAffairs } from "@/services/affairs/matching";
 import { clampConfidenceScore } from "@/services/affairs/confidence";
 import { extractDateFromUrl } from "@/lib/extract-date-from-url";
-import type { AffairCategory, AffairStatus, Involvement, SourceType } from "@/generated/prisma";
+import type { AffairCategory, AffairStatus, SourceType } from "@/generated/prisma";
 import { scoreAffairAgainstCandidates, resolveAffairPolitician } from "@/lib/affair-matching";
 import { loadCandidatePool } from "@/lib/affair-matching/persistence";
 import type { AffairCandidateRecord } from "@/lib/affair-matching";
@@ -62,35 +69,6 @@ export async function saveDiscoverAffairsCursor(lastName: string | null): Promis
   });
 }
 
-interface DiscoveredAffair {
-  politicianId: string;
-  politicianName: string;
-  title: string;
-  description: string;
-  category: AffairCategory;
-  status: AffairStatus;
-  involvement: Involvement;
-  factsDate: Date | null;
-  court: string | null;
-  prisonMonths: number | null;
-  prisonSuspended: boolean | null;
-  ineligibilityMonths: number | null;
-  communityService: number | null;
-  otherSentence: string | null;
-  courtQid: string | null;
-  charges: string[];
-  confidenceScore: number;
-  publicationStatus: "PUBLISHED" | "DRAFT";
-  sources: Array<{
-    url: string;
-    title: string;
-    publisher: string;
-    sourceType: "WIKIDATA" | "WIKIPEDIA" | "PRESSE";
-    publishedAt: Date | null;
-  }>;
-  phase: "wikidata" | "wikipedia";
-}
-
 export interface DiscoverAffairsResult {
   politiciansProcessed: number;
   wikidataAffairsFound: number;
@@ -98,17 +76,6 @@ export interface DiscoverAffairsResult {
   duplicatesSkipped: number;
   affairsCreated: number;
   errors: string[];
-}
-
-export interface ExtractedPenaltyData {
-  prisonMonths?: number;
-  prisonSuspended?: boolean;
-  hasFine?: boolean;
-  ineligibilityMonths?: number;
-  communityService?: number;
-  otherSentence?: string;
-  verdictDate?: Date;
-  courtQid?: string;
 }
 
 /**
@@ -375,20 +342,11 @@ async function runPhase1Wikidata(
           const label = getOffenseLabel(offenseQid);
           const penaltyData = extractPenaltyData(claim);
 
-          const isConviction = prop === "P1399";
-          const knownOffense = isKnownOffense(offenseQid);
-          // Only auto-publish convictions with known offense types.
-          // Unknown Q-IDs produce "Infraction inconnue" titles -> DRAFT for review.
-          const publicationStatus = isConviction && knownOffense ? "PUBLISHED" : "DRAFT";
-          const confidence = isConviction ? 95 : 75;
-          const titlePrefix = isConviction ? "" : "[\u00c0 V\u00c9RIFIER] ";
-          const title = `${titlePrefix}${label} \u2014 ${politician.fullName}`;
-
-          // Call the resolver for audit-trail uniformity. The external-id signal
-          // fires at +10.0 via the Q-ID match, so this is a no-op confirmation.
-          // Non-blocking: resolver failure must not prevent affair creation.
+          // Invariant I1 : le resolver est appel\u00e9 pour l'audit trail et la
+          // future liaison d\u00e9cision\u2192affaire, jamais pour publier.
+          let decisionId: string | null = null;
           try {
-            await resolveAffairPolitician({
+            const resolveResult = await resolveAffairPolitician({
               text: `${politician.fullName}: ${label}`,
               metadata: {
                 source: "WIKIDATA" as SourceType,
@@ -397,6 +355,7 @@ async function runPhase1Wikidata(
                 externalIds: { wikidataQId: qid },
               },
             });
+            decisionId = resolveResult.decisionId;
           } catch (resolveErr) {
             console.warn(
               `[discover-affairs] Wikidata resolver call failed for ${politician.fullName} (${qid}):`,
@@ -404,36 +363,19 @@ async function runPhase1Wikidata(
             );
           }
 
-          discovered.push({
-            politicianId: politician.id,
-            politicianName: politician.fullName,
-            title,
-            description: `${label} (${isConviction ? "condamnation" : "mise en cause"}) \u2014 source Wikidata (${qid}, propri\u00e9t\u00e9 ${prop}).`,
-            category,
-            status,
-            involvement: isConviction ? "DIRECT" : "MENTIONED_ONLY",
-            factsDate: penaltyData.verdictDate ?? null,
-            court: null,
-            prisonMonths: penaltyData.prisonMonths ?? null,
-            prisonSuspended: penaltyData.prisonSuspended ?? null,
-            ineligibilityMonths: penaltyData.ineligibilityMonths ?? null,
-            communityService: penaltyData.communityService ?? null,
-            otherSentence: penaltyData.otherSentence ?? null,
-            courtQid: penaltyData.courtQid ?? null,
-            charges: [label],
-            confidenceScore: clampConfidenceScore(confidence),
-            publicationStatus: publicationStatus as "PUBLISHED" | "DRAFT",
-            sources: [
-              {
-                url: `https://www.wikidata.org/wiki/${qid}`,
-                title: `Wikidata \u2014 ${politician.fullName}`,
-                publisher: "Wikidata",
-                sourceType: "WIKIDATA",
-                publishedAt: null,
-              },
-            ],
-            phase: "wikidata",
-          });
+          discovered.push(
+            buildWikidataDiscoveredAffair({
+              politicianId: politician.id,
+              politicianName: politician.fullName,
+              qid,
+              prop,
+              offenseLabel: label,
+              category,
+              status,
+              penaltyData,
+              decisionId,
+            })
+          );
 
           stats.wikidataAffairsFound++;
         }
@@ -573,6 +515,7 @@ async function runPhase2Wikipedia(
             charges: extracted.charges,
             confidenceScore: clampConfidenceScore(extracted.confidenceScore),
             publicationStatus: "DRAFT",
+            decisionId: null,
             sources,
             phase: "wikipedia",
           });
@@ -702,7 +645,6 @@ async function runPhase3Reconciliation(
           sentence: buildSentenceSummary(affair),
           confidenceScore: affair.confidenceScore,
           publicationStatus: affair.publicationStatus,
-          verifiedAt: affair.publicationStatus === "PUBLISHED" ? new Date() : null,
           sources: {
             create: affair.sources.map((s) => ({
               url: s.url,

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -616,6 +616,15 @@ async function runPhase3Reconciliation(
           }
         }
 
+        // Même en cas de doublon enrichi, la décision resolver est rattachée
+        // à l'affaire existante pour la piste d'audit du rattachement.
+        if (affair.decisionId) {
+          await db.affairPoliticianDecision.update({
+            where: { id: affair.decisionId },
+            data: { affairId: highMatch.affairId },
+          });
+        }
+
         stats.duplicatesSkipped++;
         continue;
       }
@@ -626,7 +635,7 @@ async function runPhase3Reconciliation(
       });
       const slug = await generateUniqueAffairSlug(politician?.slug ?? "", affair.title);
 
-      await db.affair.create({
+      const createdAffair = await db.affair.create({
         data: {
           politicianId: affair.politicianId,
           title: affair.title,
@@ -655,7 +664,17 @@ async function runPhase3Reconciliation(
             })),
           },
         },
+        select: { id: true },
       });
+
+      // Lie la décision du resolver à l'affaire créée : le publish-guard
+      // (Phase 2) exigera une revue humaine de cette décision avant publication.
+      if (affair.decisionId) {
+        await db.affairPoliticianDecision.update({
+          where: { id: affair.decisionId },
+          data: { affairId: createdAffair.id },
+        });
+      }
 
       stats.affairsCreated++;
     } catch (error) {

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -277,7 +277,15 @@ export async function syncPressAnalysis(
             dryRun,
             verbose
           );
-          if (enriched) stats.affairsEnriched++;
+          if (enriched) {
+            stats.affairsEnriched++;
+            if (!dryRun) {
+              await db.affairPoliticianDecision.update({
+                where: { id: resolveResult.decisionId },
+                data: { affairId: bestMatch.affairId },
+              });
+            }
+          }
         } else if (detected.isNewRevelation) {
           // Reject low-confidence detections before creating
           if (detected.confidenceScore < MIN_CONFIDENCE_THRESHOLD) {
@@ -294,6 +302,7 @@ export async function syncPressAnalysis(
             article.feedSource,
             article.publishedAt,
             detected,
+            resolveResult.decisionId,
             dryRun,
             verbose
           );
@@ -484,6 +493,7 @@ async function createAffairFromPress(
   feedSource: string,
   publishedAt: Date,
   detected: DetectedAffair,
+  decisionId: string | null,
   dryRun: boolean,
   verbose?: boolean
 ): Promise<boolean> {
@@ -533,6 +543,15 @@ async function createAffairFromPress(
 
     // Link article to affair
     await linkArticleToAffair(articleId, affair.id, "REVELATION");
+
+    // Lie la décision du resolver à l'affaire créée (audit du rattachement,
+    // prérequis du publish-guard Phase 2).
+    if (decisionId) {
+      await db.affairPoliticianDecision.update({
+        where: { id: decisionId },
+        data: { affairId: affair.id },
+      });
+    }
 
     if (verbose) {
       const scoreLabel = detected.confidenceScore >= 70 ? "✓" : "⚠";


### PR DESCRIPTION
Phase 1 du chantier affaires judiciaires / RGPD article 10 (réduction du risque, spec locale 2026-06-07).

## Changements

- **discover-affairs ne crée plus jamais en PUBLISHED** : builders extraits dans un module pur, `publicationStatus: "DRAFT"` imposé au niveau du type (PUBLISHED inassignable à la compilation).
- **Fuites par id colmatées** : le fallback id de la page détail, l'image OpenGraph et les relations `linkedAffair`/`linkedBy` ne résolvent plus aucune affaire non publiée (helper `pickPublicLinkedAffair`, `getLinkedAffair` mort supprimé).
- **Where-builders centralisés** (`src/lib/affairs/public-filters.ts`) + `PROCEDURE_VALIDEE_STATUSES` : les agrégats à charge excluent désormais par construction les enquêtes préliminaires, les issues favorables (prescription incluse), les mentions, victimes et plaignants.
- **Agrégats « mis en cause » en Tier 2 strict** (homepage, /statistiques, fiche politicien) avec le wording public corrigé **dans le même commit** : la promesse méthodologique « les enquêtes préliminaires ne sont pas comptabilisées » devient vraie (64 affaires ENQUETE_PRELIMINAIRE sortent des compteurs ; « mis en cause » passe à 30 politiciens).
- **`AffairPoliticianDecision.affairId` systématiquement relié** à la création et à l'enrichissement (discover-affairs + presse, dry-run safe) : prérequis du publish-guard de Phase 2.

## Notes de lecture

- La décomposition `maturityCounts` de /statistiques reste volontairement sur le groupBy complet (cartes par tier affichées comme telles) ; seuls les compteurs uniques `uniqueCondamnes`/`uniqueMisEnCause` passent en Tier 2 strict.
- `EN_COURS_STATUSES` (Tier 2+3) reste exporté pour les affichages explicitement étiquetés, plus utilisé par aucun agrégat « validé par un juge ».

## Vérifications

- typecheck, lint (fichiers modifiés) et test:run : verts (1455 tests, +12 tests no-leak).
- Smoke test dev : affaire REJECTED par id/slug/OG → page non trouvée, zéro contenu exposé.

Phases suivantes : publish-guard + revue SAME (Phase 2), encarts UI + MCP (Phase 3), docs LEGAL.md (Phase 4).