### PR TITLE
RGPD art. 10 Phase 3 : encarts publics et issues favorables dominantes

### DIFF
--- a/src/app/affaires/[slug]/opengraph-image.tsx
+++ b/src/app/affaires/[slug]/opengraph-image.tsx
@@ -19,7 +19,7 @@ const STATUS_LABELS: Partial<Record<AffairStatus, string>> = {
   RELAXE: "Relaxe",
   ACQUITTEMENT: "Acquittement",
   NON_LIEU: "Non-lieu",
-  PRESCRIPTION: "Prescription",
+  PRESCRIPTION: "Action publique éteinte par prescription",
   CLASSEMENT_SANS_SUITE: "Classement sans suite",
 };
 

--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -25,6 +25,7 @@ import {
   CERTAINTY_COLORS,
   CERTAINTY_DESCRIPTIONS,
 } from "@/config/certainty";
+import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
 import { LinkedAffairBanner } from "@/components/affairs/LinkedAffairBanner";
 import { SentenceDetails } from "@/components/affairs/SentenceDetails";
 import { StatusTooltip } from "@/components/affairs/StatusTooltip";
@@ -290,16 +291,13 @@ export default async function AffairDetailPage({ params }: PageProps) {
           </div>
         </div>
 
-        {/* Presumption of innocence — only for accused, not victims */}
-        {AFFAIR_STATUS_NEEDS_PRESUMPTION[affair.status] &&
-          (affair.involvement === "DIRECT" || affair.involvement === "INDIRECT") && (
-            <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg p-4 mb-6">
-              <p className="text-sm text-amber-800 dark:text-amber-200">
-                <strong>Présomption d&apos;innocence :</strong> Cette affaire est en cours. La
-                personne concernée est présumée innocente jusqu&apos;à condamnation définitive.
-              </p>
-            </div>
-          )}
+        {/* Encart de prudence juridique : présomption, recours, issue favorable
+            ou prescription selon le statut (RGPD art. 10, invariant I5) */}
+        <AffairStatusNotice
+          status={affair.status}
+          involvement={affair.involvement}
+          className="mb-6"
+        />
 
         {/* Linked affair cross-reference */}
         {linked && (

--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -520,10 +520,12 @@ export default async function AffairesPage({ searchParams }: PageProps) {
           <CardContent className="pt-6">
             <h3 className="font-semibold text-blue-900 mb-2">À propos des données</h3>
             <p className="text-sm text-blue-800">
-              Chaque affaire est documentée avec au minimum une source vérifiable (article de
-              presse, décision de justice). La présomption d&apos;innocence est systématiquement
-              rappelée pour les affaires en cours. Les informations proviennent de sources publiques
-              : Wikidata, articles de presse, décisions de justice publiées.
+              Les affaires listées sont issues de sources publiques vérifiables (articles de presse,
+              décisions de justice) et font l&apos;objet d&apos;une validation éditoriale avant
+              publication. Les procédures en cours sont présentées avec rappel de la présomption
+              d&apos;innocence. Les issues favorables (relaxe, acquittement, non-lieu, classement
+              sans suite) sont distinguées des condamnations ; l&apos;action publique éteinte par
+              prescription est signalée comme telle.
             </p>
           </CardContent>
         </Card>

--- a/src/app/methodologie/page.tsx
+++ b/src/app/methodologie/page.tsx
@@ -28,7 +28,13 @@ const CERTAINTY_STATUSES: Record<CertaintyLevel, string[]> = {
     "Renvoi devant le tribunal",
     "Procès en cours",
   ],
-  CLOS_FAVORABLE: ["Relaxe", "Acquittement", "Non-lieu", "Prescription", "Classement sans suite"],
+  CLOS_FAVORABLE: [
+    "Relaxe",
+    "Acquittement",
+    "Non-lieu",
+    "Action publique éteinte par prescription",
+    "Classement sans suite",
+  ],
 };
 
 const SUPER_CATEGORIES: { key: AffairSuperCategory; description: string }[] = [

--- a/src/components/affairs/AffairStatusNotice.tsx
+++ b/src/components/affairs/AffairStatusNotice.tsx
@@ -1,0 +1,115 @@
+import type { AffairStatus, Involvement } from "@/types";
+
+/**
+ * Encart de prudence juridique affiché avec chaque affaire publique
+ * (RGPD article 10, invariant I5) : la qualification procédurale exacte est
+ * énoncée avant toute lecture à charge, et les issues favorables sont
+ * dominantes (jamais rendues comme des mises en cause actives).
+ *
+ * La prescription a volontairement un wording distinct des autres issues
+ * favorables : elle éteint l'action publique sans décision sur le fond.
+ */
+
+export type AffairNoticeVariant =
+  | "presumption"
+  | "non_definitive"
+  | "definitive"
+  | "favorable"
+  | "prescription";
+
+const FAVORABLE_STATUSES: readonly AffairStatus[] = [
+  "RELAXE",
+  "ACQUITTEMENT",
+  "NON_LIEU",
+  "CLASSEMENT_SANS_SUITE",
+];
+
+const NON_DEFINITIVE_STATUSES: readonly AffairStatus[] = [
+  "CONDAMNATION_PREMIERE_INSTANCE",
+  "APPEL_EN_COURS",
+];
+
+const EN_COURS_STATUSES: readonly AffairStatus[] = [
+  "ENQUETE_PRELIMINAIRE",
+  "INSTRUCTION",
+  "MISE_EN_EXAMEN",
+  "RENVOI_TRIBUNAL",
+  "PROCES_EN_COURS",
+];
+
+export function getAffairNoticeVariant(
+  status: AffairStatus,
+  involvement: Involvement
+): AffairNoticeVariant | null {
+  // Les encarts qualifient la situation d'une personne mise en cause :
+  // pas d'encart quand le politicien est victime, plaignant ou simplement
+  // mentionné (ces affaires sont présentées dans des sections dédiées).
+  if (involvement !== "DIRECT" && involvement !== "INDIRECT") return null;
+  if (status === "PRESCRIPTION") return "prescription";
+  if (FAVORABLE_STATUSES.includes(status)) return "favorable";
+  if (status === "CONDAMNATION_DEFINITIVE") return "definitive";
+  if (NON_DEFINITIVE_STATUSES.includes(status)) return "non_definitive";
+  if (EN_COURS_STATUSES.includes(status)) return "presumption";
+  return null;
+}
+
+const NOTICES: Record<AffairNoticeVariant, { title: string; body: string; className: string }> = {
+  presumption: {
+    title: "Présomption d'innocence",
+    body: "cette procédure est en cours. La personne concernée est présumée innocente jusqu'à une éventuelle condamnation définitive.",
+    className:
+      "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200",
+  },
+  non_definitive: {
+    title: "Décision non définitive",
+    body: "cette condamnation peut encore faire l'objet d'un recours ou est en cours d'appel.",
+    className:
+      "border-orange-200 bg-orange-50 text-orange-800 dark:border-orange-800 dark:bg-orange-950/30 dark:text-orange-200",
+  },
+  definitive: {
+    title: "Condamnation définitive",
+    body: "les voies de recours ordinaires sont épuisées ou la décision est définitive selon les sources disponibles.",
+    className:
+      "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300",
+  },
+  favorable: {
+    title: "Procédure close sans condamnation",
+    body: "cette issue est favorable à la personne concernée. Cette entrée ne doit pas être lue comme une condamnation.",
+    className:
+      "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-200",
+  },
+  prescription: {
+    title: "Action publique éteinte par prescription",
+    body: "la procédure est close sans condamnation. La prescription ne constitue pas une décision sur le fond.",
+    className:
+      "border-gray-200 bg-gray-50 text-gray-700 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300",
+  },
+};
+
+interface AffairStatusNoticeProps {
+  status: AffairStatus;
+  involvement: Involvement;
+  className?: string;
+}
+
+export function AffairStatusNotice({
+  status,
+  involvement,
+  className = "",
+}: AffairStatusNoticeProps) {
+  const variant = getAffairNoticeVariant(status, involvement);
+  if (!variant) return null;
+  const notice = NOTICES[variant];
+
+  return (
+    <div
+      role="note"
+      data-variant={variant}
+      className={`rounded-lg border p-4 ${notice.className} ${className}`}
+    >
+      <p className="text-sm">
+        <strong>{notice.title} :</strong> {notice.body}
+      </p>
+    </div>
+  );
+}

--- a/src/components/affairs/__tests__/AffairStatusNotice.test.tsx
+++ b/src/components/affairs/__tests__/AffairStatusNotice.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  AffairStatusNotice,
+  getAffairNoticeVariant,
+} from "@/components/affairs/AffairStatusNotice";
+
+describe("getAffairNoticeVariant — sélection par statut et involvement", () => {
+  it("PRESCRIPTION a sa variante propre, jamais assimilée à une relaxe", () => {
+    expect(getAffairNoticeVariant("PRESCRIPTION", "DIRECT")).toBe("prescription");
+  });
+
+  it("les 4 issues favorables partagent la variante favorable", () => {
+    for (const s of ["RELAXE", "ACQUITTEMENT", "NON_LIEU", "CLASSEMENT_SANS_SUITE"] as const) {
+      expect(getAffairNoticeVariant(s, "DIRECT")).toBe("favorable");
+    }
+  });
+
+  it("condamnations : définitive vs non définitive", () => {
+    expect(getAffairNoticeVariant("CONDAMNATION_DEFINITIVE", "DIRECT")).toBe("definitive");
+    expect(getAffairNoticeVariant("CONDAMNATION_PREMIERE_INSTANCE", "INDIRECT")).toBe(
+      "non_definitive"
+    );
+    expect(getAffairNoticeVariant("APPEL_EN_COURS", "DIRECT")).toBe("non_definitive");
+  });
+
+  it("procédures en cours : présomption d'innocence", () => {
+    for (const s of [
+      "ENQUETE_PRELIMINAIRE",
+      "INSTRUCTION",
+      "MISE_EN_EXAMEN",
+      "RENVOI_TRIBUNAL",
+      "PROCES_EN_COURS",
+    ] as const) {
+      expect(getAffairNoticeVariant(s, "DIRECT")).toBe("presumption");
+    }
+  });
+
+  it("aucun encart pour les victimes, plaignants et simples mentions", () => {
+    for (const inv of ["VICTIM", "PLAINTIFF", "MENTIONED_ONLY"] as const) {
+      expect(getAffairNoticeVariant("RELAXE", inv)).toBeNull();
+      expect(getAffairNoticeVariant("CONDAMNATION_DEFINITIVE", inv)).toBeNull();
+      expect(getAffairNoticeVariant("INSTRUCTION", inv)).toBeNull();
+    }
+  });
+});
+
+describe("AffairStatusNotice — wordings validés (RGPD art. 10)", () => {
+  it("issue favorable : jamais lue comme une condamnation", () => {
+    const { getByRole } = render(<AffairStatusNotice status="RELAXE" involvement="DIRECT" />);
+    const note = getByRole("note");
+    expect(note.textContent).toContain("Procédure close sans condamnation");
+    expect(note.textContent).toContain("ne doit pas être lue comme une condamnation");
+  });
+
+  it("prescription : wording distinct, pas de décision sur le fond", () => {
+    const { getByRole } = render(<AffairStatusNotice status="PRESCRIPTION" involvement="DIRECT" />);
+    const note = getByRole("note");
+    expect(note.textContent).toContain("Action publique éteinte par prescription");
+    expect(note.textContent).toContain("ne constitue pas une décision sur le fond");
+    expect(note.textContent).not.toContain("favorable");
+  });
+
+  it("présomption d'innocence sur les procédures en cours", () => {
+    const { getByRole } = render(
+      <AffairStatusNotice status="MISE_EN_EXAMEN" involvement="DIRECT" />
+    );
+    expect(getByRole("note").textContent).toContain("présumée innocente");
+  });
+
+  it("condamnation non définitive : mention du recours", () => {
+    const { getByRole } = render(
+      <AffairStatusNotice status="APPEL_EN_COURS" involvement="DIRECT" />
+    );
+    expect(getByRole("note").textContent).toContain("Décision non définitive");
+  });
+
+  it("rien ne s'affiche pour une victime", () => {
+    const { container } = render(<AffairStatusNotice status="RELAXE" involvement="VICTIM" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/politicians/AffairCard.tsx
+++ b/src/components/politicians/AffairCard.tsx
@@ -3,13 +3,13 @@ import { formatDate, stripMarkdown } from "@/lib/utils";
 import {
   AFFAIR_STATUS_LABELS,
   AFFAIR_STATUS_COLORS,
-  AFFAIR_STATUS_NEEDS_PRESUMPTION,
   AFFAIR_CATEGORY_LABELS,
 } from "@/config/labels";
 import type { AffairStatus, AffairCategory } from "@/types";
 import { ensureContrast } from "@/lib/contrast";
 import { SentenceDetails } from "@/components/affairs/SentenceDetails";
 import { AffairTimeline } from "@/components/affairs/AffairTimeline";
+import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
 
 interface AffairCardProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -76,6 +76,14 @@ export function AffairCard({ affair, variant }: AffairCardProps) {
         </div>
       </div>
 
+      {/* Encart de prudence juridique — avant toute lecture à charge
+          (RGPD art. 10 : issues favorables dominantes) */}
+      <AffairStatusNotice
+        status={affair.status as AffairStatus}
+        involvement={affair.involvement}
+        className="mb-3"
+      />
+
       {/* Description */}
       <p className="text-sm text-muted-foreground mb-3">{stripMarkdown(affair.description)}</p>
 
@@ -130,15 +138,6 @@ export function AffairCard({ affair, variant }: AffairCardProps) {
           <AffairTimeline events={affair.events} />
         </div>
       )}
-
-      {/* Presumption of innocence */}
-      {AFFAIR_STATUS_NEEDS_PRESUMPTION[affair.status as AffairStatus] &&
-        (affair.involvement === "DIRECT" || affair.involvement === "INDIRECT") && (
-          <p className="text-xs text-amber-700 bg-amber-50 p-2 rounded mb-3">
-            Présomption d&apos;innocence : cette affaire est en cours, la personne est présumée
-            innocente jusqu&apos;à condamnation définitive.
-          </p>
-        )}
 
       {/* Sources */}
       {affair.sources.length > 0 && (

--- a/src/components/politicians/AffairsSection.tsx
+++ b/src/components/politicians/AffairsSection.tsx
@@ -66,6 +66,10 @@ export function AffairsSection({ affairs, civility }: AffairsSectionProps) {
       <Card id="affaires">
         <CardHeader>
           <h2 className="leading-none font-semibold">Affaires judiciaires</h2>
+          <p className="text-xs text-muted-foreground">
+            Les procédures closes sans condamnation sont distinguées des condamnations. La
+            présomption d&apos;innocence s&apos;applique aux procédures en cours.
+          </p>
         </CardHeader>
         <CardContent>
           {directAffairs.length > 0 ? (

--- a/src/components/politicians/__tests__/AffairCard.test.tsx
+++ b/src/components/politicians/__tests__/AffairCard.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { AffairCard } from "@/components/politicians/AffairCard";
+
+function makeAffair(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "a1",
+    title: "Affaire de test",
+    description: "Description factuelle des faits.",
+    status: "RELAXE",
+    category: "CORRUPTION",
+    involvement: "DIRECT",
+    factsDate: null,
+    startDate: null,
+    verdictDate: new Date("2024-01-15"),
+    appeal: false,
+    court: null,
+    chamber: null,
+    caseNumber: null,
+    partyAtTime: null,
+    events: [],
+    sources: [],
+    // SentenceDetails nullable fields
+    prisonMonths: null,
+    prisonSuspended: null,
+    fineAmount: null,
+    ineligibilityMonths: null,
+    communityService: null,
+    otherSentence: null,
+    sentence: null,
+    ...overrides,
+  };
+}
+
+describe("AffairCard — issues favorables dominantes (RGPD art. 10)", () => {
+  it("une relaxe affiche l'encart favorable AVANT la description", () => {
+    const { container } = render(<AffairCard affair={makeAffair()} variant="other" />);
+    const note = container.querySelector('[role="note"][data-variant="favorable"]');
+    expect(note).toBeTruthy();
+    const description = Array.from(container.querySelectorAll("p")).find((p) =>
+      p.textContent?.includes("Description factuelle")
+    );
+    expect(description).toBeTruthy();
+    // L'encart précède la description dans l'ordre du DOM
+    expect(
+      note!.compareDocumentPosition(description!) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("une prescription affiche son wording distinct, pas celui des relaxes", () => {
+    const { container } = render(
+      <AffairCard affair={makeAffair({ status: "PRESCRIPTION" })} variant="other" />
+    );
+    const note = container.querySelector('[role="note"][data-variant="prescription"]');
+    expect(note?.textContent).toContain("Action publique éteinte par prescription");
+    expect(container.querySelector('[data-variant="favorable"]')).toBeNull();
+  });
+
+  it("une affaire close sans condamnation n'affiche jamais la présomption d'innocence", () => {
+    for (const status of [
+      "RELAXE",
+      "ACQUITTEMENT",
+      "NON_LIEU",
+      "CLASSEMENT_SANS_SUITE",
+      "PRESCRIPTION",
+    ]) {
+      const { container } = render(<AffairCard affair={makeAffair({ status })} variant="other" />);
+      expect(container.textContent).not.toContain("présumée innocente");
+    }
+  });
+
+  it("une procédure en cours DIRECT affiche la présomption d'innocence", () => {
+    const { container } = render(
+      <AffairCard affair={makeAffair({ status: "MISE_EN_EXAMEN" })} variant="other" />
+    );
+    expect(container.textContent).toContain("présumée innocente");
+  });
+
+  it("aucun encart quand le politicien est victime", () => {
+    const { container } = render(
+      <AffairCard
+        affair={makeAffair({ status: "ENQUETE_PRELIMINAIRE", involvement: "VICTIM" })}
+        variant="other"
+      />
+    );
+    expect(container.querySelector('[role="note"]')).toBeNull();
+  });
+});

--- a/src/components/stats/JudicialSection.tsx
+++ b/src/components/stats/JudicialSection.tsx
@@ -5,7 +5,7 @@ import {
   AFFAIR_STATUS_LABELS,
   type AffairSuperCategory,
 } from "@/config/labels";
-import type { JudicialMaturity } from "@/config/judicial-maturity";
+import { CLOSE_STATUSES, type JudicialMaturity } from "@/config/judicial-maturity";
 import type { AffairCategory, AffairStatus } from "@/types";
 import { DonutChart } from "./DonutChart";
 import { HorizontalBars } from "./HorizontalBars";
@@ -55,6 +55,8 @@ interface JudicialSectionProps {
   hemicycleGroups: HemicycleGroup[];
   victimStats: ViolenceStats;
 }
+
+const CLOSE_SANS_CONDAMNATION_SET = new Set<AffairStatus>(CLOSE_STATUSES);
 
 const ONGOING_STATUSES = new Set<AffairStatus>([
   "ENQUETE_PRELIMINAIRE",
@@ -232,7 +234,11 @@ export function JudicialSection({
                 .map((s) => ({
                   label: AFFAIR_STATUS_LABELS[s.status],
                   value: s.count,
-                  color: ONGOING_STATUSES.has(s.status) ? "#d97706" : "#2563eb",
+                  color: ONGOING_STATUSES.has(s.status)
+                    ? "#d97706"
+                    : CLOSE_SANS_CONDAMNATION_SET.has(s.status)
+                      ? "#6b7280"
+                      : "#2563eb",
                 }))}
             />
           </CardContent>

--- a/src/config/certainty.ts
+++ b/src/config/certainty.ts
@@ -30,7 +30,7 @@ export const CERTAINTY_LABELS: Record<CertaintyLevel, string> = {
   ETABLI: "Condamnation définitive",
   PRONONCE: "Condamnation non définitive",
   EN_COURS: "Procédure en cours",
-  CLOS_FAVORABLE: "Procédure close",
+  CLOS_FAVORABLE: "Procédure close sans condamnation",
 };
 
 export const CERTAINTY_COLORS: Record<CertaintyLevel, string> = {

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -44,7 +44,7 @@ export const AFFAIR_STATUS_LABELS: Record<AffairStatus, string> = {
   RELAXE: "Relaxe",
   ACQUITTEMENT: "Acquittement",
   NON_LIEU: "Non-lieu",
-  PRESCRIPTION: "Prescription",
+  PRESCRIPTION: "Action publique éteinte par prescription",
   CLASSEMENT_SANS_SUITE: "Classement sans suite",
 };
 
@@ -81,7 +81,8 @@ export const AFFAIR_STATUS_DESCRIPTIONS: Record<AffairStatus, string> = {
   RELAXE: "Le tribunal correctionnel a déclaré la personne non coupable.",
   ACQUITTEMENT: "La cour d'assises a déclaré la personne non coupable.",
   NON_LIEU: "Le juge d'instruction a conclu que les charges étaient insuffisantes pour un procès.",
-  PRESCRIPTION: "Le délai légal pour engager des poursuites est dépassé.",
+  PRESCRIPTION:
+    "La prescription clôt la procédure sans condamnation, mais ne constitue pas une décision sur le fond.",
   CLASSEMENT_SANS_SUITE: "Le procureur a décidé de ne pas poursuivre l'affaire.",
 };
 


### PR DESCRIPTION
Phase 3 du chantier affaires judiciaires / RGPD article 10. Fait suite à #363 et #365.

## Changements

- **`AffairStatusNotice`** : encart unique de prudence juridique par statut (présomption d'innocence / décision non définitive / condamnation définitive / procédure close sans condamnation / action publique éteinte par prescription), réservé aux mises en cause DIRECT/INDIRECT — aucun encart pour les affaires victime/plaignant/mention.
- **Issues favorables dominantes** : l'encart s'affiche avant la description sur la page détail et sur chaque carte des fiches politiques ; une affaire close sans condamnation n'est jamais rendue avec la présomption d'innocence ni comme mise en cause active (prouvé par tests DOM).
- **Prescription distincte** : label « Action publique éteinte par prescription » (badges, OG, /methodologie), encart et tooltip précisant l'absence de décision sur le fond, sans assimilation à une relaxe.
- **Labels** : « Procédure close » → « Procédure close sans condamnation » (groupes des fiches, badges, filtres).
- **Encart méthodologique** mis à jour sur /affaires (validation éditoriale, présomption, distinction des issues) + sous-titre méthodologique sur les fiches politiques.
- **Stats** : couleur grise distincte pour les statuts favorables dans le graphe « Statut des procédures » — présentation pure, aucun agrégat modifié.
- **Tests** : 15 tests composants no-leak UI (matrice variante x statut x involvement, dominance DOM, wording prescription, frontière victime).

## Hors périmètre (respecté)

Pas de migration, pas d'admin, pas d'agrégats, pas de LEGAL.md (Phase 4). Le contrat MCP fait l'objet d'une PR séparée sur le repo MCP (poligraph-mcp#2).

## Vérifications

- typecheck, lint (fichiers modifiés), test:run : verts (1483 tests, +15).
- Smoke dev : encart favorable rendu AVANT la description (positions DOM vérifiées), sous-titre méthodo sur fiche Bardella, encart /affaires en place.