### PR TITLE
fix(admin) : le refus de publication s'affiche au lieu de faire tomber la page

### DIFF
--- a/src/app/admin/affaires/[id]/page.tsx
+++ b/src/app/admin/affaires/[id]/page.tsx
@@ -28,7 +28,10 @@ async function getAffair(id: string) {
   });
 }
 
-async function updatePublicationStatus(id: string, status: PublicationStatus) {
+async function updatePublicationStatus(
+  id: string,
+  status: PublicationStatus
+): Promise<{ ok: true } | { ok: false; error: string }> {
   "use server";
   const { isAuthenticated } = await import("@/lib/auth");
   const { db } = await import("@/lib/db");
@@ -39,17 +42,23 @@ async function updatePublicationStatus(id: string, status: PublicationStatus) {
 
   const authenticated = await isAuthenticated();
   if (!authenticated) {
-    throw new Error("Non autorisé");
+    return { ok: false, error: "Non autorisé" };
   }
 
   if (status === PUBLISHED_STATUS) {
     // RGPD art. 10 : publication uniquement via le guard (sources +
     // rattachements validés, verifiedAt/verifiedBy écrits atomiquement).
+    // Le refus est RETOURNÉ, pas jeté : en production, Next masque le message
+    // des erreurs levées par une action serveur et la page tombe sur l'error
+    // boundary générique au lieu d'afficher la raison au modérateur.
     try {
       await assertPublishable(id, { verifiedBy: VERIFIED_BY_MODERATION });
     } catch (err) {
       if (err instanceof PublishGuardError) {
-        throw new Error(`Affaire non publiable : ${err.reasons.map((r) => r.message).join(" ; ")}`);
+        return {
+          ok: false,
+          error: `Affaire non publiable : ${err.reasons.map((r) => r.message).join(" ; ")}`,
+        };
       }
       throw err;
     }
@@ -71,6 +80,7 @@ async function updatePublicationStatus(id: string, status: PublicationStatus) {
 
   invalidateEntity("affair");
   revalidatePath(`/admin/affaires/${id}`);
+  return { ok: true };
 }
 
 export default async function AdminAffairDetailPage({ params }: PageProps) {

--- a/src/components/admin/PublicationStatusSelect.tsx
+++ b/src/components/admin/PublicationStatusSelect.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { PublicationStatus } from "@/generated/prisma";
 
 const STATUS_OPTIONS: { value: PublicationStatus; label: string }[] = [
@@ -23,7 +23,11 @@ interface PublicationStatusSelectProps {
   entityId: string;
   entityType: "affair" | "politician" | "factcheck";
   currentStatus: PublicationStatus;
-  onChange: (id: string, status: PublicationStatus) => Promise<void>;
+  /** L'action peut retourner un refus structuré ({ ok: false, error }) à afficher. */
+  onChange: (
+    id: string,
+    status: PublicationStatus
+  ) => Promise<void | { ok: boolean; error?: string }>;
 }
 
 export function PublicationStatusSelect({
@@ -32,26 +36,38 @@ export function PublicationStatusSelect({
   onChange,
 }: PublicationStatusSelectProps) {
   const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
 
   return (
-    <select
-      value={currentStatus}
-      disabled={isPending}
-      aria-label="Statut de publication"
-      className={`h-8 rounded-md border px-2 text-sm font-medium cursor-pointer appearance-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${STATUS_STYLES[currentStatus]} ${isPending ? "opacity-50 cursor-wait" : ""}`}
-      onChange={(e) => {
-        const newStatus = e.target.value as PublicationStatus;
-        if (newStatus === currentStatus) return;
-        startTransition(async () => {
-          await onChange(entityId, newStatus);
-        });
-      }}
-    >
-      {STATUS_OPTIONS.map((opt) => (
-        <option key={opt.value} value={opt.value}>
-          {opt.label}
-        </option>
-      ))}
-    </select>
+    <div className="flex flex-col items-end gap-1">
+      <select
+        value={currentStatus}
+        disabled={isPending}
+        aria-label="Statut de publication"
+        className={`h-8 rounded-md border px-2 text-sm font-medium cursor-pointer appearance-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${STATUS_STYLES[currentStatus]} ${isPending ? "opacity-50 cursor-wait" : ""}`}
+        onChange={(e) => {
+          const newStatus = e.target.value as PublicationStatus;
+          if (newStatus === currentStatus) return;
+          setError(null);
+          startTransition(async () => {
+            const result = await onChange(entityId, newStatus);
+            if (result && result.ok === false) {
+              setError(result.error ?? "La mise à jour a échoué");
+            }
+          });
+        }}
+      >
+        {STATUS_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {error && (
+        <p role="alert" className="max-w-xs text-right text-xs text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
Constaté en vérification post-merge de #365 : tenter de publier une affaire bloquée par le publish-guard depuis le sélecteur de statut faisait tomber la page admin sur l'error boundary générique (« Une erreur est survenue »), sans afficher la raison.

Cause : l'action serveur `updatePublicationStatus` jetait une `Error`. En production, Next masque le message des erreurs levées par une action serveur (seul le digest est transmis) : le client ne peut donc jamais afficher la raison.

Fix :
- l'action retourne `{ ok: false, error }` pour le refus du guard (et pour « Non autorisé »), `{ ok: true }` sinon ; le refus n'écrit plus d'auditLog (rien ne s'est passé) ;
- `PublicationStatusSelect` affiche l'erreur retournée sous le sélecteur (`role="alert"`), le statut affiché reste l'actuel (le prop n'ayant pas changé) ;
- signature `onChange` élargie (`Promise<void | { ok, error? }>`) : l'usage factchecks existant (retour void) reste compatible.

Test : typecheck, lint, suite affairs verts. À re-vérifier après déploiement : republier l'affaire `cmq1cjp1v0006iz28ikw2lwgc` doit afficher « Affaire non publiable : 1 décision(s) de rattachement automatique non validée(s) par un humain » sous le sélecteur, sans crash.