### PR TITLE
Auto-publie les titres de votes via le cron quotidien

### DIFF
--- a/src/app/admin/dossiers/[id]/page.tsx
+++ b/src/app/admin/dossiers/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   DOSSIER_CATEGORY_COLORS,
 } from "@/config/labels";
 import { formatDate } from "@/lib/utils";
+import { extractText } from "@/lib/parsing/html-utils";
 import { DossierSummaryEditor } from "@/components/admin/DossierSummaryEditor";
 
 interface PageProps {
@@ -166,10 +167,12 @@ export default async function AdminDossierDetailPage({ params }: PageProps) {
                   <div>
                     <span className="font-mono text-sm">#{amendment.number}</span>
                     {amendment.article && (
-                      <span className="text-muted-foreground ml-2">Art. {amendment.article}</span>
+                      <span className="text-muted-foreground ml-2">
+                        Art. {extractText(amendment.article)}
+                      </span>
                     )}
                     {amendment.authorName && (
-                      <span className="text-sm ml-2">{amendment.authorName}</span>
+                      <span className="text-sm ml-2">{extractText(amendment.authorName)}</span>
                     )}
                   </div>
                   <Badge

--- a/src/app/admin/policy-titles/actions.ts
+++ b/src/app/admin/policy-titles/actions.ts
@@ -6,17 +6,19 @@ import { isAuthenticated } from "@/lib/auth";
 import {
   approveGuard,
   computeCurrentWarnings,
-  detectEvidenceDrift,
   type HardBlocker,
 } from "@/app/admin/policy-titles/approve-guard";
-import { buildInputHashInput, generateScrutinPolicyTitle } from "@/services/scrutin-policy-title";
-import { computeInputHash } from "@/services/scrutin-policy-title/input-hash";
-import { resolveSubstanceSources } from "@/services/scrutin-policy-title/substance-resolver";
-import type {
-  EvidenceQuote,
-  GenerationWarning,
-  SubstanceTextBlock,
-} from "@/services/scrutin-policy-title/types";
+import { generateScrutinPolicyTitle } from "@/services/scrutin-policy-title";
+import type { EvidenceQuote, GenerationWarning } from "@/services/scrutin-policy-title/types";
+import {
+  recomputeApprovalContext,
+  evaluateBatchEligibility,
+  persistApproval,
+  isRejectedNotRevised,
+  snapshot,
+  asJson,
+  type ApprovalContext,
+} from "@/services/scrutin-policy-title/approval";
 import { queryQueue, type QueueFilters } from "@/app/admin/policy-titles/_data/queue-query";
 import { themeToSlug } from "@/lib/theme-utils";
 import { ApproveBlockedError } from "@/app/admin/policy-titles/errors";
@@ -33,81 +35,9 @@ async function assertAuthenticated(): Promise<void> {
   if (!(await isAuthenticated())) throw new Error("Non autorisé");
 }
 
-interface ApprovalContext {
-  row: ScrutinPolicyTitle;
-  scrutin: {
-    id: string;
-    title: string;
-    sourceUrl: string | null;
-    amendmentLinks: { role: string; amendment: { id: string; number: string } }[];
-  };
-  blocks: SubstanceTextBlock[];
-  currentInputHash: string;
-  currentWarnings: GenerationWarning[];
-  evidenceDrift: boolean;
-}
-
-/**
- * Loads the row + scrutin and recomputes substance, input hash, validator
- * warnings and evidence drift FRESH. Never trusts the stored values: every
- * approval decision must reflect what the official text says today. Shared by
- * the approve/edit actions so the guard always sees current reality.
- */
-async function recomputeApprovalContext(scrutinId: string): Promise<ApprovalContext> {
-  const policy = await db.scrutinPolicyTitle.findUnique({
-    where: { scrutinId },
-    include: {
-      scrutin: {
-        select: {
-          id: true,
-          title: true,
-          sourceUrl: true,
-          amendmentLinks: {
-            select: { role: true, amendment: { select: { id: true, number: true } } },
-          },
-        },
-      },
-    },
-  });
-
-  if (!policy) throw new Error(`Aucun titre public pour le scrutin ${scrutinId}`);
-
-  const { scrutin, ...row } = policy;
-
-  const resolved = await resolveSubstanceSources(scrutinId);
-  const currentInputHash = computeInputHash(
-    buildInputHashInput(
-      {
-        title: scrutin.title,
-        sourceUrl: scrutin.sourceUrl,
-        amendmentLinks: scrutin.amendmentLinks.map((l) => ({
-          role: l.role,
-          amendment: { id: l.amendment.id, number: l.amendment.number },
-        })),
-      },
-      row.proceduralLabel,
-      resolved.blocks
-    )
-  );
-
-  const evidenceQuotes = (row.evidenceQuotes ?? []) as unknown as EvidenceQuote[];
-  const currentWarnings = computeCurrentWarnings(
-    row.policyTitle,
-    row.policySubtitle,
-    evidenceQuotes,
-    resolved.blocks
-  );
-  const evidenceDrift = detectEvidenceDrift(evidenceQuotes, resolved.blocks);
-
-  return {
-    row: policy as ScrutinPolicyTitle,
-    scrutin,
-    blocks: resolved.blocks,
-    currentInputHash,
-    currentWarnings,
-    evidenceDrift,
-  };
-}
+// Approval context recompute, the batch-eligibility guard, and persistence live
+// in the shared service so the cron applies the EXACT same rules. See
+// `@/services/scrutin-policy-title/approval`.
 
 function revalidate(scrutinId: string): void {
   revalidatePath("/admin/policy-titles");
@@ -133,15 +63,6 @@ async function revalidatePublicForScrutin(scrutinId: string): Promise<void> {
     revalidatePath("/");
     revalidatePath("/parlement");
   }
-}
-
-function asJson(value: unknown): Prisma.InputJsonValue {
-  return value as unknown as Prisma.InputJsonValue;
-}
-
-/** Snapshot of the row as stored, for revision history. */
-function snapshot(row: ScrutinPolicyTitle): Prisma.InputJsonValue {
-  return row as unknown as Prisma.InputJsonValue;
 }
 
 /**
@@ -190,52 +111,6 @@ export async function editScrutinPolicyTitle(
   if (row.status === "APPROVED") await revalidatePublicForScrutin(scrutinId);
 }
 
-/** True when the row is REJECTED and its most-recent revision is a rejection. */
-async function isRejectedNotRevised(row: ScrutinPolicyTitle): Promise<boolean> {
-  if (row.status !== "REJECTED") return false;
-  const latest = await db.scrutinPolicyTitleRevision.findFirst({
-    where: { policyTitleId: row.id },
-    orderBy: { createdAt: "desc" },
-  });
-  return latest?.action === "rejected";
-}
-
-interface ApprovePersistArgs {
-  ctx: ApprovalContext;
-  approvalOverride?: { reason: string; actor: string };
-}
-
-/** Persists APPROVED + the freshly recomputed hash/warnings + an "approved"
- *  revision. Only ever called after approveGuard returns ok. */
-async function persistApproval({ ctx, approvalOverride }: ApprovePersistArgs): Promise<void> {
-  const { row, currentInputHash, currentWarnings } = ctx;
-  const reviewedAt = new Date();
-
-  await db.$transaction(async (tx) => {
-    await tx.scrutinPolicyTitleRevision.create({
-      data: {
-        policyTitleId: row.id,
-        snapshot: {
-          ...(snapshot(row) as object),
-          ...(approvalOverride ? { approvalOverride } : {}),
-        } as Prisma.InputJsonValue,
-        action: "approved",
-        actorId: ACTOR,
-      },
-    });
-    await tx.scrutinPolicyTitle.update({
-      where: { id: row.id },
-      data: {
-        status: "APPROVED",
-        reviewedAt,
-        reviewedBy: ACTOR,
-        inputHash: currentInputHash,
-        currentWarnings: asJson(currentWarnings),
-      },
-    });
-  });
-}
-
 /**
  * Approves a clean row. Order: REJECTED-not-revised check, then approveGuard in
  * single mode. On INPUT_DRIFT the row is flipped to STALE (with a revision) before
@@ -263,7 +138,7 @@ export async function approveScrutinPolicyTitle(scrutinId: string): Promise<void
     await handleGuardFailure(row, scrutinId, result.hardBlockers);
   }
 
-  await persistApproval({ ctx });
+  await persistApproval(ctx, { actor: ACTOR });
   revalidate(scrutinId);
   await revalidatePublicForScrutin(scrutinId);
 }
@@ -301,7 +176,7 @@ export async function approveWithOverrideScrutinPolicyTitle(
     await handleGuardFailure(row, scrutinId, result.hardBlockers);
   }
 
-  await persistApproval({ ctx, approvalOverride: { reason: trimmed, actor: ACTOR } });
+  await persistApproval(ctx, { actor: ACTOR, approvalOverride: { reason: trimmed, actor: ACTOR } });
   revalidate(scrutinId);
   await revalidatePublicForScrutin(scrutinId);
 }
@@ -439,51 +314,6 @@ export interface BatchApproveResult {
 }
 
 /**
- * Per-id batch eligibility. Recomputes the approval context FRESH and runs the
- * guard in batch mode (which enforces HIGH confidence, zero currentWarnings, no
- * input/evidence drift, non-empty/<=140 title, no validation blocker). On top of
- * the guard, two explicit extra checks that batch mode must never relax:
- *   - zero generationWarnings (a row that generated with ANY warning is not clean)
- *   - the row is NOT a FALLBACK row
- * Returns the failure reasons for a row, or an empty array when batch-eligible.
- */
-async function evaluateBatchEligibility(scrutinId: string): Promise<string[]> {
-  const ctx = await recomputeApprovalContext(scrutinId);
-  const { row, currentInputHash, currentWarnings, evidenceDrift } = ctx;
-  const reasons: string[] = [];
-
-  // REJECTED-not-revised is a hard precondition for the single path too.
-  if (await isRejectedNotRevised(row)) {
-    reasons.push("REJECTED_NOT_REVISED");
-  }
-
-  // Extra explicit checks (not all covered by the guard in batch mode).
-  const generationWarnings = (row.generationWarnings ?? []) as unknown as GenerationWarning[];
-  if (generationWarnings.length > 0) {
-    reasons.push("GENERATION_WARNINGS");
-  }
-  if (row.generationSource === "FALLBACK") {
-    reasons.push("FALLBACK_ROW");
-  }
-
-  const result = approveGuard({
-    row,
-    currentInputHash,
-    currentWarnings,
-    evidenceDrift,
-    mode: "batch",
-  });
-  if (!result.ok) {
-    for (const code of result.hardBlockers) reasons.push(code);
-    // In batch mode the guard reports overridable warnings (incl. HIGH-confidence
-    // failure) by leaving hardBlockers empty; surface that explicitly.
-    if (result.hardBlockers.length === 0) reasons.push("NOT_BATCH_CLEAN");
-  }
-
-  return reasons;
-}
-
-/**
  * Approves a set of rows, EXTRA conservative and ALL-OR-NOTHING. Every id is
  * recomputed and evaluated against the batch guard plus the explicit extra
  * checks (zero generationWarnings, not FALLBACK). If ANY id fails, NONE are
@@ -501,11 +331,12 @@ export async function batchApprove(scrutinIds: string[]): Promise<BatchApproveRe
   const contexts: ApprovalContext[] = [];
 
   for (const scrutinId of ids) {
-    const reasons = await evaluateBatchEligibility(scrutinId);
+    const ctx = await recomputeApprovalContext(scrutinId);
+    const reasons = await evaluateBatchEligibility(ctx);
     if (reasons.length > 0) {
       failures.push({ scrutinId, reasons });
     } else {
-      contexts.push(await recomputeApprovalContext(scrutinId));
+      contexts.push(ctx);
     }
   }
 
@@ -515,7 +346,7 @@ export async function batchApprove(scrutinIds: string[]): Promise<BatchApproveRe
   }
 
   for (const ctx of contexts) {
-    await persistApproval({ ctx });
+    await persistApproval(ctx, { actor: ACTOR });
     revalidate(ctx.scrutin.id);
     await revalidatePublicForScrutin(ctx.scrutin.id);
   }

--- a/src/app/parlement/dossiers/[slug]/page.tsx
+++ b/src/app/parlement/dossiers/[slug]/page.tsx
@@ -20,6 +20,7 @@ import { LegislationJsonLd } from "@/components/seo/JsonLd";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { SITE_URL } from "@/config/site";
 import { formatDate } from "@/lib/utils";
+import { extractText } from "@/lib/parsing/html-utils";
 import type { MandateType } from "@/generated/prisma";
 
 export const revalidate = 3600; // ISR: revalidate every hour
@@ -296,14 +297,18 @@ export default async function DossierDetailPage({ params }: PageProps) {
                       </div>
                       {amendment.authorName && (
                         <p className="text-sm text-muted-foreground">
-                          Par {amendment.authorName}
+                          Par {extractText(amendment.authorName)}
                           {amendment.authorType && ` (${amendment.authorType})`}
                         </p>
                       )}
                       {amendment.article && (
-                        <p className="text-sm text-muted-foreground">Article {amendment.article}</p>
+                        <p className="text-sm text-muted-foreground">
+                          Article {extractText(amendment.article)}
+                        </p>
                       )}
-                      {amendment.summary && <p className="text-sm mt-2">{amendment.summary}</p>}
+                      {amendment.summary && (
+                        <p className="text-sm mt-2">{extractText(amendment.summary)}</p>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/src/config/pipeline-registry.test.ts
+++ b/src/config/pipeline-registry.test.ts
@@ -249,3 +249,52 @@ describe("PIPELINE_REGISTRY", () => {
     }
   });
 });
+
+describe("policy-title pipeline steps", () => {
+  // id → the SyncMetadata key the matching sync-daily step writes via markCompleted.
+  const STEP_KEYS: Record<string, string> = {
+    "policy-amendments": "policy-titles:amendments",
+    "policy-link": "policy-titles:link",
+    "policy-generate": "policy-titles:generate",
+    "policy-approve": "policy-titles:approve",
+  };
+
+  it("registers all four steps with their sync-metadata keys", () => {
+    for (const [id, key] of Object.entries(STEP_KEYS)) {
+      const config = getPipelineConfig(id);
+      expect(config, `pipeline ${id} should be registered`).toBeDefined();
+      expect(config!.metadataKeys).toContain(key);
+      expect(config!.enabled).toBe(true);
+      expect(config!.category).toBe("votes");
+    }
+  });
+
+  it("flags a step as warning then critical as its last run goes stale", () => {
+    const config = getPipelineConfig("policy-approve")!;
+    expect(
+      computePipelineHealth(
+        config,
+        makeLastRun({ lastRunAt: hoursAgo(40), status: "completed" }),
+        NOW
+      ).status
+    ).toBe("warning");
+    expect(
+      computePipelineHealth(
+        config,
+        makeLastRun({ lastRunAt: hoursAgo(100), status: "completed" }),
+        NOW
+      ).status
+    ).toBe("critical");
+  });
+
+  it("is healthy right after a successful run, surfacing counts", () => {
+    const config = getPipelineConfig("policy-generate")!;
+    const result = computePipelineHealth(
+      config,
+      makeLastRun({ lastRunAt: hoursAgo(3), itemCount: 5, status: "completed" }),
+      NOW
+    );
+    expect(result.status).toBe("healthy");
+    expect(result.lastItemCount).toBe(5);
+  });
+});

--- a/src/config/pipeline-registry.ts
+++ b/src/config/pipeline-registry.ts
@@ -183,6 +183,58 @@ export const PIPELINE_REGISTRY: PipelineConfig[] = [
     enabled: true,
   },
 
+  // Policy-title pipeline (Inngest, sync-daily steps). Each writes its own
+  // SyncMetadata key so freshness is tracked per step. Public-facing + partly
+  // AI-driven, so monitored separately rather than as one black box.
+  {
+    id: "policy-amendments",
+    name: "Titres de votes : import amendements",
+    category: "votes",
+    frequency: "daily",
+    source: "inngest",
+    warnAfterHours: 30,
+    criticalAfterHours: 72,
+    metadataKeys: ["policy-titles:amendments"],
+    command: "sync-daily (amendments-an)",
+    enabled: true,
+  },
+  {
+    id: "policy-link",
+    name: "Titres de votes : liaison scrutins",
+    category: "votes",
+    frequency: "daily",
+    source: "inngest",
+    warnAfterHours: 30,
+    criticalAfterHours: 72,
+    metadataKeys: ["policy-titles:link"],
+    command: "sync-daily (link-scrutins-amendments)",
+    enabled: true,
+  },
+  {
+    id: "policy-generate",
+    name: "Titres de votes : génération IA",
+    category: "votes",
+    frequency: "daily",
+    source: "inngest",
+    warnAfterHours: 30,
+    criticalAfterHours: 72,
+    metadataKeys: ["policy-titles:generate"],
+    command: "sync-daily (generate-policy-titles)",
+    enabled: true,
+  },
+  {
+    id: "policy-approve",
+    name: "Titres de votes : auto-approbation",
+    category: "votes",
+    frequency: "daily",
+    source: "inngest",
+    warnAfterHours: 30,
+    criticalAfterHours: 72,
+    metadataKeys: ["policy-titles:approve"],
+    command: "sync-daily (approve-policy-titles)",
+    enabled: true,
+  },
+
   // Weekly pipelines (GitHub Actions)
   {
     id: "deputes",

--- a/src/config/policy-titles.ts
+++ b/src/config/policy-titles.ts
@@ -1,0 +1,27 @@
+/**
+ * Tunables for the daily policy-title pipeline steps in sync-daily.
+ * All values are env-overridable; the defaults are sane for a 3×/day cron over
+ * the incremental delta of new AN votes.
+ */
+function intEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+export const POLICY_TITLE_CRON = {
+  /** Max amendments pulled per daily delta import (feed-state bounded). */
+  amendmentsImportLimit: intEnv("POLICY_TITLE_AMENDMENTS_LIMIT", 2000),
+  /** Newest-first scrutins re-scanned for amendment links each run (idempotent). */
+  linkLimit: intEnv("POLICY_TITLE_LINK_LIMIT", 200),
+  /** Max titles generated per run — a safety cap, not a target. */
+  generateLimit: intEnv("POLICY_TITLE_GENERATE_LIMIT", 30),
+  /** Max DRAFT rows evaluated for auto-approval per run. */
+  approveLimit: intEnv("POLICY_TITLE_APPROVE_LIMIT", 50),
+  /**
+   * Auto-approve only titles at least this old. Gives a deliberate veto window:
+   * a freshly generated title is never published in the same run that made it.
+   */
+  approveMinAgeHours: intEnv("POLICY_TITLE_APPROVE_MIN_AGE_HOURS", 24),
+} as const;

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -1,5 +1,6 @@
 import { inngest } from "../client";
 import { POLICY_TITLE_CRON } from "@/config/policy-titles";
+import { syncMetadata } from "@/lib/sync/sync-metadata";
 
 interface DailyStep {
   name: string;
@@ -78,6 +79,16 @@ const DAILY_STEPS: DailyStep[] = [
         force: false,
         limit: POLICY_TITLE_CRON.amendmentsImportLimit,
       });
+      await syncMetadata.markCompleted("policy-titles:amendments", {
+        itemCount: stats.amendmentsCreated,
+        durationS: stats.durationMs / 1000,
+        extra: {
+          seen: stats.amendmentsSeen,
+          created: stats.amendmentsCreated,
+          updated: stats.amendmentsUpdated,
+          skipped: stats.amendmentsSkipped,
+        },
+      });
       console.info("[sync-daily] amendments-an", stats);
       return stats;
     },
@@ -91,6 +102,15 @@ const DAILY_STEPS: DailyStep[] = [
         legislature: 17,
         limit: POLICY_TITLE_CRON.linkLimit,
       });
