### PR TITLE
perf(votes): restore ISR on scrutin detail (type tab client-side)

### DIFF
--- a/src/app/parlement/votes/[slug]/page.tsx
+++ b/src/app/parlement/votes/[slug]/page.tsx
@@ -52,17 +52,16 @@ function extractScrutinNumber(externalId: string): string | null {
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
-// NOTE: Do NOT add `generateStaticParams` here.
-// This page reads `searchParams.type` (date-archive branch) and downstream
-// calls `"use cache"` functions in `@/lib/data/scrutins`. Combining all three
-// (generateStaticParams + searchParams + "use cache") triggers
-// DYNAMIC_SERVER_USAGE on date-archive URLs like /parlement/votes/2026-04-08.
-// Rely on `revalidate = 3600` ISR alone, the same pattern used by the
-// sibling `parlement/votes/aujourd-hui/page.tsx`.
+// This route must NOT access `searchParams`: doing so opts the whole route into
+// dynamic rendering, which silently disables the ISR above and makes every
+// scrutin-detail request re-run the heavy votes query. The date-archive `type`
+// tab is therefore read client-side inside DailyVotesList (useSearchParams), so
+// /parlement/votes/YYYY-MM-DD?type=amendements still works while the route stays
+// ISR-cacheable. (Do not add `generateStaticParams` either — heavy detail pages
+// rely on ISR + on-demand revalidation, not build-time prerendering.)
 
 interface PageProps {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ type?: string }>;
 }
 
 /**
@@ -218,15 +217,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-export default async function ScrutinPage({ params, searchParams }: PageProps) {
+export default async function ScrutinPage({ params }: PageProps) {
   const { slug } = await params;
 
-  // Date archive page (e.g., /votes/2026-03-04)
+  // Date archive page (e.g., /votes/2026-03-04). The `type` tab is handled
+  // client-side in DailyVotesList, so this route never reads searchParams.
   if (DATE_REGEX.test(slug)) {
     const date = new Date(slug + "T00:00:00Z");
     if (!isNaN(date.getTime())) {
-      const { type: typeTab } = await searchParams;
-      return <DailyVotesPage date={slug} typeTab={typeTab} />;
+      return <DailyVotesPage date={slug} />;
     }
   }
 

--- a/src/app/parlement/votes/aujourd-hui/page.tsx
+++ b/src/app/parlement/votes/aujourd-hui/page.tsx
@@ -20,12 +20,8 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function AujourdhuiPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ type?: string }>;
-}) {
+export default async function AujourdhuiPage() {
   const today = getParisToday();
-  const { type: typeTab } = await searchParams;
-  return <DailyVotesPage date={today} isToday typeTab={typeTab} />;
+  // The `type` tab is read client-side in DailyVotesList, so this route stays ISR.
+  return <DailyVotesPage date={today} isToday />;
 }

--- a/src/components/votes/DailyVotesList.tsx
+++ b/src/components/votes/DailyVotesList.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+import { VoteCard } from "./VoteCard";
+import { ScrutinTypeTabs } from "./ScrutinTypeTabs";
+import { CHAMBER_LABELS } from "@/config/labels";
+import { Vote, CheckCircle, XCircle, Building2, Sparkles } from "lucide-react";
+import type { Chamber } from "@/generated/prisma";
+import type { DailyScrutin } from "@/lib/data/scrutins";
+
+interface DailyVotesListProps {
+  scrutins: DailyScrutin[];
+  canonicalPath: string;
+}
+
+/**
+ * Client-side type-tab filtering for the daily votes view. The server fetches
+ * ALL scrutins for the date (it never filtered server-side), so reading the
+ * `?type=` tab here via useSearchParams keeps the date-archive route static/ISR
+ * instead of forcing it dynamic. Must be rendered inside a Suspense boundary.
+ */
+export function DailyVotesList({ scrutins, canonicalPath }: DailyVotesListProps) {
+  const searchParams = useSearchParams();
+  const typeTab = searchParams.get("type") || "votes";
+
+  const { filtered, grouped, adopted, rejected, tabs, hasMultipleTypes } = useMemo(() => {
+    let amendementCount = 0;
+    let nonAmendementCount = 0;
+    for (const s of scrutins) {
+      if (s.type === "AMENDEMENT") amendementCount++;
+      else nonAmendementCount++;
+    }
+    const totalAll = scrutins.length;
+
+    let filtered = scrutins;
+    if (typeTab === "votes") {
+      filtered = scrutins.filter((s) => s.type !== "AMENDEMENT");
+    } else if (typeTab === "amendements") {
+      filtered = scrutins.filter((s) => s.type === "AMENDEMENT");
+    }
+
+    const grouped: Record<Chamber, DailyScrutin[]> = { AN: [], SENAT: [] };
+    let adopted = 0;
+    let rejected = 0;
+    for (const s of filtered) {
+      grouped[s.chamber].push(s);
+      if (s.result === "ADOPTED") adopted++;
+      else rejected++;
+    }
+
+    const buildTypeUrl = (tabKey: string) =>
+      tabKey === "votes" ? canonicalPath : `${canonicalPath}?type=${tabKey}`;
+
+    const tabs = [
+      {
+        key: "votes",
+        label: "Textes de loi",
+        count: nonAmendementCount,
+        href: buildTypeUrl("votes"),
+      },
+      {
+        key: "amendements",
+        label: "Amendements",
+        count: amendementCount,
+        href: buildTypeUrl("amendements"),
+      },
+      { key: "tous", label: "Tous", count: totalAll, href: buildTypeUrl("tous") },
+    ];
+
+    return {
+      filtered,
+      grouped,
+      adopted,
+      rejected,
+      tabs,
+      hasMultipleTypes: amendementCount > 0 && nonAmendementCount > 0,
+    };
+  }, [scrutins, typeTab, canonicalPath]);
+
+  return (
+    <>
+      {hasMultipleTypes && <ScrutinTypeTabs tabs={tabs} activeKey={typeTab} />}
+
+      <div className="flex flex-wrap gap-4 mb-8">
+        <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 rounded-lg">
+          <Vote className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <span className="text-sm font-medium">
+            {filtered.length} scrutin{filtered.length > 1 ? "s" : ""}
+          </span>
+        </div>
+        {adopted > 0 && (
+          <div className="flex items-center gap-2 px-4 py-2 bg-green-500/10 rounded-lg">
+            <CheckCircle className="h-4 w-4 text-green-600" aria-hidden="true" />
+            <span className="text-sm font-medium text-green-600 dark:text-green-400">
+              {adopted} adopté{adopted > 1 ? "s" : ""}
+            </span>
+          </div>
+        )}
+        {rejected > 0 && (
+          <div className="flex items-center gap-2 px-4 py-2 bg-red-500/10 rounded-lg">
+            <XCircle className="h-4 w-4 text-red-600" aria-hidden="true" />
+            <span className="text-sm font-medium text-red-600 dark:text-red-400">
+              {rejected} rejeté{rejected > 1 ? "s" : ""}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {(["AN", "SENAT"] as Chamber[]).map((chamber) => {
+        const votes = grouped[chamber];
+        if (votes.length === 0) return null;
+        return <ChamberSection key={chamber} chamber={chamber} scrutins={votes} />;
+      })}
+    </>
+  );
+}
+
+function ChamberSection({ chamber, scrutins }: { chamber: Chamber; scrutins: DailyScrutin[] }) {
+  return (
+    <section className="mb-10">
+      <div className="flex items-center gap-2.5 mb-4">
+        <Building2
+          className={`h-4 w-4 ${chamber === "AN" ? "text-blue-700" : "text-rose-700"}`}
+          aria-hidden="true"
+        />
+        <h2 className="text-lg font-semibold">{CHAMBER_LABELS[chamber]}</h2>
+        <span className="text-sm text-muted-foreground">
+          {scrutins.length} scrutin{scrutins.length > 1 ? "s" : ""}
+        </span>
+      </div>
+      <div className="grid gap-4">
+        {scrutins.map((s) => (
+          <div key={s.id}>
+            <VoteCard
+              id={s.id}
+              externalId={s.externalId}
+              slug={s.slug}
+              title={s.title}
+              votingDate={s.votingDate}
+              legislature={s.legislature}
+              chamber={s.chamber}
+              votesFor={s.votesFor}
+              votesAgainst={s.votesAgainst}
+              votesAbstain={s.votesAbstain}
+              result={s.result}
+              sourceUrl={s.sourceUrl}
+              theme={s.theme}
+              type={s.type}
+              policy={s.policyTitle}
+            />
+            {s.summary && <SummaryExcerpt summary={s.summary} />}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SummaryExcerpt({ summary }: { summary: string }) {
+  const firstParagraph = summary.split("\n\n")[0]?.trim();
+  if (!firstParagraph) return null;
+
+  return (
+    <div className="mt-2 ml-4 pl-3 border-l-2 border-primary/20 text-sm text-muted-foreground">
+      <div className="flex items-center gap-1.5 mb-1">
+        <Sparkles className="h-3 w-3 text-primary/50" aria-hidden="true" />
+        <span className="text-xs font-medium text-primary/50 uppercase tracking-wider">
+          Résumé IA
+        </span>
+      </div>
+      <p className="line-clamp-2">{firstParagraph}</p>
+    </div>
+  );
+}

--- a/src/components/votes/DailyVotesPage.tsx
+++ b/src/components/votes/DailyVotesPage.tsx
@@ -1,81 +1,30 @@
 import Link from "next/link";
-import { VoteCard } from "./VoteCard";
+import { Suspense } from "react";
 import { DateNavigation } from "./DateNavigation";
-import { ScrutinTypeTabs } from "./ScrutinTypeTabs";
+import { DailyVotesList } from "./DailyVotesList";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { getScrutinsByDate, getAdjacentVoteDates } from "@/lib/data/scrutins";
-import { CHAMBER_LABELS } from "@/config/labels";
 import { SITE_URL } from "@/config/site";
 import { formatDateFrUTC } from "@/lib/utils";
-import { Vote, CheckCircle, XCircle, Building2, ArrowRight, Sparkles } from "lucide-react";
-import type { Chamber } from "@/generated/prisma";
-import type { DailyScrutin } from "@/lib/data/scrutins";
+import { Vote, ArrowRight } from "lucide-react";
 
 interface DailyVotesPageProps {
   date: string;
   isToday?: boolean;
-  typeTab?: string;
 }
 
-export async function DailyVotesPage({ date, isToday, typeTab = "votes" }: DailyVotesPageProps) {
+// The `type` tab is read client-side in DailyVotesList (useSearchParams), NOT
+// here — accessing searchParams in this server component would opt the whole
+// route (and the scrutin-detail [slug] route that renders it) into dynamic
+// rendering, defeating ISR. The data fetch returns ALL scrutins regardless of
+// tab, so client-side filtering is lossless.
+export async function DailyVotesPage({ date, isToday }: DailyVotesPageProps) {
   const [data, adjacent] = await Promise.all([getScrutinsByDate(date), getAdjacentVoteDates(date)]);
 
   const formatted = formatDateFrUTC(date);
   const title = isToday ? "Votes du jour" : `Votes du ${formatted}`;
   const canonicalPath = isToday ? "/parlement/votes/aujourd-hui" : `/parlement/votes/${date}`;
-
-  // Compute type counts from loaded data
-  let amendementCount = 0;
-  let nonAmendementCount = 0;
-  for (const s of data.scrutins) {
-    if (s.type === "AMENDEMENT") amendementCount++;
-    else nonAmendementCount++;
-  }
-  const totalAll = data.scrutins.length;
-
-  // Filter scrutins by type tab
-  let filtered = data.scrutins;
-  if (typeTab === "votes") {
-    filtered = data.scrutins.filter((s) => s.type !== "AMENDEMENT");
-  } else if (typeTab === "amendements") {
-    filtered = data.scrutins.filter((s) => s.type === "AMENDEMENT");
-  }
-
-  // Regroup filtered scrutins by chamber
-  const grouped: Record<Chamber, DailyScrutin[]> = { AN: [], SENAT: [] };
-  let adopted = 0;
-  let rejected = 0;
-  for (const s of filtered) {
-    grouped[s.chamber].push(s);
-    if (s.result === "ADOPTED") adopted++;
-    else rejected++;
-  }
-
-  const buildTypeUrl = (tabKey: string) => {
-    const base = canonicalPath;
-    if (tabKey === "votes") return base;
-    return `${base}?type=${tabKey}`;
-  };
-
-  const tabs = [
-    {
-      key: "votes",
-      label: "Textes de loi",
-      count: nonAmendementCount,
-      href: buildTypeUrl("votes"),
-    },
-    {
-      key: "amendements",
-      label: "Amendements",
-      count: amendementCount,
-      href: buildTypeUrl("amendements"),
-    },
-    { key: "tous", label: "Tous", count: totalAll, href: buildTypeUrl("tous") },
-  ];
-
-  // Only show tabs if there are votes of multiple types
-  const hasMultipleTypes = amendementCount > 0 && nonAmendementCount > 0;
 
   return (
     <>
@@ -110,43 +59,9 @@ export async function DailyVotesPage({ date, isToday, typeTab = "votes" }: Daily
         </div>
 
         {data.total > 0 ? (
-          <>
-            {/* Type tabs */}
-            {hasMultipleTypes && <ScrutinTypeTabs tabs={tabs} activeKey={typeTab} />}
-
-            {/* Stats row */}
-            <div className="flex flex-wrap gap-4 mb-8">
-              <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 rounded-lg">
-                <Vote className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-                <span className="text-sm font-medium">
-                  {filtered.length} scrutin{filtered.length > 1 ? "s" : ""}
-                </span>
-              </div>
-              {adopted > 0 && (
-                <div className="flex items-center gap-2 px-4 py-2 bg-green-500/10 rounded-lg">
-                  <CheckCircle className="h-4 w-4 text-green-600" aria-hidden="true" />
-                  <span className="text-sm font-medium text-green-600 dark:text-green-400">
-                    {adopted} adopté{adopted > 1 ? "s" : ""}
-                  </span>
-                </div>
-              )}
-              {rejected > 0 && (
-                <div className="flex items-center gap-2 px-4 py-2 bg-red-500/10 rounded-lg">
-                  <XCircle className="h-4 w-4 text-red-600" aria-hidden="true" />
-                  <span className="text-sm font-medium text-red-600 dark:text-red-400">
-                    {rejected} rejeté{rejected > 1 ? "s" : ""}
-                  </span>
-                </div>
-              )}
-            </div>
-
-            {/* Chamber sections */}
-            {(["AN", "SENAT"] as Chamber[]).map((chamber) => {
-              const votes = grouped[chamber];
-              if (votes.length === 0) return null;
-              return <ChamberSection key={chamber} chamber={chamber} scrutins={votes} />;
-            })}
-          </>
+          <Suspense fallback={null}>
+            <DailyVotesList scrutins={data.scrutins} canonicalPath={canonicalPath} />
+          </Suspense>
         ) : (
           <EmptyState prevDate={adjacent.prevDate} />
         )}
@@ -158,64 +73,6 @@ export async function DailyVotesPage({ date, isToday, typeTab = "votes" }: Daily
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function ChamberSection({ chamber, scrutins }: { chamber: Chamber; scrutins: DailyScrutin[] }) {
-  return (
-    <section className="mb-10">
-      <div className="flex items-center gap-2.5 mb-4">
-        <Building2
-          className={`h-4 w-4 ${chamber === "AN" ? "text-blue-700" : "text-rose-700"}`}
-          aria-hidden="true"
-        />
-        <h2 className="text-lg font-semibold">{CHAMBER_LABELS[chamber]}</h2>
-        <span className="text-sm text-muted-foreground">
-          {scrutins.length} scrutin{scrutins.length > 1 ? "s" : ""}
-        </span>
-      </div>
-      <div className="grid gap-4">
-        {scrutins.map((s) => (
-          <div key={s.id}>
-            <VoteCard
-              id={s.id}
-              externalId={s.externalId}
-              slug={s.slug}
-              title={s.title}
-              votingDate={s.votingDate}
-              legislature={s.legislature}
-              chamber={s.chamber}
-              votesFor={s.votesFor}
-              votesAgainst={s.votesAgainst}
-              votesAbstain={s.votesAbstain}
-              result={s.result}
-              sourceUrl={s.sourceUrl}
-              theme={s.theme}
-              type={s.type}
-              policy={s.policyTitle}
-            />
-            {s.summary && <SummaryExcerpt summary={s.summary} />}
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function SummaryExcerpt({ summary }: { summary: string }) {
-  const firstParagraph = summary.split("\n\n")[0]?.trim();
-  if (!firstParagraph) return null;
-
-  return (
-    <div className="mt-2 ml-4 pl-3 border-l-2 border-primary/20 text-sm text-muted-foreground">
-      <div className="flex items-center gap-1.5 mb-1">
-        <Sparkles className="h-3 w-3 text-primary/50" aria-hidden="true" />
-        <span className="text-xs font-medium text-primary/50 uppercase tracking-wider">
-          Résumé IA
-        </span>
-      </div>
-      <p className="line-clamp-2">{firstParagraph}</p>
-    </div>
-  );
-}
 
 function EmptyState({ prevDate }: { prevDate: string | null }) {
   return (


### PR DESCRIPTION
## Problème
La page détail scrutin était servie en **dynamique** (`cache-control: private, no-store`, `x-vercel-cache: MISS` permanent) malgré `revalidate = 3600`. Cause : `[slug]/page.tsx` lisait `searchParams.type` (onglet de l'archive-par-date), ce qui bascule toute la route en rendu dynamique et désactive l'ISR. Chaque visite ré-exécutait la grosse requête `getScrutinWithRedirect` (~577 votes + arbre politicien/parti/mandat/groupe).

## Correctif
`DailyVotesPage` fetch déjà tous les scrutins du jour (le filtre `type` est purement en mémoire). On déplace ce filtre dans un composant client `DailyVotesList` (`useSearchParams`, dans une `Suspense`). La route détail ne touche plus `searchParams` et redevient ISR.

- URLs inchangées. `/parlement/votes/YYYY-MM-DD` et `?type=amendements` marchent toujours (onglet géré côté client).
- `aujourd-hui/page.tsx` ne lit plus `searchParams` non plus.
- Commentaire obsolète (qui justifiait l'absence de generateStaticParams par searchParams) réécrit.

## Vérifs
- `tsc` : 0 erreur source ; `next build` : compilé ; suite complète : 1489 tests passés.
- À vérifier après déploiement : headers de la page détail (avant `private, no-store` / MISS → après `public` / HIT), et les archives `/parlement/votes/2026-05-30(?type=amendements)` + `/parlement/votes/aujourd-hui?type=amendements`.