### PR TITLE
SEO : émettre les chemins canoniques /parlement (RSS guid + citizen impacts)

### DIFF
--- a/src/app/api/rss/votes.xml/route.ts
+++ b/src/app/api/rss/votes.xml/route.ts
@@ -32,7 +32,7 @@ export const GET = withPublicRoute(async () => {
         link: `${SITE_URL}/parlement/votes/${s.slug}`,
         description: `${resultLabel} — ${desc}`,
         pubDate: s.votingDate,
-        guid: `${SITE_URL}/votes/${s.slug}`,
+        guid: `${SITE_URL}/parlement/votes/${s.slug}`,
         category: CHAMBER_LABELS[s.chamber as Chamber],
       };
     });

--- a/src/services/sync/generate-scrutin-citizen-impacts.ts
+++ b/src/services/sync/generate-scrutin-citizen-impacts.ts
@@ -88,7 +88,7 @@ export async function generateScrutinCitizenImpacts(options?: {
       };
 
       if (context.dossierSlug) {
-        links.dossierUrl = `/assemblee/${context.dossierSlug}`;
+        links.dossierUrl = `/parlement/dossiers/${context.dossierSlug}`;
         links.dossierLabel = context.dossierTitle ?? "Dossier legislatif";
       }
 
@@ -105,7 +105,7 @@ export async function generateScrutinCitizenImpacts(options?: {
         });
         for (const related of relatedScrutins) {
           links.relatedVotes.push({
-            url: `/votes/${related.slug}`,
+            url: `/parlement/votes/${related.slug}`,
             label: related.title.slice(0, 80),
           });
         }


### PR DESCRIPTION
Suite au diagnostic par URL de l'index bloat (issue #385). Les pages explorées-non-indexées sont dominées par des **URL legacy** (`/votes/...`, `/assemblee/...`) et des images OpenGraph, **pas** par les fiches politiques/communes comme supposé initialement.

Ce PR corrige deux émetteurs internes de chemins legacy (qui 308-redirigent vers `/parlement/...`), pour cesser d'inviter les crawlers à explorer des URL de redirection :

- **Flux RSS votes** (`votes.xml`) : le `guid` utilisait `/votes/${slug}` alors que le `link` et le flux factchecks utilisent déjà le chemin canonique. Comme `buildRss` émet `<guid isPermaLink="true">`, ce guid était traité comme une URL à explorer. Aligné sur `/parlement/votes/${slug}`.
- **Génération des citizen impacts** (`generate-scrutin-citizen-impacts.ts`) : les liens générés (`dossierUrl`, `relatedVotes`) pointaient vers `/assemblee/...` et `/votes/...`. Passés en `/parlement/dossiers/...` et `/parlement/votes/...`.

### Effet
- Stoppe l'émission de nouveaux liens internes legacy.
- Effet secondaire mineur : les lecteurs RSS verront les 50 items du flux votes comme « nouveaux » une fois (changement de guid). Acceptable.

### Hors périmètre (différé, voir #385)
- Nettoyage des contenus déjà générés contenant des chemins legacy (write prod, à valider séparément).
- noindex des votes d'amendement fins et des combinaisons de filtres profondes `/parlement/votes?...` (nécessite un recoupement avec les performances avant tout changement).
- Pas de modification des fiches politiques (le diagnostic par URL ne les désigne pas comme cause principale).

### Vérification
- `eslint` : 0 erreur. `tsc --noEmit` : 0 erreur côté source. Tests RSS : 3 passés.

Aucune donnée Search Console privée n'est versionnée ni exposée.