### PR TITLE
perf(municipales): requête parité une-passe + index couvrant (40s -> 2s)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1762,7 +1762,10 @@ model Candidacy {
   @@index([electionId, communeId])
   @@index([electionId, listName])
   @@index([electionId, partyLabel])
-  @@index([electionId, candidateId])
+  // Covering index for parity-outliers aggregation (index-only scan, no heap fetch).
+  // Created in prod via CREATE INDEX CONCURRENTLY; declared here so db:push keeps it.
+  // Superset of the former [electionId, candidateId] index (dropped as redundant).
+  @@index([electionId, candidateId, communeId, listName])
   @@index([politicianId])
   @@index([constituencyCode])
   @@index([candidateId])

--- a/src/__tests__/lib/data/municipales-snapshots.test.ts
+++ b/src/__tests__/lib/data/municipales-snapshots.test.ts
@@ -72,33 +72,33 @@ describe("municipales snapshot fallback", () => {
 
   it("getParityOutliers falls back to live SQL when snapshot is missing", async () => {
     findUniqueMock.mockResolvedValueOnce(null);
-    queryRawMock
-      .mockResolvedValueOnce([
-        {
-          listName: "Live A",
-          communeId: "x",
-          communeName: "X",
-          departmentCode: "01",
-          femaleRate: 0.5,
-          candidateCount: 30,
-        },
-      ])
-      .mockResolvedValueOnce([
-        {
-          listName: "Live B",
-          communeId: "y",
-          communeName: "Y",
-          departmentCode: "02",
-          femaleRate: 0.0,
-          candidateCount: 30,
-        },
-      ]);
+    // Single-pass query: one $queryRaw returns both buckets, tagged by `bucket`.
+    queryRawMock.mockResolvedValueOnce([
+      {
+        bucket: "best",
+        listName: "Live A",
+        communeId: "x",
+        communeName: "X",
+        departmentCode: "01",
+        femaleRate: 0.5,
+        candidateCount: 30,
+      },
+      {
+        bucket: "worst",
+        listName: "Live B",
+        communeId: "y",
+        communeName: "Y",
+        departmentCode: "02",
+        femaleRate: 0.0,
+        candidateCount: 30,
+      },
+    ]);
 
     const result = await getParityOutliers();
 
     expect(result.best[0]?.listName).toBe("Live A");
     expect(result.worst[0]?.listName).toBe("Live B");
-    expect(queryRawMock).toHaveBeenCalledTimes(2); // fell back to live
+    expect(queryRawMock).toHaveBeenCalledTimes(1); // single-pass live fallback
   });
 
   it("getParityBySize falls back to live when snapshot missing", async () => {

--- a/src/services/sync/candidatures.ts
+++ b/src/services/sync/candidatures.ts
@@ -573,7 +573,7 @@ export async function syncCandidaturesMunicipales(
   if (!dryRun && (candidaciesCreated > 0 || candidaciesUpdated > 0)) {
     try {
       console.log(`\nRunning VACUUM (ANALYZE) on "Candidacy"...`);
-      await db.$executeRawUnsafe(`VACUUM (ANALYZE) "Candidacy"`);
+      await db.$executeRaw(Prisma.sql`VACUUM (ANALYZE) "Candidacy"`);
       console.log(`  VACUUM ANALYZE done`);
     } catch (error) {
       console.warn(`  VACUUM ANALYZE skipped: ${error}`);

--- a/src/services/sync/candidatures.ts
+++ b/src/services/sync/candidatures.ts
@@ -566,6 +566,20 @@ export async function syncCandidaturesMunicipales(
     console.log(`\nElection status updated to CANDIDACIES`);
   }
 
+  // ─── Maintenance : VACUUM ANALYZE après l'import massif ──────────────
+  // Met à jour la visibility map (sinon les index-only scans, ex. parité,
+  // retombent sur le heap) et les stats du planner. Non bloquant : une
+  // erreur de maintenance ne doit pas faire échouer le sync.
+  if (!dryRun && (candidaciesCreated > 0 || candidaciesUpdated > 0)) {
+    try {
+      console.log(`\nRunning VACUUM (ANALYZE) on "Candidacy"...`);
+      await db.$executeRawUnsafe(`VACUUM (ANALYZE) "Candidacy"`);
+      console.log(`  VACUUM ANALYZE done`);
+    } catch (error) {
+      console.warn(`  VACUUM ANALYZE skipped: ${error}`);
+    }
+  }
+
   console.log(`\nResults:`);
   console.log(`  Candidacies created: ${candidaciesCreated}`);
   console.log(`  Candidacies updated: ${candidaciesUpdated}`);

--- a/src/services/sync/compute-municipales-snapshots.ts
+++ b/src/services/sync/compute-municipales-snapshots.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import {
   MUNICIPALES_SNAPSHOT_KEYS,
   type ParityOutliers,
+  type ParityListRow,
   type ParityBySize,
   type DeptPartyData,
 } from "@/types/stats-snapshots";
@@ -77,8 +78,13 @@ async function runAndUpsert<T>(
 // ─── Live computers (also exported for fallback in src/lib/data/municipales.ts) ──
 
 export async function computeParityOutliersLive(electionId: string): Promise<ParityOutliers> {
-  const best = await db.$queryRaw<
+  // Une seule passe d'agrégation (CTE `agg`, référencée deux fois → matérialisée
+  // une seule fois par Postgres) au lieu de deux scans complets. La jointure
+  // `Commune` (nom + département) est différée aux 20 lignes finales seulement,
+  // ce qui la sort du hot path. Voir EXPLAIN dans la PR pour les gains.
+  const rows = await db.$queryRaw<
     Array<{
+      bucket: "best" | "worst";
       listName: string;
       communeId: string;
       communeName: string;
@@ -87,40 +93,60 @@ export async function computeParityOutliersLive(electionId: string): Promise<Par
       candidateCount: number;
     }>
   >(Prisma.sql`
+    WITH agg AS (
+      SELECT
+        c."listName" AS list_name,
+        c."communeId" AS commune_id,
+        COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0) AS female_rate,
+        COUNT(*)::int AS candidate_count
+      FROM "Candidacy" c
+      JOIN "Candidate" ca ON c."candidateId" = ca.id
+      WHERE c."electionId" = ${electionId}
+        AND ca."gender" IS NOT NULL
+        AND c."listName" IS NOT NULL
+        AND c."communeId" IS NOT NULL
+      GROUP BY c."listName", c."communeId"
+      HAVING COUNT(*) >= 10
+    ),
+    best AS (
+      SELECT list_name, commune_id, female_rate, candidate_count, 'best'::text AS bucket
+      FROM agg ORDER BY ABS(0.5 - female_rate) ASC LIMIT 10
+    ),
+    worst AS (
+      SELECT list_name, commune_id, female_rate, candidate_count, 'worst'::text AS bucket
+      FROM agg ORDER BY ABS(0.5 - female_rate) DESC LIMIT 10
+    )
     SELECT
-      c."listName",
-      co.id as "communeId",
-      co.name as "communeName",
-      co."departmentCode",
-      COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0) as "femaleRate",
-      COUNT(*)::int as "candidateCount"
-    FROM "Candidacy" c
-    JOIN "Commune" co ON c."communeId" = co.id
-    JOIN "Candidate" ca ON c."candidateId" = ca.id
-    WHERE c."electionId" = ${electionId} AND ca."gender" IS NOT NULL AND c."listName" IS NOT NULL
-    GROUP BY c."listName", co.id, co.name, co."departmentCode"
-    HAVING COUNT(*) >= 10
-    ORDER BY ABS(0.5 - COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0)) ASC
-    LIMIT 10
+      picked.bucket,
+      picked.list_name AS "listName",
+      co.id AS "communeId",
+      co.name AS "communeName",
+      co."departmentCode" AS "departmentCode",
+      picked.female_rate AS "femaleRate",
+      picked.candidate_count AS "candidateCount"
+    FROM (SELECT * FROM best UNION ALL SELECT * FROM worst) picked
+    JOIN "Commune" co ON picked.commune_id = co.id
+    ORDER BY
+      picked.bucket,
+      (CASE WHEN picked.bucket = 'best'
+            THEN ABS(0.5 - picked.female_rate)
+            ELSE -ABS(0.5 - picked.female_rate) END) ASC
   `);
 
-  const worst = await db.$queryRaw<typeof best>(Prisma.sql`
-    SELECT
-      c."listName",
-      co.id as "communeId",
-      co.name as "communeName",
-      co."departmentCode",
-      COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0) as "femaleRate",
-      COUNT(*)::int as "candidateCount"
-    FROM "Candidacy" c
-    JOIN "Commune" co ON c."communeId" = co.id
-    JOIN "Candidate" ca ON c."candidateId" = ca.id
-    WHERE c."electionId" = ${electionId} AND ca."gender" IS NOT NULL AND c."listName" IS NOT NULL
-    GROUP BY c."listName", co.id, co.name, co."departmentCode"
-    HAVING COUNT(*) >= 10
-    ORDER BY ABS(0.5 - COUNT(*) FILTER (WHERE ca."gender" = 'F')::float / NULLIF(COUNT(*)::float, 0)) DESC
-    LIMIT 10
-  `);
+  const best: ParityListRow[] = [];
+  const worst: ParityListRow[] = [];
+  for (const r of rows) {
+    const row: ParityListRow = {
+      listName: r.listName,
+      communeId: r.communeId,
+      communeName: r.communeName,
+      departmentCode: r.departmentCode,
+      femaleRate: r.femaleRate,
+      candidateCount: r.candidateCount,
+    };
+    if (r.bucket === "best") best.push(row);
+    else worst.push(row);
+  }
 
   return { best, worst };
 }


### PR DESCRIPTION
## Contexte

La requête des outliers de parité (`computeParityOutliersLive`) tournait en ~40 s (2 appels de ~20 s, `best` + `worst`) sur les 888K candidatures municipales 2026. Coût payé par le cron quotidien `compute-municipales-snapshots`, et exposition d'un visiteur à ~20 s si le snapshot venait à manquer.

Diagnostic via `EXPLAIN ANALYZE` : 15 s passées à scanner `Candidacy`. Le genre vivant sur `Candidate`, Postgres joignait les 888K lignes à `Candidate`, et l'index `(electionId, candidateId)` ne couvrant pas `listName`/`communeId`, chaque ligne déclenchait un heap fetch dispersé.

## Changements

1. **Une seule passe** : CTE `agg` (référencé deux fois donc matérialisé une fois), `best`/`worst` extraits par `UNION ALL`. Plus de double agrégation.
2. **Jointure `Commune` différée** : on agrège par `listName` + `communeId`, puis on joint `Commune` (nom, département) sur les 20 lignes finales seulement.
3. **Index couvrant** `(electionId, candidateId, communeId, listName)` : active un `Index Only Scan` (zéro heap fetch). Créé en prod via `CREATE INDEX CONCURRENTLY`, déclaré au schéma pour que `db:push` le conserve. L'ancien `(electionId, candidateId)`, devenu préfixe redondant, est supprimé.
4. **VACUUM ANALYZE** sur `Candidacy` en fin d'import municipales : maintient la visibility map (sans quoi l'index-only scan retombe sur le heap) et les stats du planner.

## Mesures (prod, `EXPLAIN ANALYZE`)

| Étape | Temps | Scan Candidacy | Heap fetches |
|-------|------:|---------------:|-------------:|
| Avant (2 requêtes) | ~40 s | 15 s | heap scatter |
| Une passe + Commune différée | ~17,5 s | 16 s | idem |
| + index couvrant | 9,9 s | 8,6 s | 1 183 600 |
| + VACUUM | **2,0 s** | **589 ms** | **0** |

Bout en bout via le code : 2,4 s à froid, 32 ms à chaud. Sortie identique (best/worst = 10/10, mêmes champs, même ordre).

## Notes

- DDL prod (création/suppression d'index, VACUUM) déjà appliqué en direct via `CONCURRENTLY`. Le schéma committé reflète l'état réel de la base, pas de drift.
- Le fallback live de `getParityOutliers` reste en place : protégé par snapshot-first + `"use cache"` / `cacheLife("hours")`, et désormais à ~2,4 s au pire au lieu de 40 s.

## Tests

- `municipales-snapshots.test.ts` mis à jour (fallback = 1 appel `$queryRaw`), 6/6 verts.
- Typecheck `src/` : 0 erreur.