+      await syncMetadata.markCompleted("policy-titles:link", {
+        itemCount: stats.linksCreated,
+        durationS: stats.durationMs / 1000,
+        extra: {
+          scanned: stats.scrutinsScanned,
+          linked: stats.scrutinsLinked,
+          linksCreated: stats.linksCreated,
+        },
+      });
       console.info("[sync-daily] link-scrutins-amendments", stats);
       return stats;
     },
@@ -102,6 +122,16 @@ const DAILY_STEPS: DailyStep[] = [
       const { generateScrutinPolicyTitles } =
         await import("@/services/sync/generate-scrutin-policy-titles");
       const stats = await generateScrutinPolicyTitles({ limit: POLICY_TITLE_CRON.generateLimit });
+      await syncMetadata.markCompleted("policy-titles:generate", {
+        itemCount: stats.generated,
+        durationS: stats.durationMs / 1000,
+        extra: {
+          processed: stats.processed,
+          generated: stats.generated,
+          fallbacks: stats.fallbacks,
+          errors: stats.errors.length,
+        },
+      });
       console.info("[sync-daily] generate-policy-titles", stats);
       return stats;
     },
@@ -113,6 +143,16 @@ const DAILY_STEPS: DailyStep[] = [
       const stats = await autoApproveBatchEligible({
         limit: POLICY_TITLE_CRON.approveLimit,
         minAgeHours: POLICY_TITLE_CRON.approveMinAgeHours,
+      });
+      await syncMetadata.markCompleted("policy-titles:approve", {
+        itemCount: stats.approved,
+        durationS: stats.durationMs / 1000,
+        extra: {
+          scanned: stats.scanned,
+          approved: stats.approved,
+          skipped: stats.skipped,
+          byReason: stats.byReason,
+        },
       });
       console.info("[sync-daily] approve-policy-titles", stats);
       return stats;

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -1,4 +1,5 @@
 import { inngest } from "../client";
+import { POLICY_TITLE_CRON } from "@/config/policy-titles";
 
 interface DailyStep {
   name: string;
@@ -63,6 +64,58 @@ const DAILY_STEPS: DailyStep[] = [
     run: async () => {
       const { reconcileScrutinDossier } = await import("@/services/sync/reconcile-scrutin-dossier");
       return reconcileScrutinDossier();
+    },
+  },
+  // Policy-title pipeline: import new amendments → link them to scrutins →
+  // generate simplified titles → auto-approve the settled HIGH-confidence ones.
+  // Each step is bounded/idempotent. Auto-approve only touches DRAFT rows ≥24h
+  // old, via the shared guard; new titles surface on the public ISR pages.
+  {
+    name: "amendments-an",
+    run: async () => {
+      const { syncAmendmentsAN } = await import("@/services/sync/amendments-an");
+      const stats = await syncAmendmentsAN({
+        force: false,
+        limit: POLICY_TITLE_CRON.amendmentsImportLimit,
+      });
+      console.info("[sync-daily] amendments-an", stats);
+      return stats;
+    },
+  },
+  {
+    name: "link-scrutins-amendments",
+    run: async () => {
+      const { linkScrutinsToAmendments } =
+        await import("@/services/sync/link-scrutins-to-amendments");
+      const stats = await linkScrutinsToAmendments({
+        legislature: 17,
+        limit: POLICY_TITLE_CRON.linkLimit,
+      });
+      console.info("[sync-daily] link-scrutins-amendments", stats);
+      return stats;
+    },
+  },
+  {
+    name: "generate-policy-titles",
+    run: async () => {
+      if (!process.env.MISTRAL_API_KEY) return { skipped: "no MISTRAL_API_KEY" };
+      const { generateScrutinPolicyTitles } =
+        await import("@/services/sync/generate-scrutin-policy-titles");
+      const stats = await generateScrutinPolicyTitles({ limit: POLICY_TITLE_CRON.generateLimit });
+      console.info("[sync-daily] generate-policy-titles", stats);
+      return stats;
+    },
+  },
+  {
+    name: "approve-policy-titles",
+    run: async () => {
+      const { autoApproveBatchEligible } = await import("@/services/scrutin-policy-title/approval");
+      const stats = await autoApproveBatchEligible({
+        limit: POLICY_TITLE_CRON.approveLimit,
+        minAgeHours: POLICY_TITLE_CRON.approveMinAgeHours,
+      });
+      console.info("[sync-daily] approve-policy-titles", stats);
+      return stats;
     },
   },
   {

--- a/src/services/scrutin-policy-title/__tests__/auto-approve.test.ts
+++ b/src/services/scrutin-policy-title/__tests__/auto-approve.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+// DB-integration suite: gated behind DATABASE_URL (skipped in plain `npm test`).
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+
+const PFX = "TEST_AUTO_";
+
+let db: typeof import("@/lib/db").db;
+let autoApproveBatchEligible: typeof import("../approval").autoApproveBatchEligible;
+let CRON_ACTOR: string;
+let toPublicTitleView: typeof import("@/lib/votes/to-public-title-view").toPublicTitleView;
+let buildInputHashInput: typeof import("@/services/scrutin-policy-title").buildInputHashInput;
+let computeInputHash: typeof import("@/services/scrutin-policy-title/input-hash").computeInputHash;
+let resolveSubstanceSources: typeof import("@/services/scrutin-policy-title/substance-resolver").resolveSubstanceSources;
+
+// Grounded summary: the title quotes appear here verbatim so EvidenceGrounding passes.
+const SUMMARY =
+  "Le sous-amendement supprime une dérogation aux seuils de qualité de l'eau imposés aux exploitations agricoles.";
+const CLEAN_TITLE = "Supprimer une dérogation aux seuils de qualité de l'eau";
+const CLEAN_QUOTE = "supprime une dérogation aux seuils de qualité de l'eau";
+
+const PUBLIC_SELECT = {
+  title: true,
+  votingDate: true,
+  result: true,
+  chamber: true,
+  sourceUrl: true,
+  policyTitle: {
+    select: {
+      status: true,
+      policyTitle: true,
+      policySubtitle: true,
+      officialSourceUrl: true,
+      proceduralLabel: true,
+    },
+  },
+} as const;
+
+interface SeedOpts {
+  suffix: string;
+  confidence?: "HIGH" | "MEDIUM" | "LOW";
+  status?: "DRAFT" | "NEEDS_REVIEW" | "APPROVED" | "REJECTED" | "STALE";
+  generationSource?: "DETERMINISTIC" | "LLM" | "MANUAL" | "FALLBACK";
+  /** Hours in the past for generatedAt. Default 48 (clears the 24h age gate). */
+  ageHours?: number;
+}
+
+interface Seeded {
+  scrutinId: string;
+  amendmentId: string;
+}
+
+async function seedRow(opts: SeedOpts): Promise<Seeded> {
+  const ext = `${PFX}${opts.suffix}`;
+  const amendment = await db.amendment.create({
+    data: {
+      externalId: `${ext}_AMD`,
+      number: "100",
+      status: "ADOPTE",
+      legislature: 17,
+      chamber: "AN",
+      summary: SUMMARY,
+    },
+  });
+
+  const scrutin = await db.scrutin.create({
+    data: {
+      externalId: `${ext}_S`,
+      title: "Sous-amendement n° 100 sur la qualité de l'eau",
+      votingDate: new Date("2026-03-10T00:00:00Z"),
+      legislature: 17,
+      chamber: "AN",
+      votesFor: 50,
+      votesAgainst: 20,
+      votesAbstain: 5,
+      result: "ADOPTED",
+      sourceUrl: "https://www.assemblee-nationale.fr/test",
+      amendmentLinks: {
+        create: [{ amendmentId: amendment.id, role: "SUB_AMENDMENT", source: "TITLE_REGEX" }],
+      },
+    },
+  });
+
+  const label = "Sous-amendement n°100";
+  const resolved = await resolveSubstanceSources(scrutin.id);
+  const correctHash = computeInputHash(
+    buildInputHashInput(
+      {
+        title: scrutin.title,
+        sourceUrl: scrutin.sourceUrl,
+        amendmentLinks: [{ role: "SUB_AMENDMENT", amendment: { id: amendment.id, number: "100" } }],
+      },
+      label,
+      resolved.blocks
+    )
+  );
+
+  const ageHours = opts.ageHours ?? 48;
+  await db.scrutinPolicyTitle.create({
+    data: {
+      scrutinId: scrutin.id,
+      officialTitleSnapshot: scrutin.title,
+      officialSourceUrl: scrutin.sourceUrl,
+      inputHash: correctHash,
+      policyTitle: CLEAN_TITLE,
+      policySubtitle: null,
+      proceduralLabel: label,
+      confidence: opts.confidence ?? "HIGH",
+      generationSource: opts.generationSource ?? "LLM",
+      status: opts.status ?? "DRAFT",
+      qualitySignals: { substanceDepth: "subAmendment", evidenceCoverage: 0.6 },
+      evidenceQuotes: [
+        {
+          sourceType: "subAmendment",
+          sourceId: amendment.id,
+          field: "Amendment.summary",
+          quote: CLEAN_QUOTE,
+        },
+      ],
+      generationWarnings: [],
+      currentWarnings: [],
+      generatedAt: new Date(Date.now() - ageHours * 60 * 60 * 1000),
+    },
+  });
+
+  return { scrutinId: scrutin.id, amendmentId: amendment.id };
+}
+
+async function statusOf(scrutinId: string): Promise<string | undefined> {
+  const row = await db.scrutinPolicyTitle.findUnique({ where: { scrutinId } });
+  return row?.status;
+}
+
+async function cleanup() {
+  await db.scrutinAmendment.deleteMany({
+    where: { scrutin: { externalId: { startsWith: PFX } } },
+  });
+  await db.scrutinPolicyTitleRevision.deleteMany({
+    where: { policyTitle: { scrutin: { externalId: { startsWith: PFX } } } },
+  });
+  await db.scrutinPolicyTitle.deleteMany({
+    where: { scrutin: { externalId: { startsWith: PFX } } },
+  });
+  await db.amendment.deleteMany({ where: { externalId: { startsWith: PFX } } });
+  await db.scrutin.deleteMany({ where: { externalId: { startsWith: PFX } } });
+}
+
+describeIfDb("autoApproveBatchEligible", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ autoApproveBatchEligible, CRON_ACTOR } = await import("../approval"));
+    ({ toPublicTitleView } = await import("@/lib/votes/to-public-title-view"));
+    ({ buildInputHashInput } = await import("@/services/scrutin-policy-title"));
+    ({ computeInputHash } = await import("@/services/scrutin-policy-title/input-hash"));
+    ({ resolveSubstanceSources } =
+      await import("@/services/scrutin-policy-title/substance-resolver"));
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("approves an eligible HIGH DRAFT title older than 24h, attributed to the cron actor", async () => {
+    const { scrutinId } = await seedRow({ suffix: "OK", ageHours: 48 });
+
+    const stats = await autoApproveBatchEligible({ scrutinIds: [scrutinId] });
+
+    expect(stats.approved).toBe(1);
+    const row = await db.scrutinPolicyTitle.findUnique({ where: { scrutinId } });
+    expect(row?.status).toBe("APPROVED");
+    expect(row?.reviewedBy).toBe(CRON_ACTOR);
+    expect(row?.reviewedAt).not.toBeNull();
+
+    const rev = await db.scrutinPolicyTitleRevision.findFirst({
+      where: { policyTitleId: row!.id, action: "approved" },
+    });
+    expect(rev?.actorId).toBe(CRON_ACTOR);
+  });
+
+  it("skips a HIGH DRAFT title younger than 24h (age gate)", async () => {
+    const { scrutinId } = await seedRow({ suffix: "YOUNG", ageHours: 1 });
+
+    const stats = await autoApproveBatchEligible({ scrutinIds: [scrutinId] });
+
+    expect(stats.approved).toBe(0);
+    expect(stats.scanned).toBe(0); // excluded by the age filter, never scanned
+    expect(await statusOf(scrutinId)).toBe("DRAFT");
+  });
+
+  it("never approves NEEDS_REVIEW, even when HIGH and old", async () => {
+    const { scrutinId } = await seedRow({ suffix: "NR", status: "NEEDS_REVIEW", ageHours: 48 });
+
+    const stats = await autoApproveBatchEligible({ scrutinIds: [scrutinId] });
+
+    expect(stats.approved).toBe(0);
+    expect(await statusOf(scrutinId)).toBe("NEEDS_REVIEW");
+  });
+
+  it("skips MEDIUM and LOW confidence rows", async () => {
+    const med = await seedRow({ suffix: "MED", confidence: "MEDIUM", ageHours: 48 });
+    const low = await seedRow({ suffix: "LOW", confidence: "LOW", ageHours: 48 });
+
+    const stats = await autoApproveBatchEligible({
+      scrutinIds: [med.scrutinId, low.scrutinId],
+    });
+
+    expect(stats.approved).toBe(0);
+    expect(await statusOf(med.scrutinId)).toBe("DRAFT");
+    expect(await statusOf(low.scrutinId)).toBe("DRAFT");
+  });
+
+  it("skips FALLBACK rows", async () => {
+    const { scrutinId } = await seedRow({
+      suffix: "FB",
+      generationSource: "FALLBACK",
+      ageHours: 48,
+    });
+
+    const stats = await autoApproveBatchEligible({ scrutinIds: [scrutinId] });
+
+    expect(stats.approved).toBe(0);
+    expect(await statusOf(scrutinId)).toBe("DRAFT");
+  });
+
+  it("reuses the approval guard: skips a drifted row (INPUT_DRIFT)", async () => {
+    const { scrutinId, amendmentId } = await seedRow({ suffix: "DRIFT", ageHours: 48 });
+    // Mutate the amendment so the recomputed input hash no longer matches.
+    await db.amendment.update({
+      where: { id: amendmentId },
+      data: { summary: "Texte totalement différent et sans aucun rapport." },
+    });
+
+    const stats = await autoApproveBatchEligible({ scrutinIds: [scrutinId] });
+
+    expect(stats.approved).toBe(0);
+    expect(stats.byReason.INPUT_DRIFT).toBeGreaterThanOrEqual(1);
+    expect(await statusOf(scrutinId)).toBe("DRAFT");
+  });
+
+  it("public view: approved → policy title, unapproved → official title (no leak)", async () => {
+    const approved = await seedRow({ suffix: "PUB_OK", ageHours: 48 });
+    const young = await seedRow({ suffix: "PUB_YOUNG", ageHours: 1 });
+
+    await autoApproveBatchEligible({ scrutinIds: [approved.scrutinId, young.scrutinId] });
+
+    const approvedRow = await db.scrutin.findUnique({
+      where: { id: approved.scrutinId },
+      select: PUBLIC_SELECT,
+    });
+    const youngRow = await db.scrutin.findUnique({
+      where: { id: young.scrutinId },
+      select: PUBLIC_SELECT,
+    });
+
+    expect(toPublicTitleView(approvedRow!).mode).toBe("policy");
+    // The unapproved (young) row must still render its official title publicly.
+    const youngView = toPublicTitleView(youngRow!);
+    expect(youngView.mode).toBe("official");
+    expect(youngView.mode === "official" && youngView.officialTitle).toContain("Sous-amendement");
+  });
+});

