### PR TITLE
perf+fix(stats): index couvrant dissidence + majorité de groupe sur la bonne population de votes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -945,7 +945,10 @@ model Vote {
   chamber    Chamber
 
   @@unique([scrutinId, politicianId])
-  @@index([politicianId, position])
+  // Covering index for the dissidence aggregations (compute-stats.ts): index-only
+  // scan over a politician's votes, no heap fetch. Created in prod via CREATE INDEX
+  // CONCURRENTLY. Superset of the former [politicianId, position] index (dropped).
+  @@index([politicianId, position, votingDate, scrutinId])
   @@index([politicianId, votingDate(sort: Desc)], map: "Vote_politicianId_votingDate_idx")
   @@index([politicianId, chamber, votingDate(sort: Desc)], map: "Vote_politicianId_chamber_votingDate_idx")
 }

--- a/src/services/sync/__tests__/dissidence.test.ts
+++ b/src/services/sync/__tests__/dissidence.test.ts
@@ -9,10 +9,10 @@ import {
 } from "../dissidence";
 
 describe("CURRENT_GROUP_VOTES_FROM (shared dissidence scan)", () => {
-  // Régression : la majorité de groupe et les votes individuels DOIVENT venir de
-  // la même population. Le filtre de date du mandat doit rester dans le fragment
-  // partagé, sinon la majorité est calculée sur des votes hors mandat (bug passé :
-  // 333 majorités basculées, ~140 politiciens jugés contre une majorité fausse).
+  // Regression: the group majority and the individual votes MUST come from the
+  // same population. The mandate date filter has to stay in the shared fragment,
+  // otherwise the majority is computed on out-of-mandate votes (past bug: 333
+  // majorities flipped, ~140 politicians judged against a wrong majority).
   const sql = CURRENT_GROUP_VOTES_FROM.sql;
 
   it("filters votes to the current mandate date range", () => {

--- a/src/services/sync/__tests__/dissidence.test.ts
+++ b/src/services/sync/__tests__/dissidence.test.ts
@@ -3,9 +3,29 @@ import {
   findGroupMajority,
   computePoliticianDissidence,
   aggregateDissidenceByGroup,
+  CURRENT_GROUP_VOTES_FROM,
   type GroupVoteEntry,
   type PoliticianVoteWithGroup,
 } from "../dissidence";
+
+describe("CURRENT_GROUP_VOTES_FROM (shared dissidence scan)", () => {
+  // Régression : la majorité de groupe et les votes individuels DOIVENT venir de
+  // la même population. Le filtre de date du mandat doit rester dans le fragment
+  // partagé, sinon la majorité est calculée sur des votes hors mandat (bug passé :
+  // 333 majorités basculées, ~140 politiciens jugés contre une majorité fausse).
+  const sql = CURRENT_GROUP_VOTES_FROM.sql;
+
+  it("filters votes to the current mandate date range", () => {
+    expect(sql).toContain('v."votingDate" >= m."startDate"');
+    expect(sql).toContain('m."endDate" IS NULL OR v."votingDate" <= m."endDate"');
+  });
+
+  it("scopes to current DEPUTE/SENATEUR mandates and real positions", () => {
+    expect(sql).toContain('m."isCurrent" = true');
+    expect(sql).toContain("'DEPUTE'::\"MandateType\", 'SENATEUR'::\"MandateType\"");
+    expect(sql).toContain("v.position IN ('POUR', 'CONTRE', 'ABSTENTION')");
+  });
+});
 
 describe("findGroupMajority", () => {
   it("returns the position with most votes per scrutin+group", () => {

--- a/src/services/sync/compute-stats.ts
+++ b/src/services/sync/compute-stats.ts
@@ -24,6 +24,7 @@ import {
   findGroupMajority,
   computePoliticianDissidence,
   aggregateDissidenceByGroup,
+  CURRENT_GROUP_VOTES_FROM,
   type GroupVoteEntry,
   type PoliticianVoteWithGroup,
 } from "./dissidence";
@@ -213,18 +214,22 @@ async function computePoliticianParticipation(verbose = false): Promise<Politici
 async function computeDissidenceData(verbose = false): Promise<Map<string, DissidenceRow>> {
   if (verbose) console.log("  Computing dissidence rates...");
 
+  // Rafraîchit la visibility map de "Vote" pour que les deux agrégations
+  // ci-dessous restent en Index Only Scan (sinon elles retombent sur le heap,
+  // ~1,5M fetches). Non bloquant : un échec de maintenance ne doit pas tuer le calcul.
+  try {
+    await db.$executeRaw(Prisma.sql`VACUUM (ANALYZE) "Vote"`);
+  } catch (error) {
+    if (verbose) console.warn(`  VACUUM "Vote" skipped: ${error}`);
+  }
+
   const groupVoteCounts = await db.$queryRaw<GroupVoteEntry[]>`
     SELECT
       v."scrutinId" as "scrutinId",
       mp."parliamentaryGroupId" as "groupId",
       v.position,
       COUNT(*)::int as count
-    FROM "Vote" v
-    JOIN "Mandate" m ON m."politicianId" = v."politicianId"
-      AND m."isCurrent" = true
-      AND m.type IN ('DEPUTE'::"MandateType", 'SENATEUR'::"MandateType")
-    JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
-    WHERE v.position IN ('POUR', 'CONTRE', 'ABSTENTION')
+    ${CURRENT_GROUP_VOTES_FROM}
     GROUP BY v."scrutinId", mp."parliamentaryGroupId", v.position
   `;
 
@@ -237,14 +242,7 @@ async function computeDissidenceData(verbose = false): Promise<Map<string, Dissi
       v."scrutinId" as "scrutinId",
       mp."parliamentaryGroupId" as "groupId",
       v.position
-    FROM "Vote" v
-    JOIN "Mandate" m ON m."politicianId" = v."politicianId"
-      AND m."isCurrent" = true
-      AND m.type IN ('DEPUTE'::"MandateType", 'SENATEUR'::"MandateType")
-    JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
-    WHERE v.position IN ('POUR', 'CONTRE', 'ABSTENTION')
-      AND v."votingDate" >= m."startDate"
-      AND (m."endDate" IS NULL OR v."votingDate" <= m."endDate")
+    ${CURRENT_GROUP_VOTES_FROM}
   `;
 
   const dissidenceMap = computePoliticianDissidence(politicianVotes, groupMajority);

--- a/src/services/sync/compute-stats.ts
+++ b/src/services/sync/compute-stats.ts
@@ -214,9 +214,9 @@ async function computePoliticianParticipation(verbose = false): Promise<Politici
 async function computeDissidenceData(verbose = false): Promise<Map<string, DissidenceRow>> {
   if (verbose) console.log("  Computing dissidence rates...");
 
-  // Rafraîchit la visibility map de "Vote" pour que les deux agrégations
-  // ci-dessous restent en Index Only Scan (sinon elles retombent sur le heap,
-  // ~1,5M fetches). Non bloquant : un échec de maintenance ne doit pas tuer le calcul.
+  // Refresh "Vote"'s visibility map so the two aggregations below stay on an
+  // Index Only Scan (otherwise they fall back to the heap, ~1.5M fetches).
+  // Non-blocking: a maintenance failure must not kill the stats computation.
   try {
     await db.$executeRaw(Prisma.sql`VACUUM (ANALYZE) "Vote"`);
   } catch (error) {

--- a/src/services/sync/dissidence.ts
+++ b/src/services/sync/dissidence.ts
@@ -1,3 +1,24 @@
+import { Prisma } from "@/generated/prisma";
+
+/**
+ * FROM/JOIN/WHERE partagé par les DEUX scans de la dissidence (compute-stats.ts) :
+ * l'agrégation de la majorité de groupe ET le scan des votes par politicien.
+ * Les deux DOIVENT opérer sur la même population de votes. Bug passé : la requête
+ * de majorité n'avait pas le filtre de date du mandat, donc des votes émis hors
+ * mandat polluaient la majorité (333 majorités (scrutin, groupe) basculaient,
+ * ~140 politiciens jugés contre une majorité fausse). Une seule source de vérité.
+ */
+export const CURRENT_GROUP_VOTES_FROM = Prisma.sql`
+  FROM "Vote" v
+  JOIN "Mandate" m ON m."politicianId" = v."politicianId"
+    AND m."isCurrent" = true
+    AND m.type IN ('DEPUTE'::"MandateType", 'SENATEUR'::"MandateType")
+  JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
+  WHERE v.position IN ('POUR', 'CONTRE', 'ABSTENTION')
+    AND v."votingDate" >= m."startDate"
+    AND (m."endDate" IS NULL OR v."votingDate" <= m."endDate")
+`;
+
 export interface GroupVoteEntry {
   scrutinId: string;
   groupId: string;

--- a/src/services/sync/dissidence.ts
+++ b/src/services/sync/dissidence.ts
@@ -1,12 +1,11 @@
 import { Prisma } from "@/generated/prisma";
 
 /**
- * FROM/JOIN/WHERE partagé par les DEUX scans de la dissidence (compute-stats.ts) :
- * l'agrégation de la majorité de groupe ET le scan des votes par politicien.
- * Les deux DOIVENT opérer sur la même population de votes. Bug passé : la requête
- * de majorité n'avait pas le filtre de date du mandat, donc des votes émis hors
- * mandat polluaient la majorité (333 majorités (scrutin, groupe) basculaient,
- * ~140 politiciens jugés contre une majorité fausse). Une seule source de vérité.
+ * Shared FROM/JOIN/WHERE for BOTH dissidence scans (compute-stats.ts): the group
+ * majority aggregation AND the per-politician vote scan. Both MUST run on the same
+ * vote population. Past bug: the majority query lacked the mandate date filter, so
+ * out-of-mandate votes polluted the majority (333 (scrutin, group) majorities
+ * flipped, ~140 politicians judged against a wrong majority). Single source of truth.
  */
 export const CURRENT_GROUP_VOTES_FROM = Prisma.sql`
   FROM "Vote" v


### PR DESCRIPTION
## Contexte

Deux requêtes du pipeline `sync:compute-stats` (`computeDissidenceData`) ressortaient dans pg_stat_statements : agrégat votes × groupe × position, ~11 s de moyenne, 1,16M lignes traitées par appel.

`EXPLAIN ANALYZE` : pour chacun des 923 mandats courants (députés/sénateurs), un index scan sur `Vote_politicianId_position_idx` = `(politicianId, position)` lisait les votes, mais le `GROUP BY` réclamait `scrutinId` absent de l'index, d'où ~1,5M heap fetches.

## Performance

Index couvrant `Vote(politicianId, position, votingDate, scrutinId)` : `Index Only Scan`, plus de heap fetch. Un seul index sert les deux scans de `computeDissidenceData` et remplace le `(politicianId, position)` redondant (droppé). `VACUUM (ANALYZE) "Vote"` au début du calcul pour garder la visibility map fraîche.

Server-side, mesuré en prod :

| Requête | Avant | Après |
|---------|------:|------:|
| group-majority counts | 14,9 s | 1,3 s |
| per-politician votes | 4,6 s | 0,46 s |

## Correctness (le vrai sujet)

En instrumentant, j'ai trouvé une asymétrie : la requête de **majorité de groupe** joignait sur le mandat courant **sans filtre de date**, alors que la requête des **votes individuels** filtrait `votingDate` dans la fenêtre du mandat. Conséquence : un élu était jugé contre une majorité calculée sur une population de votes différente de la sienne, polluée par des votes émis hors mandat.

Mesuré sur la prod :
- 37 806 majorités fantômes (vieux scrutins) calculées pour rien.
- **333** majorités `(scrutin, groupe)` consultées dont la position bascule selon le filtre.
- **140 élus sur 898** (~16 %), sur 7 groupes, jugés contre une majorité fausse.

Correctif : extraction du `FROM/JOIN/WHERE` commun dans un fragment `Prisma.sql` unique (`CURRENT_GROUP_VOTES_FROM`) utilisé par les deux requêtes. La divergence devient impossible par construction. Test de régression qui verrouille la présence du filtre de date dans le fragment.

## Impact données

Les taux de dissidence affichés vont bouger pour ~140 élus au prochain `sync:compute-stats` (ampleur par élu faible mais non nulle). Recalcul à déclencher après merge.

## Notes

- DDL prod (création/drop d'index, VACUUM) déjà appliqué via `CONCURRENTLY`. Schéma committé aligné, pas de drift.
- VACUUM via `$executeRaw(Prisma.sql...)` (le CI interdit `$executeRawUnsafe`).

## Tests

- `dissidence.test.ts` : +2 tests de régression sur le fragment partagé, 8/8 verts.
- Typecheck `src/` : 0 erreur.
