### PR TITLE
SEO : titre descriptif pour /statistiques + audit indexation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ job-logs.txt
 
 # git worktrees
 /.worktrees
+
+# Local Search Console analysis (exports + plans with private SEO data, not committed)
+/docs/search-console/

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -405,7 +405,7 @@ async function buildScrutinsSitemap(): Promise<MetadataRoute.Sitemap> {
     }));
 }
 
-// Sitemap 4: Top 500 communes by population (priority 0.6)
+// Sitemap 4: Top 200 communes by population, restricted to those with candidacies (priority 0.6)
 async function buildCommunesSitemap(): Promise<MetadataRoute.Sitemap> {
   const communes: Array<{ id: string }> = await db.$queryRaw`
     SELECT DISTINCT c.id, c.population

--- a/src/app/statistiques/page.tsx
+++ b/src/app/statistiques/page.tsx
@@ -22,9 +22,9 @@ import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 export const revalidate = 300;
 
 export const metadata: Metadata = {
-  title: "Statistiques",
+  title: "Statistiques de la vie politique française",
   description:
-    "Statistiques sur la vie politique française : travail législatif, transparence judiciaire, fact-checking",
+    "Tableaux de bord sur les responsables politiques français : condamnations par parti, activité parlementaire, votes et fact-checks. Données ouvertes, méthodologie transparente.",
   alternates: { canonical: "/statistiques" },
 };
 


### PR DESCRIPTION
Audit indexation/SEO à partir des exports Search Console (analysés en local, non versionnés).

## Changements (low-risk)
- **`/statistiques`** : le `<title>` générique « Statistiques » devient « Statistiques de la vie politique française », avec une description plus descriptive et neutre. C'est la page la plus exposée dans la recherche et son titre n'était pas descriptif. Copie publique, factuelle, sans formulation sensationnaliste.
- **`sitemap.ts`** : commentaire du builder communes corrigé (200, pas 500). Aucun changement de comportement.
- **`.gitignore`** : `docs/search-console/` ignoré (exports et plan d'analyse contiennent des données SEO privées, gardés en local).

## Volontairement non modifié (voir plan local, nécessite un crawl)
- Le gros volume « Explorée, actuellement non indexée » : à traiter après classification des URL par motif (fiches fines, communes municipales, scrutins, combinaisons de filtres), pas à l'aveugle.
- `noindex` sur les pages à facettes : certaines facettes performent, donc pas de noindex global.
- `/affaires` : titre déjà neutre et correct ; son CTR est lié à la position, pas au titre.

## Vérification
- `eslint` : 0 erreur. `tsc --noEmit` : 0 erreur côté source. Tests SEO (`src/lib/seo`) : 13 passés.

Le détail chiffré (clics, impressions, requêtes) reste en local et n'est pas publié.