### PR TITLE
RGPD art. 10 Phase 3b : compteurs d'affaires par rôle + PartyAffairsList

### DIFF
--- a/src/app/api/politiques/[slug]/route.ts
+++ b/src/app/api/politiques/[slug]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getPoliticianBySlug } from "@/services/politicians";
 import { withCache } from "@/lib/cache";
 import { withPublicRoute } from "@/lib/api/with-public-route";
+import { computeAffairCounts } from "@/lib/affairs/affair-counts";
 
 /**
  * @openapi
@@ -100,6 +101,7 @@ export const GET = withPublicRoute(async (request, context) => {
         details: d.details,
       })),
       affairsCount: politician.affairs.length,
+      ...computeAffairCounts(politician.affairs),
       factchecksCount:
         (politician as unknown as { _count: { factCheckMentions: number } })._count
           ?.factCheckMentions ?? 0,

--- a/src/components/affairs/PartyAffairsList.tsx
+++ b/src/components/affairs/PartyAffairsList.tsx
@@ -8,7 +8,6 @@ import { stripMarkdown } from "@/lib/utils";
 import {
   AFFAIR_STATUS_LABELS,
   AFFAIR_STATUS_COLORS,
-  AFFAIR_STATUS_NEEDS_PRESUMPTION,
   AFFAIR_SUPER_CATEGORY_LABELS,
   AFFAIR_SUPER_CATEGORY_COLORS,
   CATEGORY_TO_SUPER,
@@ -16,10 +15,9 @@ import {
   INVOLVEMENT_COLORS,
   type AffairSuperCategory,
 } from "@/config/labels";
+import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
 import { getJudicialMaturity } from "@/config/judicial-maturity";
 import type { AffairCategory, AffairStatus, Involvement } from "@/types";
-
-const MIS_EN_CAUSE: Involvement[] = ["DIRECT", "INDIRECT"];
 
 const MATURITY_TAB_LABELS: Record<string, string> = {
   ALL: "Toutes",
@@ -197,12 +195,11 @@ export function PartyAffairsList({ affairs }: PartyAffairsListProps) {
                   <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
                     {stripMarkdown(affair.description)}
                   </p>
-                  {AFFAIR_STATUS_NEEDS_PRESUMPTION[affair.status as AffairStatus] &&
-                    MIS_EN_CAUSE.includes(affair.involvement as Involvement) && (
-                      <p className="text-xs text-amber-700 bg-amber-50 p-2 rounded mt-2 inline-block dark:bg-amber-900/30 dark:text-amber-300">
-                        Présomption d&apos;innocence : affaire en cours
-                      </p>
-                    )}
+                  <AffairStatusNotice
+                    status={affair.status as AffairStatus}
+                    involvement={affair.involvement as Involvement}
+                    className="mt-2"
+                  />
                 </div>
               );
             })

--- a/src/lib/affairs/__tests__/affair-counts.test.ts
+++ b/src/lib/affairs/__tests__/affair-counts.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { computeAffairCounts } from "@/lib/affairs/affair-counts";
+
+type A = { status: string; involvement: string };
+const a = (status: string, involvement: string): A => ({ status, involvement });
+
+describe("computeAffairCounts — compteurs par rôle (RGPD art. 10)", () => {
+  it("adverseAffairsCount = DIRECT/INDIRECT + statuts à charge (Tier 1+2)", () => {
+    const counts = computeAffairCounts([
+      a("CONDAMNATION_DEFINITIVE", "DIRECT"),
+      a("MISE_EN_EXAMEN", "INDIRECT"),
+      a("ENQUETE_PRELIMINAIRE", "DIRECT"), // exclu (Tier 3)
+      a("RELAXE", "DIRECT"), // exclu (favorable)
+      a("CONDAMNATION_DEFINITIVE", "MENTIONED_ONLY"), // exclu (involvement)
+    ]);
+    expect(counts.adverseAffairsCount).toBe(2);
+  });
+
+  it("affairsMentionedCount = MENTIONED_ONLY", () => {
+    const counts = computeAffairCounts([
+      a("CONDAMNATION_DEFINITIVE", "MENTIONED_ONLY"),
+      a("ENQUETE_PRELIMINAIRE", "MENTIONED_ONLY"),
+      a("RELAXE", "DIRECT"),
+    ]);
+    expect(counts.affairsMentionedCount).toBe(2);
+  });
+
+  it("affairsVictimOrPlaintiffCount = VICTIM + PLAINTIFF", () => {
+    const counts = computeAffairCounts([
+      a("ENQUETE_PRELIMINAIRE", "VICTIM"),
+      a("ENQUETE_PRELIMINAIRE", "PLAINTIFF"),
+      a("CONDAMNATION_DEFINITIVE", "DIRECT"),
+    ]);
+    expect(counts.affairsVictimOrPlaintiffCount).toBe(2);
+  });
+
+  it("favorableOutcomeCount = DIRECT/INDIRECT + issues favorables (prescription incluse)", () => {
+    const counts = computeAffairCounts([
+      a("RELAXE", "DIRECT"),
+      a("ACQUITTEMENT", "INDIRECT"),
+      a("NON_LIEU", "DIRECT"),
+      a("CLASSEMENT_SANS_SUITE", "DIRECT"),
+      a("PRESCRIPTION", "DIRECT"),
+      a("RELAXE", "VICTIM"), // exclu (involvement)
+      a("CONDAMNATION_DEFINITIVE", "DIRECT"), // exclu (à charge)
+    ]);
+    expect(counts.favorableOutcomeCount).toBe(5);
+  });
+
+  it("liste vide → tous les compteurs à 0", () => {
+    expect(computeAffairCounts([])).toEqual({
+      adverseAffairsCount: 0,
+      affairsMentionedCount: 0,
+      affairsVictimOrPlaintiffCount: 0,
+      favorableOutcomeCount: 0,
+    });
+  });
+
+  it("une ENQUETE_PRELIMINAIRE DIRECT n'entre dans aucun compteur (ni à charge ni favorable)", () => {
+    const counts = computeAffairCounts([a("ENQUETE_PRELIMINAIRE", "DIRECT")]);
+    expect(counts).toEqual({
+      adverseAffairsCount: 0,
+      affairsMentionedCount: 0,
+      affairsVictimOrPlaintiffCount: 0,
+      favorableOutcomeCount: 0,
+    });
+  });
+});

--- a/src/lib/affairs/affair-counts.ts
+++ b/src/lib/affairs/affair-counts.ts
@@ -1,0 +1,51 @@
+import type { AffairStatus, Involvement } from "@/generated/prisma";
+import { AGGREGATE_STATUSES, CLOSE_STATUSES } from "@/config/judicial-maturity";
+import { ADVERSE_INVOLVEMENTS } from "@/lib/affairs/public-filters";
+
+/**
+ * Compteurs d'affaires par rôle, calculés en mémoire depuis les affaires
+ * publiées déjà chargées (RGPD art. 10 : ne pas mélanger mis en cause,
+ * mention et victime/plaignant dans un chiffre unique).
+ *
+ * Cohérent avec les where-builders publics (public-filters.ts) :
+ * - adverse  = à charge (Tier 1+2), comme getAdverseAffairWhere()
+ * - favorable = issues closes sans condamnation, comme getFavorableOutcomeWhere()
+ *
+ * Ces compteurs ne partitionnent pas le total : une enquête préliminaire
+ * DIRECT n'entre dans aucun (ni à charge, ni favorable).
+ */
+
+export interface AffairCounts {
+  adverseAffairsCount: number;
+  affairsMentionedCount: number;
+  affairsVictimOrPlaintiffCount: number;
+  favorableOutcomeCount: number;
+}
+
+const ADVERSE_INVOLVEMENT_SET = new Set<string>(ADVERSE_INVOLVEMENTS);
+const AGGREGATE_STATUS_SET = new Set<string>(AGGREGATE_STATUSES);
+const CLOSE_STATUS_SET = new Set<string>(CLOSE_STATUSES);
+
+type CountableAffair = { status: AffairStatus | string; involvement: Involvement | string };
+
+export function computeAffairCounts(affairs: readonly CountableAffair[]): AffairCounts {
+  let adverseAffairsCount = 0;
+  let affairsMentionedCount = 0;
+  let affairsVictimOrPlaintiffCount = 0;
+  let favorableOutcomeCount = 0;
+
+  for (const { status, involvement } of affairs) {
+    const isAdverseInvolvement = ADVERSE_INVOLVEMENT_SET.has(involvement);
+    if (involvement === "MENTIONED_ONLY") affairsMentionedCount++;
+    if (involvement === "VICTIM" || involvement === "PLAINTIFF") affairsVictimOrPlaintiffCount++;
+    if (isAdverseInvolvement && AGGREGATE_STATUS_SET.has(status)) adverseAffairsCount++;
+    if (isAdverseInvolvement && CLOSE_STATUS_SET.has(status)) favorableOutcomeCount++;
+  }
+
+  return {
+    adverseAffairsCount,
+    affairsMentionedCount,
+    affairsVictimOrPlaintiffCount,
+    favorableOutcomeCount,
+  };
+}