--- a/src/services/scrutin-policy-title/approval.ts
+++ b/src/services/scrutin-policy-title/approval.ts
@@ -1,0 +1,276 @@
+/**
+ * Shared policy-title approval logic. Extracted verbatim from the admin server
+ * action so BOTH the admin UI (`/admin/policy-titles/actions.ts`, which adds auth
+ * + revalidatePath) and the daily cron (`autoApproveBatchEligible`) run the SAME
+ * eligibility guard and persistence — never a second copy of the rules.
+ *
+ * This module is server-only but NOT a "use server" file: it exports sync helpers
+ * and types, and is imported by both a server action and an Inngest function.
+ */
+import { db } from "@/lib/db";
+import {
+  approveGuard,
+  computeCurrentWarnings,
+  detectEvidenceDrift,
+} from "@/app/admin/policy-titles/approve-guard";
+import { buildInputHashInput } from "@/services/scrutin-policy-title";
+import { computeInputHash } from "@/services/scrutin-policy-title/input-hash";
+import { resolveSubstanceSources } from "@/services/scrutin-policy-title/substance-resolver";
+import type {
+  EvidenceQuote,
+  GenerationWarning,
+  SubstanceTextBlock,
+} from "@/services/scrutin-policy-title/types";
+import type { Prisma, ScrutinPolicyTitle } from "@/generated/prisma";
+import { POLICY_TITLE_CRON } from "@/config/policy-titles";
+
+/** Actor attributed to cron-driven (automated) approvals, distinct from the
+ *  admin UI's "admin" so the revision history shows which approvals were
+ *  automated. */
+export const CRON_ACTOR = "system:cron";
+
+export interface ApprovalContext {
+  row: ScrutinPolicyTitle;
+  scrutin: {
+    id: string;
+    title: string;
+    sourceUrl: string | null;
+    amendmentLinks: { role: string; amendment: { id: string; number: string } }[];
+  };
+  blocks: SubstanceTextBlock[];
+  currentInputHash: string;
+  currentWarnings: GenerationWarning[];
+  evidenceDrift: boolean;
+}
+
+export function asJson(value: unknown): Prisma.InputJsonValue {
+  return value as unknown as Prisma.InputJsonValue;
+}
+
+/** Snapshot of the row as stored, for revision history. */
+export function snapshot(row: ScrutinPolicyTitle): Prisma.InputJsonValue {
+  return row as unknown as Prisma.InputJsonValue;
+}
+
+/**
+ * Loads the row + scrutin and recomputes substance, input hash, validator
+ * warnings and evidence drift FRESH. Never trusts the stored values: every
+ * approval decision must reflect what the official text says today.
+ */
+export async function recomputeApprovalContext(scrutinId: string): Promise<ApprovalContext> {
+  const policy = await db.scrutinPolicyTitle.findUnique({
+    where: { scrutinId },
+    include: {
+      scrutin: {
+        select: {
+          id: true,
+          title: true,
+          sourceUrl: true,
+          amendmentLinks: {
+            select: { role: true, amendment: { select: { id: true, number: true } } },
+          },
+        },
+      },
+    },
+  });
+
+  if (!policy) throw new Error(`Aucun titre public pour le scrutin ${scrutinId}`);
+
+  const { scrutin, ...row } = policy;
+
+  const resolved = await resolveSubstanceSources(scrutinId);
+  const currentInputHash = computeInputHash(
+    buildInputHashInput(
+      {
+        title: scrutin.title,
+        sourceUrl: scrutin.sourceUrl,
+        amendmentLinks: scrutin.amendmentLinks.map((l) => ({
+          role: l.role,
+          amendment: { id: l.amendment.id, number: l.amendment.number },
+        })),
+      },
+      row.proceduralLabel,
+      resolved.blocks
+    )
+  );
+
+  const evidenceQuotes = (row.evidenceQuotes ?? []) as unknown as EvidenceQuote[];
+  const currentWarnings = computeCurrentWarnings(
+    row.policyTitle,
+    row.policySubtitle,
+    evidenceQuotes,
+    resolved.blocks
+  );
+  const evidenceDrift = detectEvidenceDrift(evidenceQuotes, resolved.blocks);
+
+  return {
+    row: policy as ScrutinPolicyTitle,
+    scrutin,
+    blocks: resolved.blocks,
+    currentInputHash,
+    currentWarnings,
+    evidenceDrift,
+  };
+}
+
+/** True when the row is REJECTED and its most-recent revision is a rejection. */
+export async function isRejectedNotRevised(row: ScrutinPolicyTitle): Promise<boolean> {
+  if (row.status !== "REJECTED") return false;
+  const latest = await db.scrutinPolicyTitleRevision.findFirst({
+    where: { policyTitleId: row.id },
+    orderBy: { createdAt: "desc" },
+  });
+  return latest?.action === "rejected";
+}
+
+/**
+ * Batch eligibility for a PRE-RECOMPUTED context. Runs the batch-mode guard
+ * (HIGH confidence, zero current warnings, no input/evidence drift,
+ * non-empty/<=140 title, no validation blocker) plus two explicit checks batch
+ * mode must never relax: zero generationWarnings and not a FALLBACK row. Returns
+ * the failure reasons, or an empty array when batch-eligible.
+ */
+export async function evaluateBatchEligibility(ctx: ApprovalContext): Promise<string[]> {
+  const { row, currentInputHash, currentWarnings, evidenceDrift } = ctx;
+  const reasons: string[] = [];
+
+  if (await isRejectedNotRevised(row)) {
+    reasons.push("REJECTED_NOT_REVISED");
+  }
+
+  const generationWarnings = (row.generationWarnings ?? []) as unknown as GenerationWarning[];
+  if (generationWarnings.length > 0) {
+    reasons.push("GENERATION_WARNINGS");
+  }
+  if (row.generationSource === "FALLBACK") {
+    reasons.push("FALLBACK_ROW");
+  }
+
+  const result = approveGuard({
+    row,
+    currentInputHash,
+    currentWarnings,
+    evidenceDrift,
+    mode: "batch",
+  });
+  if (!result.ok) {
+    for (const code of result.hardBlockers) reasons.push(code);
+    if (result.hardBlockers.length === 0) reasons.push("NOT_BATCH_CLEAN");
+  }
+
+  return reasons;
+}
+
+export interface PersistApprovalOptions {
+  /** Who is approving — "admin" for the UI, CRON_ACTOR for the cron. */
+  actor: string;
+  approvalOverride?: { reason: string; actor: string };
+}
+
+/** Persists APPROVED + the freshly recomputed hash/warnings + an "approved"
+ *  revision. Only ever called after evaluateBatchEligibility/approveGuard pass. */
+export async function persistApproval(
+  ctx: ApprovalContext,
+  { actor, approvalOverride }: PersistApprovalOptions
+): Promise<void> {
+  const { row, currentInputHash, currentWarnings } = ctx;
+  const reviewedAt = new Date();
+
+  await db.$transaction(async (tx) => {
+    await tx.scrutinPolicyTitleRevision.create({
+      data: {
+        policyTitleId: row.id,
+        snapshot: {
+          ...(snapshot(row) as object),
+          ...(approvalOverride ? { approvalOverride } : {}),
+        } as Prisma.InputJsonValue,
+        action: "approved",
+        actorId: actor,
+      },
+    });
+    await tx.scrutinPolicyTitle.update({
+      where: { id: row.id },
+      data: {
+        status: "APPROVED",
+        reviewedAt,
+        reviewedBy: actor,
+        inputHash: currentInputHash,
+        currentWarnings: asJson(currentWarnings),
+      },
+    });
+  });
+}
+
+export interface AutoApproveOptions {
+  /** Max DRAFT rows evaluated. Defaults to POLICY_TITLE_CRON.approveLimit. */
+  limit?: number;
+  /** Only approve titles at least this old. Defaults to approveMinAgeHours. */
+  minAgeHours?: number;
+  /** Approval actor. Defaults to CRON_ACTOR. */
+  actor?: string;
+  /** Restrict the scan to these scrutins. Omit to scan the whole eligible set
+   *  (the cron does); tests pass their seeded ids to stay scoped. */
+  scrutinIds?: string[];
+}
+
+export interface AutoApproveStats {
+  scanned: number;
+  approved: number;
+  skipped: number;
+  byReason: Record<string, number>;
+  durationMs: number;
+}
+
+/**
+ * Cron auto-approval. DELIBERATELY stricter than the manual batchApprove: it only
+ * considers DRAFT rows (NEEDS_REVIEW stays for human review even when HIGH), that
+ * are HIGH-confidence, non-FALLBACK, and at least `minAgeHours` old (a veto
+ * window). Each candidate is recomputed and run through the SAME shared
+ * `evaluateBatchEligibility` guard; only rows with zero failure reasons are
+ * approved. Never does a blunt UPDATE; never revalidates (public pages are ISR).
+ */
+export async function autoApproveBatchEligible(
+  opts: AutoApproveOptions = {}
+): Promise<AutoApproveStats> {
+  const startedAt = Date.now();
+  const limit = opts.limit ?? POLICY_TITLE_CRON.approveLimit;
+  const minAgeHours = opts.minAgeHours ?? POLICY_TITLE_CRON.approveMinAgeHours;
+  const actor = opts.actor ?? CRON_ACTOR;
+  const cutoff = new Date(startedAt - minAgeHours * 60 * 60 * 1000);
+
+  const candidates = await db.scrutinPolicyTitle.findMany({
+    where: {
+      status: "DRAFT",
+      confidence: "HIGH",
+      generationSource: { not: "FALLBACK" },
+      generatedAt: { lte: cutoff },
+      ...(opts.scrutinIds ? { scrutinId: { in: opts.scrutinIds } } : {}),
+    },
+    select: { scrutinId: true },
+    orderBy: { generatedAt: "asc" },
+    take: limit,
+  });
+
+  const stats: AutoApproveStats = {
+    scanned: candidates.length,
+    approved: 0,
+    skipped: 0,
+    byReason: {},
+    durationMs: 0,
+  };
+
+  for (const { scrutinId } of candidates) {
+    const ctx = await recomputeApprovalContext(scrutinId);
+    const reasons = await evaluateBatchEligibility(ctx);
+    if (reasons.length === 0) {
+      await persistApproval(ctx, { actor });
+      stats.approved++;
+    } else {
+      stats.skipped++;
+      for (const r of reasons) stats.byReason[r] = (stats.byReason[r] ?? 0) + 1;
+    }
+  }
+
+  stats.durationMs = Date.now() - startedAt;
+  return stats;
+}

