### PR TITLE
RGPD art. 10 Phase 4 : documentation (LEGAL.md, méthodologie, AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,8 @@ These rules apply to AI assistants specifically when generating code, queries, o
 - **Write party-asymmetric logic.** No conditional branching on party name for editorial treatment.
 - **Escalate `Affair.involvement` automatically.** The default `MENTIONED_ONLY` exists to protect the presumption of innocence. Only human moderators can upgrade involvement.
 - **Auto-link politicians to affairs below threshold.** The resolver returns `SAME / UNDECIDED / NO_MATCH`. Only `SAME` (>= 0.95 for identity, above `SAME_THRESHOLD` for affair-matching) auto-links. `UNDECIDED` requires manual review.
+- **Publish a judicial affair outside the guard (RGPD art. 10).** Never write `publicationStatus: "PUBLISHED"` on `Affair` directly. The only path to publication is `assertPublishable()` in `src/lib/affairs/publish-guard.ts`, which requires a source, requires every automated matching decision to be human-validated, and writes `verifiedAt` + `verifiedBy` atomically. A CI guard rejects direct `PUBLISHED` literals; variable-based writes are caught in review.
+- **Let an automated pipeline create a non-DRAFT affair.** Press, Wikidata, Wikipedia, Judilibre and any future source create affairs in `DRAFT` only. Publication is always a separate, explicit human action.
 - **Import data from unverified sources.** Blogs, forums, social media, unverified aggregators are not allowed as primary sources.
 - **Add feature flags or compatibility shims** when the code can be changed directly.
 - **Use em dashes (—) in any generated content.** Commas, colons, and parentheses do the job.
@@ -279,6 +281,7 @@ These rules apply to AI assistants specifically when generating code, queries, o
 - **Pair data fixes with regression tests.** If you fix a false-positive mention or a wrong party display, add a test reproducing the bug before implementing the fix.
 - **Prefer editing existing files** over creating new ones. Prefer deleting dead code over keeping legacy shims.
 - **Use domain helpers**: `getAffairPartyDisplay()`, `getCertaintyLevel()`, `NUANCE_POLITIQUE_MAPPING`, `callAnthropic()`, `withAdminAuth()`, `withValidation()`, `parsePagination()`, `stripMarkdownForCSV()`. They encode editorial and security constraints.
+- **Filter affairs through the centralized builders on every public surface.** Web pages, public API routes, CSV/JSON exports and the MCP server must use the where-builders in `src/lib/affairs/public-filters.ts` (`getPublishedAffairWhere`, `getAdverseAffairWhere`, `getMisEnCauseWhere`, `getFavorableOutcomeWhere`) and the per-role counters in `affair-counts.ts`. Never hand-roll a `publicationStatus`/status filter in a public surface: the MCP server consumes the public API and inherits its filters, so no judicial data leaks through a side door. Methodology is documented in `/methodologie` and the RGPD art. 10 measures in `docs/LEGAL.md` §7.
 - **Default to small commits.** Under 400 changed lines per commit when possible. Split large features into schema, service, UI commits.
 - **Write tests for every new service, data function, or pure utility** added by a `feat()` commit. Reference examples: `resolver.test.ts`, `hatvp-xml.test.ts`, `confidence.test.ts`.
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -136,7 +136,88 @@ Les représentants politiques mentionnés disposent de :
 
 ---
 
-## 7. Propriété intellectuelle
+## 7. Traitement de données pénales (article 10 RGPD)
+
+> Cette section décrit des **mesures de réduction du risque**. Elle ne constitue
+> pas un avis juridique et n'affirme pas que le traitement est conforme. La
+> qualification finale relève d'un avocat spécialisé et, le cas échéant, d'une
+> analyse d'impact (AIPD). Voir la section 8.
+
+### 7.1 Pourquoi ces données sont sensibles
+
+Une affaire judiciaire rattachée nommément à une personne est une donnée
+relative à une infraction ou à une procédure pénale. Le regroupement
+automatisé et structuré de telles données par personne, surtout à grande
+échelle, peut relever de l'article 10 du RGPD, qui encadre strictement le
+traitement des données pénales. Le risque ne vient pas de la mention isolée
+d'une affaire sourcée, mais de la constitution d'un fichier durable
+d'antécédents ou de mises en cause.
+
+### 7.2 Poligraph n'est pas un casier judiciaire
+
+Poligraph documente des affaires déjà publiques, issues de sources vérifiables,
+dans un objectif d'information citoyenne sur la vie politique. Le site ne
+reconstitue pas, ne vend pas et ne prétend pas refléter le casier judiciaire
+d'une personne. Une affaire absente du site ne signifie rien sur la situation
+judiciaire réelle d'une personne, et une affaire présente n'établit pas une
+culpabilité (voir la présomption d'innocence, section 4).
+
+### 7.3 Mesures techniques mises en place
+
+Ces garde-fous sont implémentés dans le code et vérifiés par des tests
+automatisés :
+
+- **Aucune publication automatique.** Tout pipeline automatisé (presse,
+  Wikidata, Wikipédia, Judilibre) crée une affaire en brouillon (`DRAFT`),
+  jamais publiée directement. Même une condamnation issue d'une source
+  structurée reste en attente de revue.
+- **Validation humaine obligatoire avant publication.** La mise en ligne d'une
+  affaire passe par un point de contrôle unique côté serveur qui exige au moins
+  une source vérifiable, refuse la publication si un rattachement automatique
+  n'a pas été validé par un humain, et enregistre qui a validé et quand.
+- **Pas de rattachement publié sur un score algorithmique seul.** Le moteur de
+  rapprochement personne / affaire ne fait que proposer un candidat avec un
+  score et des indices. Aucun rattachement pénal n'est rendu public sur la
+  seule base de ce score : un modérateur confirme l'identité, le statut
+  judiciaire, l'implication et les sources.
+- **Issues favorables affichées de manière dominante.** Une relaxe, un
+  acquittement, un non-lieu ou un classement sans suite est signalé clairement,
+  avant toute description, et n'est jamais présenté comme une mise en cause
+  active.
+- **Prescription distinguée.** L'extinction de l'action publique par
+  prescription est affichée séparément (« action publique éteinte par
+  prescription ») et n'est pas assimilée à une relaxe : elle clôt la procédure
+  sans décision sur le fond.
+- **Agrégats prudents.** Les compteurs publics distinguent les condamnations,
+  les procédures validées par un juge, les enquêtes préliminaires et les
+  procédures closes sans condamnation. Les enquêtes préliminaires ne sont pas
+  comptées comme des procédures validées par un juge (voir la page
+  Méthodologie).
+- **Mêmes règles sur toutes les surfaces.** Les pages web, les routes API
+  publiques, les exports et le serveur MCP appliquent les mêmes filtres : ils
+  n'exposent que des affaires publiées après validation humaine. Une affaire en
+  brouillon, archivée, exclue ou rejetée n'est accessible par aucune de ces
+  voies.
+
+### 7.4 Droits des personnes concernées
+
+Au-delà des droits rappelés en section 5 (droit de réponse) et 6.3 (accès,
+rectification, opposition), toute personne concernée peut demander la
+correction d'une information inexacte ou le réexamen d'un rattachement. En cas
+de doute sérieux, l'affaire est repassée en brouillon le temps de la
+vérification. Le contact est indiqué dans les mentions légales.
+
+### 7.5 Limites assumées
+
+Ces mesures réduisent le risque, elles ne le suppriment pas. Une montée en
+échelle du nombre d'affaires traitées, ou l'ajout de nouvelles sources
+automatisées, doit être précédée d'un réexamen juridique. Les points listés en
+section 8.4 restent à valider par un avocat spécialisé avant tout changement
+d'échelle.
+
+---
+
+## 8. Propriété intellectuelle
 
 ### 7.1 Contenus du site
 
@@ -154,32 +235,48 @@ Les représentants politiques mentionnés disposent de :
 
 ---
 
-## 8. Recommandations
+## 9. Recommandations
 
-### 8.1 Avant mise en production
+### 9.1 Avant mise en production
 
 - [ ] Consulter un avocat spécialisé (presse/données)
 - [ ] Vérifier l'assurance RC Pro (si association/société)
 - [ ] Définir une procédure de retrait d'urgence
 - [ ] Compléter les mentions légales (éditeur, contact)
 
-### 8.2 En continu
+### 9.2 En continu
 
 - [ ] Vérifier les sources avant publication
 - [ ] Mettre à jour les statuts des affaires
 - [ ] Répondre aux demandes de rectification
 - [ ] Archiver les preuves (sources, dates)
 
-### 8.3 Bonnes pratiques (inspirées de Regards Citoyens)
+### 9.3 Bonnes pratiques (inspirées de Regards Citoyens)
 
 - Transparence sur la collecte et le traitement
 - Licences ouvertes pour la réutilisation
 - Pas de cession de données à des tiers
 - Anonymisation si analytics
 
+### 9.4 Points à valider par un avocat spécialisé
+
+Les mesures de la section 7 réduisent le risque sans garantir la conformité.
+Les questions suivantes doivent être tranchées par un avocat spécialisé avant
+toute montée en échelle :
+
+- [ ] Qualification du traitement au regard de l'article 10 RGPD (données
+      pénales) et base de licéité retenue.
+- [ ] Applicabilité du régime journalistique et de la liberté d'expression
+      (articles 80 RGPD et 67 de la loi Informatique et Libertés).
+- [ ] Durées de conservation des affaires, notamment après une issue favorable
+      ou pour les procédures anciennes.
+- [ ] Statuts judiciaires admissibles dans les agrégats publics.
+- [ ] Traitement de la prescription (affichage et conservation).
+- [ ] Conditions de publication d'un rattachement personne / affaire.
+
 ---
 
-## 9. Ressources
+## 10. Ressources
 
 - [HATVP - Open Data](https://www.hatvp.fr/open-data/)
 - [CNIL - Données publiques](https://www.cnil.fr)

--- a/src/app/methodologie/page.tsx
+++ b/src/app/methodologie/page.tsx
@@ -168,18 +168,28 @@ export default function MethodologiePage() {
               Procédures closes sans condamnation
             </h3>
             <p>
-              Relaxe, acquittement, non-lieu, prescription, classement sans suite. Ces procédures
-              sont affichées séparément comme signal positif : elles montrent que la justice a
-              examiné et écarté les accusations.
+              Relaxe, acquittement, non-lieu et classement sans suite : la procédure s{"'"}est
+              terminée sans condamnation. Ces issues favorables sont affichées séparément des
+              condamnations et ne sont jamais présentées comme une mise en cause active.
+            </p>
+          </div>
+          <div className="rounded-lg border p-4">
+            <h3 className="font-medium text-foreground mb-1">
+              Action publique éteinte par prescription
+            </h3>
+            <p>
+              La prescription clôt la procédure sans condamnation, mais à la différence d{"'"}une
+              relaxe ou d{"'"}un non-lieu, elle ne constitue pas une décision sur le fond. Elle est
+              donc signalée distinctement, et non assimilée à une issue favorable au fond.
             </p>
           </div>
           <div className="rounded-lg border p-4">
             <h3 className="font-medium text-foreground mb-1">Implication directe et indirecte</h3>
             <p>
               Seules les affaires où le politicien est directement ou indirectement impliqué (mis en
-              cause, poursuivi ou condamné) sont comptabilisées. Les simples mentions dans une
-              affaire tierce ou les cas où le politicien est victime/plaignant ne sont pas inclus
-              dans les compteurs.
+              cause, poursuivi ou condamné) sont comptabilisées dans les agrégats à charge. Les
+              simples mentions dans une affaire tierce ou les cas où le politicien est
+              victime/plaignant ne sont pas inclus dans ces compteurs.
             </p>
           </div>
           <div className="rounded-lg border p-4">
@@ -190,6 +200,62 @@ export default function MethodologiePage() {
               affaires.
             </p>
           </div>
+        </div>
+      </section>
+
+      {/* Section 3b: Per-role counters on the politician page */}
+      <section className="mb-12">
+        <h2 className="text-xl font-display font-semibold mb-4">
+          Compteurs d{"'"}affaires sur la fiche d{"'"}un politicien
+        </h2>
+        <p className="text-muted-foreground mb-6">
+          La fiche d{"'"}un politicien expose plusieurs compteurs, qui ne mesurent pas la même
+          chose. Ils sont volontairement distincts pour ne pas mélanger une mise en cause, une
+          simple mention et une situation de victime.
+        </p>
+        <div className="space-y-3 text-sm text-muted-foreground">
+          <div className="rounded-lg border p-4">
+            <h3 className="font-medium text-foreground mb-1">
+              Total des affaires publiées (tous rôles confondus)
+            </h3>
+            <p>
+              Le compteur général recense toutes les affaires publiées impliquant la personne, quel
+              que soit son rôle : mise en cause, simplement mentionnée, victime ou plaignante. Ce
+              chiffre ne dit donc rien, à lui seul, du degré de mise en cause.
+            </p>
+          </div>
+          <div className="rounded-lg border p-4">
+            <h3 className="font-medium text-foreground mb-1">À charge (procédures validées)</h3>
+            <p>
+              Affaires où la personne est mise en cause (directement ou indirectement) et où un juge
+              a validé la procédure : condamnations et procédures validées par un juge. Les enquêtes
+              préliminaires en sont exclues.
+            </p>
+          </div>
+          <div className="rounded-lg border p-4">
+            <h3 className="font-medium text-foreground mb-1">Issues favorables</h3>
+            <p>
+              Affaires où la personne était mise en cause et dont la procédure s{"'"}est terminée
+              sans condamnation : relaxe, acquittement, non-lieu, classement sans suite et
+              prescription.
+            </p>
+          </div>
+          <div className="rounded-lg border p-4">
+            <h3 className="font-medium text-foreground mb-1">Simple mention</h3>
+            <p>Affaires où la personne est citée sans être mise en cause ni poursuivie.</p>
+          </div>
+          <div className="rounded-lg border p-4">
+            <h3 className="font-medium text-foreground mb-1">Victime ou plaignant</h3>
+            <p>
+              Affaires où la personne est victime ou a porté plainte. Ces affaires ne sont jamais
+              comptées comme une mise en cause.
+            </p>
+          </div>
+          <p className="text-xs">
+            Ces compteurs ne se cumulent pas pour reconstituer le total : une enquête préliminaire
+            visant directement la personne, par exemple, n{"'"}entre ni dans les affaires à charge
+            (faute de validation par un juge), ni dans les issues favorables.
+          </p>
         </div>
       </section>
 


### PR DESCRIPTION
Phase 4 (finale) du chantier affaires judiciaires / RGPD article 10. Documentation uniquement, aucun code métier modifié. Fait suite à #363, #365, #367, #369.

## Changements

**docs/LEGAL.md** — nouvelle section 7 « Traitement de données pénales (article 10 RGPD) », formulée comme des mesures de réduction du risque (jamais une garantie de conformité) :
- pourquoi ces données sont sensibles ; Poligraph n'est pas un casier judiciaire ;
- mesures techniques en place (aucune publication automatique, validation humaine obligatoire via le guard, pas de rattachement publié sur score seul, issues favorables dominantes, prescription distinguée, agrégats prudents, mêmes règles web/API/export/MCP) ;
- droits des personnes ; limites assumées.
- Nouvelle sous-section 9.4 « Points à valider par un avocat spécialisé » (qualification art. 10, régime journalistique, durées de conservation, agrégats admissibles, prescription, conditions de rattachement). Sections suivantes renumérotées.

**src/app/methodologie/page.tsx** — page publique :
- nouvelle section « Compteurs d'affaires sur la fiche d'un politicien » : explique le total legacy (tous rôles confondus) et les compteurs additifs (à charge, issues favorables, simple mention, victime/plaignant), avec la note que les compteurs ne se cumulent pas ;
- correction d'une incohérence documentaire : la prescription n'est plus décrite comme « la justice a examiné et écarté les accusations » (faux : pas de décision sur le fond) ; elle a désormais son propre bloc distinct des autres issues favorables ;
- rappel que les enquêtes préliminaires ne sont pas comptées comme procédures validées par un juge (déjà présent, conservé).

**AGENTS.md** — note courte dans les guardrails : publication d'affaire uniquement via le guard (jamais de `PUBLISHED` direct), pipelines automatisés en DRAFT only, surfaces publiques (web/API/export/MCP) via les filtres centralisés de public-filters.ts + affair-counts.ts.

## Vérifications

- typecheck 0 erreur (hors artefacts .next), prettier + eslint OK.
- Cohérence doc / code vérifiée : publish-guard.ts, public-filters.ts (builders cités), affair-counts.ts et le garde-fou CI existent bien.
- Aucun tiret cadratin introduit ; style factuel, non accusatoire, sans promesse de conformité.

## Hors périmètre (respecté)

Pas de migration Prisma, pas de changement d'agrégats, pas de refonte UI, pas de code métier.