--- a/src/lib/openapi/schemas.ts
+++ b/src/lib/openapi/schemas.ts
@@ -181,7 +181,19 @@
  *             $ref: '#/components/schemas/Declaration'
  *         affairsCount:
  *           type: integer
- *           description: Nombre d'affaires judiciaires
+ *           description: Nombre d'affaires publiées impliquant la personne, tous rôles confondus.
+ *         adverseAffairsCount:
+ *           type: integer
+ *           description: Affaires où la personne est mise en cause (procédures validées par un juge).
+ *         affairsMentionedCount:
+ *           type: integer
+ *           description: Affaires où la personne est simplement mentionnée.
+ *         affairsVictimOrPlaintiffCount:
+ *           type: integer
+ *           description: Affaires où la personne est victime ou plaignante.
+ *         favorableOutcomeCount:
+ *           type: integer
+ *           description: Affaires closes sans condamnation (relaxe, acquittement, non-lieu, classement, prescription).
  *
  *     Source:
  *       type: object


### PR DESCRIPTION
Suivi #368. Fait suite aux Phases 1-3 (#363, #365, #367).

## Changements

- **`computeAffairCounts`** (helper pur, réutilise les sets de public-filters/judicial-maturity) : calcule en mémoire, depuis les affaires publiées déjà chargées, quatre compteurs distincts.
- **API `/api/politiques/[slug]`** : expose `adverseAffairsCount` (DIRECT/INDIRECT + Tier 1+2), `affairsMentionedCount` (MENTIONED_ONLY), `affairsVictimOrPlaintiffCount` (VICTIM/PLAINTIFF), `favorableOutcomeCount` (DIRECT/INDIRECT + closes sans condamnation). `affairsCount` legacy CONSERVÉ (tous rôles confondus), aucun breaking change. Schéma OpenAPI mis à jour.
- **PartyAffairsList** reprend `AffairStatusNotice` : la page parti affiche désormais les issues favorables et la prescription comme la fiche personne (fin de la divergence).
- **Tests** : 6 tests du helper (matrice rôle x statut, enquête préliminaire dans aucun compteur).

Exemple prod (Sarkozy) : affairsCount 10 = 5 à charge + 2 mentionné + 1 victime/plaignant + 1 favorable + 1 enquête préliminaire (dans aucun bucket, voulu).

## Hors périmètre (respecté)

Pas de migration Prisma, pas de modification des agrégats existants (exposition additive seulement). MCP : PR séparée à merger après celle-ci (le test de contrat dépend du déploiement des champs).