--- a/src/services/sync/__tests__/amendments-an/normalize.test.ts
+++ b/src/services/sync/__tests__/amendments-an/normalize.test.ts
@@ -39,6 +39,39 @@ describe("normalizeAmendment", () => {
     expect(n.chamber).toBe("AN");
   });
 
+  it("decodes HTML entities in authorName and article (AN double-encoding)", () => {
+    const record = {
+      amendement: {
+        uid: "X",
+        identification: { numeroLong: "1" },
+        pointeurFragmentTexte: {
+          division: { articleDesignation: "APR&#200;S L&#39;ARTICLE 23" },
+        },
+        signataires: {
+          libelle: "Mme&#160;Blin, M.&#160;F&#233;gn&#233;",
+          auteur: { typeAuteur: "Député" },
+        },
+      },
+    };
+    const n = normalizeAmendment(record, {
+      dossierRefFromPath: null,
+      texteRefFromPath: null,
+      legislature: 17,
+    });
+    expect(n.authorName).toBe("Mme Blin, M. Fégné");
+    expect(n.article).toBe("APRÈS L'ARTICLE 23");
+  });
+
+  it("keeps content and summary as raw AN HTML (not decoded)", () => {
+    const n = normalizeAmendment(fx("sample-amendment.json"), {
+      dossierRefFromPath: null,
+      texteRefFromPath: null,
+      legislature: 17,
+    });
+    expect(n.content).toBe("<p>Supprimer l'alin&#xE9;a 3.</p>");
+    expect(n.summary).toBe("<p>Cet amendement supprime la d&#xE9;rogation.</p>");
+  });
+
   it("handles nil-objects as null and pending sort", () => {
     const n = normalizeAmendment(fx("nil-amendment.json"), {
       dossierRefFromPath: null,

--- a/src/services/sync/amendments-an/normalize.ts
+++ b/src/services/sync/amendments-an/normalize.ts
@@ -1,5 +1,17 @@
 import type { AmendmentStatus } from "@/generated/prisma";
+import { decodeHtmlEntities, normalizeWhitespace } from "@/lib/parsing/html-utils";
 import type { NormalizedAmendment } from "./types";
+
+/**
+ * Decode AN's double-encoded HTML entities in plain-text fields, preserving null.
+ *
+ * AN ships HTML inside XML, so a non-breaking space `&#160;` arrives as the literal
+ * text `&#160;` after the XML->JSON parse. authorName/article are rendered as plain
+ * text, so they must be decoded here. content/summary stay raw (HTML AN brut).
+ */
+function decodeText(v: string | null): string | null {
+  return v === null ? null : normalizeWhitespace(decodeHtmlEntities(v));
+}
 
 /** AN XML-derived JSON encodes nil as { "@xsi:nil": "true" }. */
 export function isNil(v: unknown): boolean {
@@ -60,14 +72,14 @@ export function normalizeAmendment(raw: unknown, ctx: NormalizeContext): Normali
     number: numberRaw ?? "",
     texteRef: str(get(a, "texteLegislatifRef")) ?? ctx.texteRefFromPath,
     dossierRefFromPath: ctx.dossierRefFromPath,
-    article: str(get(division, "articleDesignation")),
+    article: decodeText(str(get(division, "articleDesignation"))),
     content: str(get(corps, "dispositif")),
     summary: str(get(corps, "exposeSommaire")),
     status: mapStatus(get(cycleDeVie, "sort")),
     parentExternalId: str(get(a, "amendementParentRef")),
     identicalDiscussionId: str(get(discussionIdentique, "idDiscussion")),
     authorType: str(get(auteur, "typeAuteur")),
-    authorName: str(get(signataires, "libelle")),
+    authorName: decodeText(str(get(signataires, "libelle"))),
     legislature: ctx.legislature,
     chamber: "AN",
   };


### PR DESCRIPTION
## Contexte

Les titres de votes simplifiés (`ScrutinPolicyTitle`) sont en ligne depuis le go-live (1 808 titres APPROVED). Mais la chaîne qui les produit était **100 % manuelle** : import des amendements, liaison scrutin↔amendement, génération IA, puis approbation. Résultat, les votes récents prenaient du retard (titres bloqués en `NEEDS_REVIEW`/`DRAFT`, donc invisibles).

Cette PR rend la chaîne auto-entretenue via `sync-daily` (3×/jour) et la met sous surveillance santé.

## Ce que ça fait

Quatre steps ajoutés à `sync-daily`, bornés et idempotents, chacun isolé sur erreur comme les autres :

1. `amendments-an` — import delta (feed-state) des nouveaux amendements
2. `link-scrutins-amendments` — re-scan des scrutins récents, liaison des nouveaux
3. `generate-policy-titles` — génération IA (gardée par `MISTRAL_API_KEY`)
4. `approve-policy-titles` — auto-approbation des titres éligibles

### Règle d'auto-approbation (volontairement conservatrice)

`autoApproveBatchEligible` n'approuve qu'une ligne **DRAFT**, **HIGH-confidence**, **non-FALLBACK**, **zéro warning**, **sans dérive** (input/evidence), et **générée il y a ≥ 24 h** (fenêtre de veto). `NEEDS_REVIEW`, `MEDIUM`, `LOW`, `FALLBACK` restent en modération manuelle (décision explicite : `NEEDS_REVIEW` ne doit jamais passer par le cron). Acteur `system:cron` (distinct de `admin`) pour tracer les approbations automatiques dans l'historique des révisions.

## Architecture

La garde d'approbation **n'est pas dupliquée** : `recomputeApprovalContext`, `evaluateBatchEligibility` et `persistApproval` sont extraits de l'action admin vers un service partagé (`src/services/scrutin-policy-title/approval.ts`). L'action admin devient un wrapper (auth + `revalidatePath`) ; le cron appelle le même service. Une seule source de vérité pour les règles.

## Surveillance santé (pipeline-digest)

Les 4 steps sont suivis **séparément** (la chaîne est publique et en partie IA, donc pas de boîte noire) :

- chaque step appelle `syncMetadata.markCompleted("policy-titles:…", { itemCount, durationS, extra })` en cas de succès (compteurs dans `extra`) ;
- 4 entrées distinctes dans `PIPELINE_REGISTRY` (seuils `warn` 30 h / `critical` 72 h) ;
- le digest quotidien remonte donc tout maillon **périmé** (un step qui échoue cesse de mettre à jour son `lastSyncAt` → `warning` puis `critical`), avec dernier run et compteurs quand disponibles. Aucun bruit au démarrage : un step jamais exécuté est `unknown`, et le digest ne s'envoie que sur `warning`/`critical`.

Réutilise le mécanisme `SyncMetadata` existant, pas de nouvelle architecture.

## Sûreté

- Pas d'`UPDATE` brut : chaque approbation passe par la garde + transaction (révision + statut).
- Pas de `revalidatePath` depuis le cron : les pages publiques sont en ISR (listes 5 min, détail 1 h).
- Le contrat no-leak est préservé : une ligne non approuvée n'affiche jamais le titre simplifié (test dédié).
- Limites et `minAgeHours` configurables par env (`src/config/policy-titles.ts`), valeurs par défaut saines.

## Tests

- 7 tests pour `autoApproveBatchEligible` : éligible ≥24 h approuvé, <24 h ignoré, `NEEDS_REVIEW`/`MEDIUM`/`LOW`/`FALLBACK` ignorés, garde réutilisée (dérive → ignorée), acteur `system:cron`, vue publique no-leak.
- 3 tests registry : les 4 steps enregistrés avec leur clé, passage `warning`→`critical` quand le run se périme, `healthy` + compteurs juste après un run.
- Suite admin `policy-titles` complète au vert (71 tests) → l'extraction ne change pas le comportement.
- `npm run build` (typecheck + use-server + ISR) et `eslint` au vert.

## Effet public immédiat

Aucun. La fenêtre de 24 h fait que les premières auto-approbations interviendront ≥ 24 h après la prochaine génération de nouveaux votes. Pas de communication nécessaire (la fonctionnalité est déjà publique depuis le go-live).
