### PR TITLE
Refonte de la page d'accueil en point d'entrée citoyen

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,14 @@
 import { Metadata } from "next";
-import { WebSiteJsonLd } from "@/components/seo/JsonLd";
-import { SITE_URL } from "@/config/site";
 import { getWeeklyRecap, getWeekStart } from "@/lib/data/recap";
 import { getFeaturedElection } from "@/lib/data/elections";
 import { getHomepageKPIs } from "@/lib/data/homepage";
-import { getTopMovers } from "@/lib/data/top-movers";
 import { getEnabledFlags } from "@/lib/feature-flags";
-import { WelcomeBar } from "@/components/home/WelcomeBar";
+import { HomeHero } from "@/components/home/HomeHero";
 import { KPIStrip } from "@/components/home/KPIStrip";
 import { ElectionBanner } from "@/components/home/ElectionBanner";
-import { TopMovers } from "@/components/home/TopMovers";
 import { ActivityFeed } from "@/components/home/ActivityFeed";
-import { QuickAccess } from "@/components/home/QuickAccess";
+import { IntentionGrid } from "@/components/home/IntentionGrid";
+import { TrustStrip } from "@/components/home/TrustStrip";
 import { SupportBar } from "@/components/home/SupportBar";
 
 export const revalidate = 300;
