### PR TITLE
SEO : nettoyage citizenImpact par updates ligne à ligne (fix timeout)

### DIFF
--- a/scripts/cleanup-citizen-impact-legacy-links.ts
+++ b/scripts/cleanup-citizen-impact-legacy-links.ts
@@ -5,7 +5,8 @@
  *   /votes/<slug>      ->  /parlement/votes/<slug>
  *   /assemblee/<slug>  ->  /parlement/dossiers/<slug>
  *
- * Dry-run by default. Pass --apply to write (wrapped in a single transaction).
+ * Dry-run by default. Pass --apply to write (per-row atomic updates, idempotent
+ * and resumable — no long-held transaction, so it is safe alongside other writers).
  *
  *   Dry-run:  npx dotenv -e .env -- npx tsx scripts/cleanup-citizen-impact-legacy-links.ts
  *   Apply:    npx dotenv -e .env -- npx tsx scripts/cleanup-citizen-impact-legacy-links.ts --apply
@@ -50,7 +51,7 @@ async function main() {
   let assembleeTotal = 0;
   const ambiguous: Array<{ id: string; leftover: string }> = [];
   const samples: Array<{ slug: string | null; before: string; after: string }> = [];
-  const updates: Array<ReturnType<typeof db.scrutin.update>> = [];
+  const updates: Array<{ id: string; citizenImpact: string }> = [];
 
   for (const row of rows) {
     scanned++;
@@ -76,12 +77,11 @@ async function main() {
       samples.push({ slug: row.slug, before: win(text), after: win(next) });
     }
 
-    if (apply)
-      updates.push(db.scrutin.update({ where: { id: row.id }, data: { citizenImpact: next } }));
+    if (apply) updates.push({ id: row.id, citizenImpact: next });
   }
 
   console.log("===== SUMMARY =====");
-  console.log(`1. Rows scanned (contain a legacy path) : ${scanned}`);
+  console.log(`1. Candidate rows (broad prefilter)     : ${scanned}`);
   console.log(`2. Rows affected (would change)         : ${affected}`);
   console.log(`3. Replacements by type:`);
   console.log(`     /votes/      -> /parlement/votes/     : ${votesTotal}`);
@@ -100,13 +100,30 @@ async function main() {
     if (ambiguous.length) {
       throw new Error("Ambiguous occurrences detected — aborting APPLY. Review before writing.");
     }
-    console.log(`\nApplying ${updates.length} updates in a single transaction…`);
-    await db.$transaction(updates); // 6. transaction-safe: all-or-nothing
-    console.log("Done. Updates committed atomically.");
+    // Individual row updates (no wrapping transaction): each update is its own
+    // atomic statement, so locks are held only for that single row and only
+    // momentarily — gentle on the shared connection pool and any concurrent
+    // writer. A small concurrency keeps it reasonably fast without starving the
+    // pool (max: 2). Safe to interrupt/resume: the rewrite is idempotent, so
+    // re-running only touches rows that still hold a legacy path.
+    const CONCURRENCY = 4;
+    let done = 0;
+    console.log(`\nApplying ${updates.length} per-row updates (concurrency ${CONCURRENCY})…`);
+    for (let i = 0; i < updates.length; i += CONCURRENCY) {
+      const slice = updates.slice(i, i + CONCURRENCY);
+      await Promise.all(
+        slice.map((u) =>
+          db.scrutin.update({ where: { id: u.id }, data: { citizenImpact: u.citizenImpact } })
+        )
+      );
+      done += slice.length;
+      if (done % 200 === 0 || done === updates.length) {
+        console.log(`  updated ${done}/${updates.length}`);
+      }
+    }
+    console.log("Done. All rows updated (idempotent — safe to re-run).");
   } else {
-    console.log(
-      `\n(DRY-RUN) No write performed. Re-run with --apply to commit (atomic transaction).`
-    );
+    console.log(`\n(DRY-RUN) No write performed. Re-run with --apply to commit.`);
   }
 
   await db.$disconnect();

--- a/scripts/cleanup-citizen-impact-legacy-links.ts
+++ b/scripts/cleanup-citizen-impact-legacy-links.ts
@@ -1,0 +1,118 @@
+/**
+ * Rewrite legacy internal paths embedded in Scrutin.citizenImpact markdown to
+ * their canonical equivalents (the same targets the 308 redirects already use):
+ *
+ *   /votes/<slug>      ->  /parlement/votes/<slug>
+ *   /assemblee/<slug>  ->  /parlement/dossiers/<slug>
+ *
+ * Dry-run by default. Pass --apply to write (wrapped in a single transaction).
+ *
+ *   Dry-run:  npx dotenv -e .env -- npx tsx scripts/cleanup-citizen-impact-legacy-links.ts
+ *   Apply:    npx dotenv -e .env -- npx tsx scripts/cleanup-citizen-impact-legacy-links.ts --apply
+ *
+ * Idempotent: the /votes/ rule uses a (?<!parlement) lookbehind so it never
+ * rewrites an already-canonical /parlement/votes/ path; the /assemblee/ target
+ * (/parlement/dossiers/) shares no substring with /assemblee/. Running twice is a no-op.
+ */
+import "dotenv/config";
+import { db } from "@/lib/db";
+
+// Guarded so /parlement/votes/ (which contains "/votes/") is never matched.
+const VOTES_RE = /(?<!parlement)\/votes\//g;
+const ASSEMBLEE_RE = /\/assemblee\//g;
+
+function rewrite(text: string): { next: string; votes: number; assemblee: number } {
+  const votes = (text.match(VOTES_RE) || []).length;
+  const assemblee = (text.match(ASSEMBLEE_RE) || []).length;
+  const next = text
+    .replace(VOTES_RE, "/parlement/votes/")
+    .replace(ASSEMBLEE_RE, "/parlement/dossiers/");
+  return { next, votes, assemblee };
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY (will write)" : "DRY-RUN (no write)"}\n`);
+
+  const rows = await db.scrutin.findMany({
+    where: {
+      OR: [
+        { citizenImpact: { contains: "/votes/" } },
+        { citizenImpact: { contains: "/assemblee/" } },
+      ],
+    },
+    select: { id: true, slug: true, citizenImpact: true },
+  });
+
+  let scanned = 0;
+  let affected = 0;
+  let votesTotal = 0;
+  let assembleeTotal = 0;
+  const ambiguous: Array<{ id: string; leftover: string }> = [];
+  const samples: Array<{ slug: string | null; before: string; after: string }> = [];
+  const updates: Array<ReturnType<typeof db.scrutin.update>> = [];
+
+  for (const row of rows) {
+    scanned++;
+    const text = row.citizenImpact!;
+    const { next, votes, assemblee } = rewrite(text);
+    if (next === text) continue; // nothing to change (defensive)
+    affected++;
+    votesTotal += votes;
+    assembleeTotal += assemblee;
+
+    // Idempotency self-check: a second pass must be a no-op.
+    if (rewrite(next).next !== next) {
+      throw new Error(`Non-idempotent rewrite on scrutin ${row.id} — aborting before any write.`);
+    }
+
+    // Ambiguity check: any legacy token still present after rewrite is unexpected.
+    const leftover = next.match(/(?<!parlement)\/votes\/|\/assemblee\//g);
+    if (leftover) ambiguous.push({ id: row.id, leftover: leftover.join(", ") });
+
+    if (samples.length < 10) {
+      const idx = text.search(/(?<!parlement)\/votes\/|\/assemblee\//);
+      const win = (s: string) => s.slice(Math.max(0, idx - 30), idx + 70).replace(/\n/g, " ");
+      samples.push({ slug: row.slug, before: win(text), after: win(next) });
+    }
+
+    if (apply)
+      updates.push(db.scrutin.update({ where: { id: row.id }, data: { citizenImpact: next } }));
+  }
+
+  console.log("===== SUMMARY =====");
+  console.log(`1. Rows scanned (contain a legacy path) : ${scanned}`);
+  console.log(`2. Rows affected (would change)         : ${affected}`);
+  console.log(`3. Replacements by type:`);
+  console.log(`     /votes/      -> /parlement/votes/     : ${votesTotal}`);
+  console.log(`     /assemblee/  -> /parlement/dossiers/  : ${assembleeTotal}`);
+  console.log(`5. Ambiguous / un-rewritable occurrences  : ${ambiguous.length}`);
+  if (ambiguous.length) console.log(JSON.stringify(ambiguous.slice(0, 20), null, 2));
+
+  console.log(`\n4. Before/after samples (up to 10):`);
+  samples.forEach((s, i) => {
+    console.log(`\n  [${i + 1}] ${s.slug ?? "(no slug)"}`);
+    console.log(`      before: …${s.before}…`);
+    console.log(`      after : …${s.after}…`);
+  });
+
+  if (apply) {
+    if (ambiguous.length) {
+      throw new Error("Ambiguous occurrences detected — aborting APPLY. Review before writing.");
+    }
+    console.log(`\nApplying ${updates.length} updates in a single transaction…`);
+    await db.$transaction(updates); // 6. transaction-safe: all-or-nothing
+    console.log("Done. Updates committed atomically.");
+  } else {
+    console.log(
+      `\n(DRY-RUN) No write performed. Re-run with --apply to commit (atomic transaction).`
+    );
+  }
+
+  await db.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Correctif du script mergé en #387. La version initiale enveloppait les 1 644 updates dans une seule `$transaction`, ce qui dépassait le timeout interactif Prisma (5 s) et était annulé (rollback propre, aucune écriture partielle).

Remplacé par des updates atomiques **ligne à ligne** (concurrence 4) :
- pas de transaction longue → verrous très brefs, compatible avec un autre script écrivant en parallèle ;
- **idempotent et reprenable** : la réécriture `(?<!parlement)/votes/` + `/assemblee/` ne touche jamais un chemin déjà canonique, donc une reprise ne traite que les lignes restantes.

### Exécution effectuée (prod, validée)
Le nettoyage a été appliqué : 1 644 lignes mises à jour. Vérification post-run : 0 lien markdown legacy restant (`](/votes/` et `](/assemblee/`), et la réexécution en dry-run rapporte 0 changement (idempotence confirmée).

### Vérification
`tsc --noEmit` : 0 erreur côté source.