### PR TITLE
docs(RGPD art. 10) : note d'état final + dossier avocat/AIPD

### DIFF
--- a/docs/rgpd-article10/dossier-avocat-aipd.md
+++ b/docs/rgpd-article10/dossier-avocat-aipd.md
@@ -1,0 +1,151 @@
+# Dossier avocat / AIPD : traitement de données pénales (article 10 RGPD)
+
+Date : 2026-06-07
+Objet : réunir les éléments factuels pour une revue juridique et, le cas
+échéant, une analyse d'impact relative à la protection des données (AIPD).
+
+> Ce document décrit des mesures techniques et éditoriales de réduction du
+> risque. Il ne constitue pas un avis juridique et n'affirme aucune conformité.
+> Les questions ouvertes à trancher figurent en section 7.
+
+---
+
+## 1. Présentation du traitement
+
+Poligraph est un observatoire citoyen de la vie politique française. Il agrège
+des données publiques sur les responsables politiques, dont des affaires
+judiciaires rattachées nominativement. Le présent dossier concerne ce dernier
+traitement, susceptible de relever de l'article 10 du RGPD (données pénales).
+
+- Finalité : information citoyenne et débat d'intérêt général sur la probité des
+  responsables publics.
+- Personnes concernées : responsables politiques français (élus, ministres,
+  dirigeants de partis), vivants ou décédés depuis moins de dix ans.
+- Sources : articles de presse vérifiables, décisions de justice publiées,
+  Wikidata, Wikipédia. Pas de blogs, forums, réseaux sociaux.
+- Le site ne reconstitue pas un casier judiciaire (cf. `docs/LEGAL.md` §7.2).
+
+## 2. Pièces du dossier
+
+| Pièce                               | Emplacement                                                           |
+| ----------------------------------- | --------------------------------------------------------------------- |
+| Cadre juridique et mesures art. 10  | `docs/LEGAL.md`, section 7 entière                                    |
+| Questions à valider par avocat      | `docs/LEGAL.md`, section 9.4                                          |
+| Méthodologie publique (en ligne)    | `/methodologie` sur poligraph.fr                                      |
+| Schéma des flux de publication      | présent document, section 3                                           |
+| Exemples d'affichage par statut     | présent document, section 4                                           |
+| Script d'audit de conformité        | `scripts/audit-affairs-compliance.ts`                                 |
+| Résultats d'audit                   | présent document, section 5                                           |
+| Spécification technique du chantier | `docs/superpowers/specs/2026-06-07-affaires-rgpd-article10-design.md` |
+| État final et liste des PRs         | `docs/rgpd-article10/etat-final.md`                                   |
+
+## 3. Schéma des flux : pipeline → DRAFT → revue → PUBLISHED
+
+```
+SOURCES AUTOMATISÉES                         ACTION HUMAINE                         PUBLIC
+(presse, Wikidata, Wikipédia, Judilibre)
+
+  [1] Détection + classification IA
+        │
+        ▼
+  [2] Resolver personne/affaire
+        │  produit une AffairPoliticianDecision
+        │  (candidat + score + indices), JAMAIS un rattachement publié
+        ▼
+  [3] Création de l'affaire ───────────────►  publicationStatus = DRAFT
+        │  verifiedAt = null, verifiedBy = null            (jamais public)
+        │  decision.affairId renseigné
+        │
+        │                                   [4] Revue éditoriale humaine
+        │                                       - confirme l'identité (onglet SAME)
+        │                                       - vérifie statut, implication, sources
+        │                                       - corrige / requalifie / rejette
+        │                                            │
+        │                                            ▼
+        │                                   [5] assertPublishable() — point de
+        │                                       passage UNIQUE vers PUBLISHED :
+        │                                       • exige ≥ 1 source vérifiable
+        │                                       • exige décisions resolver validées
+        │                                         par un humain (reviewedBy +
+        │                                         reviewAction confirmant + bon
+        │                                         politicien)
+        │                                       • écrit verifiedAt + verifiedBy
+        │                                         atomiquement
+        │                                            │
+        │                                            ▼
+        │                                                          publicationStatus = PUBLISHED
+        │                                                          ───────────────────────────►
+        │                                                          Visible : web, API, exports, MCP
+        │                                                          (filtres centralisés identiques)
+        ▼
+  Une affaire jamais validée reste DRAFT indéfiniment : invisible partout.
+```
+
+Garanties machine :
+
+- Aucun pipeline n'écrit PUBLISHED (type DRAFT-only au niveau du compilateur).
+- Toute autre écriture directe de PUBLISHED est rejetée par un garde-fou
+  d'intégration continue (CI).
+- Les surfaces publiques (web, API, exports CSV/JSON, serveur MCP) appliquent
+  les mêmes filtres : aucune affaire DRAFT, ARCHIVED, EXCLUDED ou REJECTED n'est
+  accessible par aucune voie.
+
+## 4. Exemples d'affichage par statut (URLs publiques, 2026-06-07)
+
+Chaque affaire publique porte un encart de prudence juridique adapté à son
+statut procédural (composant `AffairStatusNotice`).
+
+| Statut                      | Encart affiché                                                                                                                                      | Exemple en ligne                                                                                                           |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Condamnation définitive     | « Condamnation définitive : les voies de recours ordinaires sont épuisées... »                                                                      | https://poligraph.fr/affaires/jean-marie-le-pen-condamnation-de-jean-marie-le-pen-pour-coups-et-blessures-volontaires-1960 |
+| Condamnation non définitive | « Décision non définitive : cette condamnation peut encore faire l'objet d'un recours... »                                                          | https://poligraph.fr/affaires/emploi-fictif-assistant-parlementaire-yann-bompard                                           |
+| Procédure en cours          | « Présomption d'innocence : cette procédure est en cours. La personne... est présumée innocente... »                                                | https://poligraph.fr/affaires/jean-christophe-lagarde-escroquerie-2024                                                     |
+| Relaxe (issue favorable)    | « Procédure close sans condamnation : cette issue est favorable... ne doit pas être lue comme une condamnation. »                                   | https://poligraph.fr/affaires/eric-woerth-woerth-bettencourt-relaxe-d-eric-woerth                                          |
+| Prescription                | « Action publique éteinte par prescription : la procédure est close sans condamnation. La prescription ne constitue pas une décision sur le fond. » | https://poligraph.fr/affaires/francois-fillon-detournements-de-fonds-publics-du-senat-urs                                  |
+
+Pour les issues favorables (relaxe, acquittement, non-lieu, classement sans
+suite), l'encart est affiché AVANT toute description, de manière dominante.
+
+## 5. Résultats d'audit (prod, 2026-06-07)
+
+Commande : `npx dotenv -e .env -- npx tsx scripts/audit-affairs-compliance.ts`
+(lecture seule).
+
+| Indicateur                                                                          | Valeur |
+| ----------------------------------------------------------------------------------- | ------ |
+| Affaires publiées sans validation humaine tracée (`verifiedBy` null)                | 0      |
+| Auto-publications Wikidata résiduelles                                              | 0      |
+| Affaires publiées sans source                                                       | 0      |
+| Issues favorables comptées dans un agrégat à charge                                 | 0      |
+| Enquêtes préliminaires publiées (visibles sur fiche, exclues des agrégats à charge) | 64     |
+| Décisions resolver orphelines pointant vers une affaire publiée (suivi éditorial)   | 50     |
+
+Agrégats publics distingués (cf. `/methodologie`) :
+
+- condamnations ; procédures validées par un juge ; enquêtes préliminaires (non
+  comptées comme validées) ; procédures closes sans condamnation.
+- Compteurs par rôle sur chaque fiche : total (tous rôles confondus, legacy),
+  à charge, issues favorables, simple mention, victime/plaignant. Ils ne se
+  cumulent pas (une enquête préliminaire directe n'entre dans aucun).
+
+## 6. Droits des personnes
+
+- Droit de réponse (loi du 29 juillet 1881) : `docs/LEGAL.md` §5.
+- Accès, rectification, opposition (RGPD art. 15, 16, 21) : `docs/LEGAL.md` §6.3.
+- En cas de doute sérieux sur un rattachement, l'affaire est repassée en DRAFT
+  le temps de la vérification (`docs/LEGAL.md` §7.4).
+
+## 7. Questions ouvertes à trancher par l'avocat (reprises de LEGAL.md §9.4)
+
+1. Qualification du traitement au regard de l'article 10 RGPD (données pénales)
+   et base de licéité retenue.
+2. Applicabilité du régime journalistique et de la liberté d'expression
+   (articles 80 RGPD et 67 de la loi Informatique et Libertés).
+3. Durées de conservation des affaires, notamment après une issue favorable ou
+   pour les procédures anciennes.
+4. Statuts judiciaires admissibles dans les agrégats publics.
+5. Traitement de la prescription (affichage et conservation).
+6. Conditions de publication d'un rattachement personne / affaire.
+
+Ces réponses conditionnent toute montée en échelle (volume d'affaires, nouvelles
+sources automatisées).

--- a/docs/rgpd-article10/etat-final.md
+++ b/docs/rgpd-article10/etat-final.md
@@ -1,0 +1,58 @@
+# RGPD article 10 : état final en production
+
+Date : 2026-06-07
+Statut : chantier complet, toutes les phases déployées en production.
+
+> Document de traçabilité interne. Décrit l'état du produit après les Phases 1
+> à 4. Pour le détail méthodologique public : `/methodologie`. Pour le cadre
+> juridique : `docs/LEGAL.md` §7. Pour le dossier avocat/AIPD :
+> `docs/rgpd-article10/dossier-avocat-aipd.md`.
+
+## Pull requests livrées
+
+| PR                      | Phase | Objet                                                                                                                                                                                                                            |
+| ----------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ironlam/poligraph#363   | 1     | Hotfix exposition : discover-affairs DRAFT-only (type-level), fuites par id / OpenGraph / affaires liées colmatées, filtres centralisés `public-filters.ts`, agrégats Tier 2 strict, liaison `AffairPoliticianDecision.affairId` |
+| ironlam/poligraph#365   | 2     | Barrière de publication : `assertPublishable` seul chemin vers PUBLISHED (5 voies admin), onglet « SAME à confirmer », script d'audit, garde-fou CI                                                                              |
+| ironlam/poligraph#366   | 2     | Fix UX : le refus du guard s'affiche au lieu de tomber sur l'error boundary                                                                                                                                                      |
+| ironlam/poligraph#367   | 3     | Encarts publics, issues favorables dominantes, prescription distincte                                                                                                                                                            |
+| ironlam/poligraph#369   | 3b    | Compteurs additifs par rôle + harmonisation PartyAffairsList                                                                                                                                                                     |
+| ironlam/poligraph#370   | 4     | Documentation : LEGAL.md §7, méthodologie publique, AGENTS.md                                                                                                                                                                    |
+| ironlam/poligraph-mcp#2 | 3     | Contrat MCP : affaires publiées uniquement, tests de contrat                                                                                                                                                                     |
+| ironlam/poligraph-mcp#3 | 3b    | Compteurs par rôle exposés et testés côté MCP                                                                                                                                                                                    |
+
+## Invariants garantis (et où ils vivent)
+
+1. **Aucune publication automatique** : pipelines en DRAFT only, `src/services/sync/discover-affairs-builders.ts` (type `publicationStatus: "DRAFT"`).
+2. **Publication = validation humaine prouvée** : `src/lib/affairs/publish-guard.ts` (`assertPublishable`, écrit `verifiedAt` + `verifiedBy` atomiquement). Garde-fou CI dans `.github/workflows/code-quality.yml`.
+3. **Pas de rattachement pénal sur score seul** : décision resolver SAME/UNDECIDED non revue bloque la publication ; revue via `/admin/affair-matching/review?tab=SAME`.
+4. **Agrégats cohérents** : `src/lib/affairs/public-filters.ts` (where-builders) + `src/lib/affairs/affair-counts.ts` (compteurs par rôle).
+5. **Issues favorables dominantes, prescription distincte** : `src/components/affairs/AffairStatusNotice.tsx`.
+6. **Mêmes règles web / API / exports / MCP** : surfaces consomment les filtres centralisés ; MCP consomme l'API publique durcie.
+
+## Vérification d'état (audit prod 2026-06-07)
+
+Script : `scripts/audit-affairs-compliance.ts` (lecture seule).
+
+| Indicateur                                        | Valeur | Cible                                      |
+| ------------------------------------------------- | ------ | ------------------------------------------ |
+| PUBLISHED sans `verifiedBy`                       | 0      | 0                                          |
+| Auto-publication Wikidata résiduelle              | 0      | 0                                          |
+| PUBLISHED sans source                             | 0      | 0                                          |
+| Issues favorables comptées à charge               | 0      | 0                                          |
+| Enquêtes préliminaires publiées (DIRECT/INDIRECT) | 64     | visibles sur fiche, hors agrégats à charge |
+| Décisions resolver orphelines vers PUBLISHED      | 50     | suivi éditorial, non bloquant              |
+
+Compteurs par rôle (exemples prod) :
+
+- Nicolas Sarkozy : total 10 = 5 à charge + 1 favorable + 2 mention + 1 victime/plaignant + 1 enquête préliminaire (dans aucun bucket, voulu).
+- Jordan Bardella : total 5 = 0 à charge + 2 favorables + 1 mention.
+
+## Suivis éditoriaux ouverts (hors chantier technique)
+
+- Réattribution de l'affaire « Renon » (mauvais rattachement Jean-Guy adjoint vs Jean Louis maire d'Ondres), actuellement en DRAFT.
+- Procès Rima Hassan (apologie du terrorisme) le 07/07/2026 : re-vérifier le statut après l'audience.
+- 50 décisions resolver orphelines à relier au fil de l'eau (liste dans `data/affairs-compliance-audit.json`).
+
+Le sujet technique est clos. Ne rouvrir que pour ces suivis éditoriaux ciblés ou
+sur retour de l'avocat (voir dossier avocat/AIPD).


### PR DESCRIPTION
Archive l'état final du chantier RGPD article 10 et prépare la revue juridique. Documentation uniquement, aucun code.

## Fichiers

- **docs/rgpd-article10/etat-final.md** : liste des PRs livrées (#363, #365, #366, #367, #369, #370 + MCP#2, #3), invariants garantis et où ils vivent dans le code, résultats d'audit prod, suivis éditoriaux ouverts.
- **docs/rgpd-article10/dossier-avocat-aipd.md** : dossier pour la revue avocat/AIPD — présentation du traitement, index des pièces, schéma des flux (pipeline → DRAFT → revue → PUBLISHED), exemples d'affichage par statut (condamnation définitive / non définitive / en cours / relaxe / prescription, avec URLs prod), résultats d'audit, droits des personnes, et les 6 questions à trancher par l'avocat.

Placés dans `docs/rgpd-article10/` (versionné) plutôt que `docs/superpowers/` (gitignoré) pour qu'ils accompagnent durablement le dépôt.

Aucun tiret cadratin, style factuel sans promesse de conformité.