@@ -27,9 +24,8 @@ export default async function HomePage() {
   const now = new Date();
   const currentWeekStart = getWeekStart(now);
 
-  const [kpis, topMovers, weeklyRecap, featuredElection, enabledFlags] = await Promise.all([
+  const [kpis, weeklyRecap, featuredElection, enabledFlags] = await Promise.all([
     getHomepageKPIs(),
-    getTopMovers(),
     getWeeklyRecap(currentWeekStart),
     getFeaturedElection(),
     getEnabledFlags(),
@@ -42,28 +38,20 @@ export default async function HomePage() {
     : null;
 
   return (
-    <>
-      <WebSiteJsonLd
-        name="Poligraph"
-        description="Observatoire citoyen de la vie politique. Mandats, votes, patrimoine, affaires judiciaires et fact-checking."
-        url={SITE_URL}
-      />
-      <div className="container mx-auto px-4 py-8 space-y-8">
-        <WelcomeBar />
+    <div className="container mx-auto px-4 py-8 space-y-10">
+      <HomeHero />
 
-        {featuredElection && <ElectionBanner election={featuredElection} daysUntil={daysUntil} />}
+      {featuredElection && <ElectionBanner election={featuredElection} daysUntil={daysUntil} />}
 
-        <KPIStrip kpis={kpis} />
+      <KPIStrip kpis={kpis} />
 
-        <TopMovers movers={topMovers} />
+      <IntentionGrid enabledFlags={enabledFlags} />
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <ActivityFeed recap={weeklyRecap} />
-          <QuickAccess enabledFlags={enabledFlags} />
-        </div>
+      <ActivityFeed recap={weeklyRecap} />
 
-        <SupportBar />
-      </div>
-    </>
+      <TrustStrip />
+
+      <SupportBar />
+    </div>
   );
 }

--- a/src/components/home/ActivityFeed.tsx
+++ b/src/components/home/ActivityFeed.tsx
@@ -13,7 +13,7 @@ export function ActivityFeed({ recap }: ActivityFeedProps) {
   if (recap.votes && recap.votes.total > 0) {
     const n = recap.votes.total;
     items.push({
-      label: `${n} vote${n > 1 ? "s" : ""} cette semaine`,
+      label: `${n} vote${n > 1 ? "s" : ""} récemment analysé${n > 1 ? "s" : ""}`,
       count: n,
       href: "/parlement/votes",
       color: "bg-blue-500",
@@ -23,7 +23,7 @@ export function ActivityFeed({ recap }: ActivityFeedProps) {
   if (recap.affairs && recap.affairs.newAffairs.length > 0) {
     const n = recap.affairs.newAffairs.length;
     items.push({
-      label: `${n} nouvelle${n > 1 ? "s" : ""} affaire${n > 1 ? "s" : ""}`,
+      label: `${n} nouvelle${n > 1 ? "s" : ""} affaire${n > 1 ? "s" : ""} documentée${n > 1 ? "s" : ""}`,
       count: n,
       href: "/affaires",
       color: "bg-red-500",
@@ -33,7 +33,7 @@ export function ActivityFeed({ recap }: ActivityFeedProps) {
   if (recap.factChecks && recap.factChecks.total > 0) {
     const n = recap.factChecks.total;
     items.push({
-      label: `${n} fact-check${n > 1 ? "s" : ""}`,
+      label: `${n} fact-check${n > 1 ? "s" : ""} ajouté${n > 1 ? "s" : ""}`,
       count: n,
       href: "/factchecks",
       color: "bg-amber-500",
@@ -45,7 +45,7 @@ export function ActivityFeed({ recap }: ActivityFeedProps) {
   return (
     <section>
       <h2 className="text-lg font-display font-bold mb-4">Activité récente</h2>
-      <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         {items.map((item) => (
           <Link
             key={item.href}
@@ -61,6 +61,10 @@ export function ActivityFeed({ recap }: ActivityFeedProps) {
           </Link>
         ))}
       </div>
+      <p className="mt-3 text-xs text-muted-foreground">
+        Les affaires en cours ne valent pas condamnation. Poligraph distingue les procédures, les
+        classements, les relaxes et les condamnations.
+      </p>
     </section>
   );
 }

--- a/src/components/home/HomeHero.tsx
+++ b/src/components/home/HomeHero.tsx
@@ -1,0 +1,19 @@
+import { HomeHeroSearch } from "./HomeHeroSearch";
+
+export function HomeHero() {
+  return (
+    <section className="space-y-4">
+      <h1 className="text-2xl font-display font-bold tracking-tight md:text-4xl">
+        Poligraph, l{"'"}observatoire citoyen de la vie politique française
+      </h1>
+      <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+        Poligraph rassemble les données publiques sur les responsables politiques français : leurs
+        votes au Parlement, leurs mandats, leur patrimoine déclaré, les affaires judiciaires
+        documentées et les fact-checks. Chaque information renvoie à sa source officielle.
+      </p>
+      <div className="max-w-xl">
+        <HomeHeroSearch />
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/HomeHeroSearch.tsx
+++ b/src/components/home/HomeHeroSearch.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { Search } from "lucide-react";
+import { useCommandPalette } from "@/components/search";
+
+const PLACEHOLDER = "Rechercher un représentant, un vote, une affaire";
+
+// Hydration detection via useSyncExternalStore: server returns false, client
+// returns true. Snapshots are stable primitives, so no re-render loop.
+const emptySubscribe = () => () => {};
+function useHydrated() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
+}
+
+/**
+ * Progressive-enhancement search field for the homepage hero.
+ *
+ * Before hydration (and with JavaScript disabled) it renders a real GET form
+ * targeting /recherche, so the search works for crawlers and no-JS users.
+ * Once hydrated it swaps to a trigger that opens the global command palette
+ * for instant results. The initial client render matches the SSR markup,
+ * so there is no hydration mismatch.
+ */
+export function HomeHeroSearch() {
+  const { open } = useCommandPalette();
+  const enhanced = useHydrated();
+
+  if (enhanced) {
+    return (
+      <button
+        type="button"
+        onClick={open}
+        aria-label={PLACEHOLDER}
+        className="group flex h-12 w-full items-center gap-3 rounded-xl border bg-card pl-4 pr-4 text-left text-sm text-muted-foreground transition-colors hover:border-primary/40"
+      >
+        <Search className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <span className="flex-1 truncate">{PLACEHOLDER}</span>
+        <kbd className="hidden shrink-0 rounded border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline">
+          Ctrl K
+        </kbd>
+      </button>
+    );
+  }
+
+  return (
+    <form action="/recherche" method="get" role="search" className="relative w-full">
+      <label htmlFor="home-hero-search" className="sr-only">
+        {PLACEHOLDER}
+      </label>
+      <Search
+        className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <input
+        id="home-hero-search"
+        name="q"
+        type="search"
+        placeholder={PLACEHOLDER}
+        autoComplete="off"
+        className="h-12 w-full rounded-xl border bg-card pl-12 pr-4 text-sm outline-none transition-colors focus:border-primary focus:ring-4 focus:ring-primary/10"
+      />
+      <button type="submit" className="sr-only">
+        Rechercher
+      </button>
+    </form>
+  );
+}

--- a/src/components/home/IntentionGrid.tsx
+++ b/src/components/home/IntentionGrid.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  MapPin,
+  Vote,
+  Scale,
+  BarChart3,
+  ArrowLeftRight,
+  CalendarDays,
+  ChevronRight,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface IntentionItem {
+  href: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  featureFlag?: string;
+}
+
+const ITEMS: IntentionItem[] = [
+  {
+    href: "/mon-depute",
+    label: "Trouver mon député",
+    description: "Qui me représente, par code postal",
+    icon: MapPin,
+    featureFlag: "MON_DEPUTE_SECTION",
+  },
+  {
+    href: "/parlement/votes",
+    label: "Voir comment ils ont voté",
+    description: "Scrutins et positions des élus",
+    icon: Vote,
+  },
+  {
+    href: "/affaires",
+    label: "Explorer les affaires",
+    description: "Dossiers judiciaires sourcés",
+    icon: Scale,
+  },
+  {
+    href: "/statistiques",
+    label: "Consulter les statistiques",
+    description: "Tableaux de bord et analyses",
+    icon: BarChart3,
+    featureFlag: "STATISTIQUES_SECTION",
+  },
+  {
+    href: "/comparer",
+    label: "Comparer des élus",
+    description: "Mandats, votes et activité",
+    icon: ArrowLeftRight,
+    featureFlag: "COMPARISON_TOOL",
+  },
+  {
+    href: "/elections",
+    label: "Suivre les élections",
+    description: "Candidats, listes et résultats",
+    icon: CalendarDays,
+  },
+];
+
+interface IntentionGridProps {
+  enabledFlags: Set<string>;
+}
+
+export function IntentionGrid({ enabledFlags }: IntentionGridProps) {
+  const filtered = ITEMS.filter((item) => !item.featureFlag || enabledFlags.has(item.featureFlag));
+
+  return (
+    <section>
+      <h2 className="mb-4 text-lg font-display font-bold">Que cherchez-vous ?</h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((item) => {
+          const Icon = item.icon;
+          return (
+            <Link key={item.href} href={item.href} prefetch={false}>
+              <Card className="group h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-md">
+                <CardContent className="flex items-center gap-3 p-4">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-semibold leading-tight">{item.label}</div>
+                    <div className="text-xs text-muted-foreground">{item.description}</div>
+                  </div>
+                  <ChevronRight
+                    className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary"
+                    aria-hidden="true"
+                  />
+                </CardContent>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/KPIStrip.tsx
+++ b/src/components/home/KPIStrip.tsx
@@ -8,10 +8,10 @@ interface KPICardProps {
   label: string;
   href?: string;
   color: string;
-  badge?: string;
+  subtext?: string;
 }
 
-function KPICard({ count, label, href, color, badge }: KPICardProps) {
+function KPICard({ count, label, href, color, subtext }: KPICardProps) {
   const content = (
     <Card
       className={`relative border-l-4 transition-all ${
@@ -29,14 +29,10 @@ function KPICard({ count, label, href, color, badge }: KPICardProps) {
         <div className="text-2xl md:text-3xl font-display font-extrabold tracking-tight">
           {count.toLocaleString("fr-FR")}
         </div>
-        <div className="text-sm font-medium mt-1 leading-tight flex items-center gap-2">
-          {label}
-          {badge && (
-            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">
-              {badge}
-            </span>
-          )}
-        </div>
+        <div className="text-sm font-medium mt-1 leading-tight">{label}</div>
+        {subtext && (
+          <div className="mt-1 text-xs text-muted-foreground leading-snug">{subtext}</div>
+        )}
       </CardContent>
     </Card>
   );
@@ -52,35 +48,46 @@ function KPICard({ count, label, href, color, badge }: KPICardProps) {
 }
 
 export function KPIStrip({ kpis }: { kpis: HomepageKPIs }) {
+  const condamnationsSubtextParts: string[] = [];
+  if (kpis.proceduresEnCoursCount > 0) {
+    condamnationsSubtextParts.push(`${kpis.proceduresEnCoursCount} procédure(s) en cours`);
+  }
+  if (kpis.closesSansCondamnationCount > 0) {
+    condamnationsSubtextParts.push(
+      `${kpis.closesSansCondamnationCount} classée(s) sans condamnation`
+    );
+  }
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-      <KPICard
-        count={kpis.politiciansCount}
-        label="Politiques suivis"
-        href="/politiques"
-        color="#002654"
-      />
-      <KPICard
-        count={kpis.condamnationsCount}
-        label="Condamnations"
-        href="/affaires?certainty=ETABLI"
-        color="#DC2626"
-        badge={
-          kpis.proceduresEnCoursCount > 0 ? `${kpis.proceduresEnCoursCount} en cours` : undefined
-        }
-      />
-      <KPICard
-        count={kpis.votesCount}
-        label="Votes analysés"
-        href="/parlement/votes"
-        color="#002654"
-      />
-      <KPICard
-        count={kpis.factchecksCount}
-        label="Fact-checks vérifiés"
-        href="/factchecks"
-        color="#6B7280"
-      />
-    </div>
+    <section>
+      <h2 className="mb-4 text-lg font-display font-bold">Poligraph en chiffres</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+        <KPICard
+          count={kpis.politiciansCount}
+          label="Politiques suivis"
+          href="/politiques"
+          color="#002654"
+        />
+        <KPICard
+          count={kpis.condamnationsCount}
+          label="Condamnations"
+          href="/affaires?certainty=ETABLI"
+          color="#DC2626"
+          subtext={condamnationsSubtextParts.join(" · ") || undefined}
+        />
+        <KPICard
+          count={kpis.votesCount}
+          label="Votes analysés"
+          href="/parlement/votes"
+          color="#002654"
+        />
+        <KPICard
+          count={kpis.factchecksCount}
+          label="Fact-checks vérifiés"
+          href="/factchecks"
+          color="#6B7280"
+        />
+      </div>
+    </section>
   );
 }

--- a/src/components/home/TrustStrip.tsx
+++ b/src/components/home/TrustStrip.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { Database, BookOpen, ArrowRight } from "lucide-react";
+
+export function TrustStrip() {
+  return (
+    <section className="rounded-xl border bg-card p-6">
+      <h2 className="text-lg font-display font-bold">D{"'"}où viennent nos données</h2>
+      <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+        Poligraph s{"'"}appuie sur des données publiques ouvertes : Assemblée nationale, Sénat,
+        Parlement européen, HATVP et sources de presse vérifiées. Notre méthode et nos principes
+        sont documentés et consultables.
+      </p>
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+        <Link
+          href="/sources"
+          className="group inline-flex items-center gap-2 rounded-lg border bg-background px-4 py-2.5 text-sm font-medium transition-colors hover:border-primary/40"
+        >
+          <Database className="h-4 w-4 text-primary" aria-hidden="true" />
+          Sources et principes
+          <ArrowRight
+            className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
+        </Link>
+        <Link
+          href="/methodologie"
+          className="group inline-flex items-center gap-2 rounded-lg border bg-background px-4 py-2.5 text-sm font-medium transition-colors hover:border-primary/40"
+        >
+          <BookOpen className="h-4 w-4 text-primary" aria-hidden="true" />
+          Méthodologie
+          <ArrowRight
+            className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
+        </Link>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Pourquoi

La page d'accueil ressemblait à un tableau de bord interne (KPIs, « top movers », flux d'activité) plutôt qu'à un point d'entrée public. Cette refonte la réorganise autour des intentions concrètes des visiteurs et renforce la neutralité du projet.

## Ce qui change

- **Hero explicatif** : un vrai `<h1>` décrivant Poligraph + un paragraphe d'introduction indexable, là où il n'y avait qu'« Observatoire citoyen » et une date.
- **Recherche accessible** : la fausse recherche (un bouton ouvrant la palette) devient un vrai `<form action="/recherche" method="get">` avec `<input name="q">`, fonctionnel sans JavaScript, qui s'enrichit en palette de commandes une fois hydraté. La palette globale (Ctrl+K, en-tête) reste inchangée.
- **Grille d'intentions** « Que cherchez-vous ? » : remplace l'ancien `QuickAccess` qui dupliquait la navigation, recadré par objectif citoyen (Mon député, les votes, les affaires, statistiques, comparer, élections).
- **Bandeau de confiance** : nouvelle section « D'où viennent nos données » vers `/sources` et `/methodologie`.
- **Neutralité** :
  - La carte « Condamnations » abandonne la pastille rouge « en cours » au profit d'un texte secondaire neutre qui affiche aussi les affaires **classées sans condamnation** (donnée déjà chargée mais jamais affichée).
  - Les cartes « top movers » (photos d'élus à côté de badges d'affaires) sont retirées de l'accueil. L'activité reste agrégée, factuelle, sans visage lié à une affaire, avec une note explicite : « Les affaires en cours ne valent pas condamnation. »

## Accessibilité

- Chaque section a un titre (`<h2>`), y compris les chiffres.
- Champ de recherche avec label, `role="search"`, cible tactile de 48px.
- Plus aucune information portée par la seule couleur.

## Hors périmètre

Sitemap, canonical, noindex et la page `/recherche` ne sont pas touchés. Composants désormais inutilisés laissés en place pour un nettoyage séparé : `WelcomeBar`, `QuickAccess`, `TopMovers`, `lib/data/top-movers.ts`.

## Vérification

- `eslint` : 0 erreur, 0 warning sur les fichiers modifiés.
- `tsc --noEmit` : 0 erreur côté source.
- Aucun test ni story ne référence les composants modifiés.