### PR TITLE
perf(politicians): cache per-politician vote stats + tab counts

### DIFF
--- a/src/app/politiques/[slug]/votes/page.tsx
+++ b/src/app/politiques/[slug]/votes/page.tsx
@@ -14,7 +14,7 @@ import { formatDate } from "@/lib/utils";
 import { ArrowLeft, ExternalLink, Info } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { feminizeRole, SCRUTIN_TYPE_LABELS, SCRUTIN_TYPE_COLORS } from "@/config/labels";
-import { getPoliticianVotingStats } from "@/services/voteStats";
+import { getPoliticianVotingStats, getPoliticianVoteTabCounts } from "@/services/voteStats";
 import type { ScrutinType } from "@/generated/prisma";
 import type { Prisma } from "@/generated/prisma";
 
@@ -78,7 +78,12 @@ async function getVotes(
     ...(hasScrutinFilter && { scrutin: scrutinWhere }),
   };
 
-  const [votes, total, stats, totalAll, amendmentCount] = await Promise.all([
+  // The per-page list is the only query that varies by page/tab, so it stays live.
+  // Counts + stats are per-politician (identical across pages/tabs) and come from
+  // cached helpers, so navigating pages/tabs no longer re-counts (those counts +
+  // the stats groupBy were the dominant DB cost). The active tab's `total` is
+  // derived from the cached counts instead of a fresh count query.
+  const [votes, stats, counts] = await Promise.all([
     db.vote.findMany({
       where,
       include: {
@@ -101,11 +106,17 @@ async function getVotes(
       skip,
       take: limit,
     }),
-    db.vote.count({ where }),
     getPoliticianVotingStats(politicianId),
-    db.vote.count({ where: { politicianId } }),
-    db.vote.count({ where: { politicianId, scrutin: { type: "AMENDEMENT" } } }),
+    getPoliticianVoteTabCounts(politicianId),
   ]);
+
+  const { totalAll, amendmentCount, nonAmendmentCount } = counts;
+  const total =
+    typeFilter.type === "AMENDEMENT"
+      ? amendmentCount
+      : typeFilter.excludeType === "AMENDEMENT"
+        ? nonAmendmentCount
+        : totalAll;
 
   return {
     votes,
@@ -114,7 +125,7 @@ async function getVotes(
     stats,
     totalAll,
     amendmentCount,
-    nonAmendmentCount: totalAll - amendmentCount,
+    nonAmendmentCount,
   };
 }
 

--- a/src/services/voteStats.ts
+++ b/src/services/voteStats.ts
@@ -1,3 +1,4 @@
+import { cacheTag, cacheLife } from "next/cache";
 import { db } from "@/lib/db";
 import { Chamber, MandateType, Prisma } from "@/generated/prisma";
 import type { ThemeCategory } from "@/generated/prisma";
@@ -350,6 +351,14 @@ export async function getPoliticianVotingStats(
   politicianId: string,
   mandateType?: MandateType
 ): Promise<PoliticianVotingStats> {
+  "use cache";
+  // Per-politician aggregate, identical across page/tab navigations — cache it so
+  // it is computed once per politician per window instead of on every page view
+  // (this groupBy was ~15% of total DB time). Invalidated by the votes/politicians
+  // cache tags after a sync.
+  cacheTag("votes", "politicians");
+  cacheLife("minutes");
+
   // Find current parliamentary mandate first — we need it to scope vote counts
   const mandate = await db.mandate.findFirst({
     where: {
@@ -438,6 +447,30 @@ export async function getPoliticianVotingStats(
   }
 
   return votingStats;
+}
+
+/**
+ * Per-politician vote tab counts (total + amendments), identical across pages of
+ * the votes view. Cached so the votes page derives every tab's count from one
+ * cached call instead of re-counting (with a Scrutin join for amendments) on
+ * every page/tab navigation. Invalidated by the votes/politicians cache tags.
+ */
+export async function getPoliticianVoteTabCounts(
+  politicianId: string
+): Promise<{ totalAll: number; amendmentCount: number; nonAmendmentCount: number }> {
+  "use cache";
+  cacheTag("votes", "politicians");
+  cacheLife("minutes");
+
+  // nonAmendmentCount uses the same `{ not: "AMENDEMENT" }` filter as the list
+  // query (so it matches the "Textes de loi" tab exactly even if a scrutin's type
+  // is null — `not` excludes nulls), rather than deriving it by subtraction.
+  const [totalAll, amendmentCount, nonAmendmentCount] = await Promise.all([
+    db.vote.count({ where: { politicianId } }),
+    db.vote.count({ where: { politicianId, scrutin: { type: "AMENDEMENT" } } }),
+    db.vote.count({ where: { politicianId, scrutin: { type: { not: "AMENDEMENT" } } } }),
+  ]);
+  return { totalAll, amendmentCount, nonAmendmentCount };
 }
 
 // ============================================


### PR DESCRIPTION
## Problème (Supabase query stats)
Les requêtes des pages politiciens dominent le temps DB cumulé : le groupBy de positions (`getPoliticianVotingStats`, ~15%) et les comptes d'onglets (total / amendements / hors-amendements, avec leurs JOINs Scrutin, rows 33/37/111 ≈ 30%) sont recalculés à **chaque** navigation de page/onglet et sur la fiche profil. Ces agrégats ne dépendent que du politicien, pas de la page.

## Correctif
- `getPoliticianVotingStats` passe en `"use cache"` (tags `votes`/`politicians`, cacheLife minutes) — calculé une fois par politicien par fenêtre, plus à chaque vue.
- Nouvelle `getPoliticianVoteTabCounts` (cachée) renvoie {totalAll, amendmentCount, nonAmendmentCount}. La page dérive le total de l'onglet actif depuis ces comptes au lieu d'une requête `count` fraîche.
- La liste paginée (qui varie par page/onglet) reste live.
- nonAmendmentCount utilise le même filtre `{ not: AMENDEMENT }` que la liste (correct même si un scrutin a un type null), pas une soustraction.

Invalidation : mêmes tags que la fiche profil existante, donc couverts par la revalidation post-sync.

## Vérifs
`tsc` 0 erreur source, `next build` compilé (route handler `/api/politiques/[slug]/votes` qui appelle la fonction cachée inclus), suite complète 1489 tests passés.