### PR TITLE
Cure la section Amendements des dossiers (stats + filtres)

### DIFF
--- a/src/app/api/dossiers/[id]/amendments/route.ts
+++ b/src/app/api/dossiers/[id]/amendments/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { withPublicRoute } from "@/lib/api/with-public-route";
+import { withCache } from "@/lib/cache";
+import { parsePagination } from "@/lib/api/pagination";
+import {
+  getCuratedAmendments,
+  AMENDMENT_FILTERS,
+  type AmendmentFilter,
+} from "@/lib/data/dossier-amendments";
+
+/**
+ * Curated, numerically-sorted amendments for a dossier, paginated.
+ * Public read-only data; cached on the "static" tier so it matches the dossier
+ * page's hourly ISR and avoids hitting the DB on every "Voir plus" click.
+ */
+export const GET = withPublicRoute(async (request, context) => {
+  const { id } = await context.params;
+
+  const url = new URL(request.url);
+  const filterParam = url.searchParams.get("filter") ?? "adopted";
+  const filter: AmendmentFilter = (AMENDMENT_FILTERS as string[]).includes(filterParam)
+    ? (filterParam as AmendmentFilter)
+    : "adopted";
+
+  // 1-based, clamped by the shared helper (CI bans inline parseInt for pagination).
+  const { page } = parsePagination(url.searchParams);
+
+  const result = await getCuratedAmendments(id!, filter, Math.min(page, 1000));
+  return withCache(NextResponse.json(result), "static");
+});

--- a/src/app/parlement/dossiers/[slug]/page.tsx
+++ b/src/app/parlement/dossiers/[slug]/page.tsx
@@ -11,16 +11,16 @@ import {
   DossierTimeline,
   DossierAuthors,
   DossierVotesList,
+  DossierAmendments,
 } from "@/components/legislation";
 import type { DossierTimelineEntry } from "@/types/legislation";
-import { AMENDMENT_STATUS_LABELS, AMENDMENT_STATUS_COLORS } from "@/config/labels";
+import { getAmendmentStats, getCuratedAmendments } from "@/lib/data/dossier-amendments";
 
-import { ExternalLink, Calendar, FileText, Vote } from "lucide-react";
+import { ExternalLink, Calendar, Vote } from "lucide-react";
 import { LegislationJsonLd } from "@/components/seo/JsonLd";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { SITE_URL } from "@/config/site";
 import { formatDate } from "@/lib/utils";
-import { extractText } from "@/lib/parsing/html-utils";
 import type { MandateType } from "@/generated/prisma";
 
 export const revalidate = 3600; // ISR: revalidate every hour
@@ -39,10 +39,6 @@ interface PageProps {
 }
 
 const includeOptions = {
-  amendments: {
-    orderBy: { number: "asc" },
-    take: 50,
-  },
   authors: {
     select: {
       role: true,
@@ -177,6 +173,13 @@ export default async function DossierDetailPage({ params }: PageProps) {
     notFound();
   }
 
+  // Curated amendments: stats + the first "adopted" page rendered server-side
+  // (SEO / no-JS); the client component paginates and switches filters from there.
+  const [amendmentStats, initialAmendments] = await Promise.all([
+    getAmendmentStats(dossier.id),
+    getCuratedAmendments(dossier.id, "adopted", 1),
+  ]);
+
   return (
     <>
       <LegislationJsonLd
@@ -271,50 +274,13 @@ export default async function DossierDetailPage({ params }: PageProps) {
         )}
 
         {/* Amendments */}
-        {dossier.amendments.length > 0 && (
-          <Card className="mb-8">
-            <CardHeader>
-              <CardTitle className="text-lg flex items-center gap-2">
-                <FileText className="h-5 w-5" />
-                Amendements ({dossier.amendments.length})
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                {dossier.amendments.map((amendment) => (
-                  <div
-                    key={amendment.id}
-                    className="flex items-start justify-between gap-4 py-3 border-b last:border-0"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <Badge variant="outline" className="font-mono">
-                          N° {amendment.number}
-                        </Badge>
-                        <Badge className={AMENDMENT_STATUS_COLORS[amendment.status]}>
-                          {AMENDMENT_STATUS_LABELS[amendment.status]}
-                        </Badge>
-                      </div>
-                      {amendment.authorName && (
-                        <p className="text-sm text-muted-foreground">
-                          Par {extractText(amendment.authorName)}
-                          {amendment.authorType && ` (${amendment.authorType})`}
-                        </p>
-                      )}
-                      {amendment.article && (
-                        <p className="text-sm text-muted-foreground">
-                          Article {extractText(amendment.article)}
-                        </p>
-                      )}
-                      {amendment.summary && (
-                        <p className="text-sm mt-2">{extractText(amendment.summary)}</p>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+        {amendmentStats.total > 0 && (
+          <DossierAmendments
+            dossierId={dossier.id}
+            stats={amendmentStats}
+            sourceUrl={dossier.sourceUrl}
+            initial={initialAmendments}
+          />
         )}
 
         {/* External link */}

--- a/src/components/legislation/DossierAmendments.tsx
+++ b/src/components/legislation/DossierAmendments.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FileText, ExternalLink, Loader2 } from "lucide-react";
+import { AMENDMENT_STATUS_LABELS, AMENDMENT_STATUS_COLORS } from "@/config/labels";
+import type { AmendmentStatus } from "@/generated/prisma";
+import type {
+  AmendmentFilter,
+  AmendmentStats,
+  CuratedAmendment,
+  CuratedAmendmentsPage,
+} from "@/lib/data/dossier-amendments";
+
+interface FilterState {
+  items: CuratedAmendment[];
+  page: number;
+  total: number;
+  hasMore: boolean;
+  capped: boolean;
+}
+
+const FILTER_LABELS: Record<AmendmentFilter, string> = {
+  adopted: "Adoptés",
+  rejected: "Rejetés",
+  "with-content": "Tous les amendements utiles",
+};
+
+// Grammatically correct empty-state per filter (the button labels don't compose
+// into a clean sentence).
+const FILTER_EMPTY: Record<AmendmentFilter, string> = {
+  adopted: "Aucun amendement adopté avec contenu exploitable.",
+  rejected: "Aucun amendement rejeté avec contenu exploitable.",
+  "with-content": "Aucun amendement avec contenu exploitable.",
+};
+
+// Stats line order (most meaningful first). AMENDMENT_STATUS_LABELS is singular,
+// so the count line needs its own plurals.
+const STAT_ORDER: AmendmentStatus[] = ["ADOPTE", "REJETE", "TOMBE", "DEPOSE", "RETIRE"];
+const STAT_PLURAL: Record<AmendmentStatus, string> = {
+  ADOPTE: "adoptés",
+  REJETE: "rejetés",
+  TOMBE: "tombés",
+  DEPOSE: "déposés",
+  RETIRE: "retirés",
+};
+
+interface Props {
+  dossierId: string;
+  stats: AmendmentStats;
+  sourceUrl: string | null;
+  /** Server-rendered first page (default "adopted" filter) for SEO and no-JS. */
+  initial: CuratedAmendmentsPage;
+}
+
+export function DossierAmendments({ dossierId, stats, sourceUrl, initial }: Props) {
+  const [filter, setFilter] = useState<AmendmentFilter>(initial.filter);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  // Per-filter cache so switching tabs (or back) doesn't refetch.
+  const cache = useRef<Map<AmendmentFilter, FilterState>>(
+    new Map([
+      [
+        initial.filter,
+        {
+          items: initial.items,
+          page: 1,
+          total: initial.total,
+          hasMore: initial.hasMore,
+          capped: initial.capped,
+        },
+      ],
+    ])
+  );
+  const [, forceRender] = useState(0);
+  const rerender = () => forceRender((n) => n + 1);
+
+  const current = cache.current.get(filter);
+
+  const load = useCallback(
+    async (f: AmendmentFilter, page: number) => {
+      setLoading(true);
+      setError(false);
+      try {
+        const res = await fetch(`/api/dossiers/${dossierId}/amendments?filter=${f}&page=${page}`);
+        if (!res.ok) throw new Error(String(res.status));
+        const data: CuratedAmendmentsPage = await res.json();
+        const prev = cache.current.get(f);
+        cache.current.set(f, {
+          items: page <= 1 ? data.items : [...(prev?.items ?? []), ...data.items],
+          page,
+          total: data.total,
+          hasMore: data.hasMore,
+          capped: data.capped,
+        });
+        rerender();
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [dossierId]
+  );
+
+  const selectFilter = (f: AmendmentFilter) => {
+    setFilter(f);
+    setError(false);
+    if (!cache.current.has(f)) void load(f, 1);
+  };
+
+  const loadMore = () => {
+    if (current) void load(filter, current.page + 1);
+  };
+
+  const statsLine = STAT_ORDER.filter((s) => stats.byStatus[s] > 0)
+    .map((s) => `${stats.byStatus[s].toLocaleString("fr-FR")} ${STAT_PLURAL[s]}`)
+    .join(" · ");
+
+  const filterCount: Partial<Record<AmendmentFilter, number>> = {
+    adopted: stats.byStatus.ADOPTE,
+    rejected: stats.byStatus.REJETE,
+  };
+
+  return (
+    <Card className="mb-8">
+      <CardHeader>
+        <CardTitle className="text-lg flex items-center gap-2">
+          <FileText className="h-5 w-5" />
+          Amendements ({stats.total.toLocaleString("fr-FR")})
+        </CardTitle>
+        <p className="text-sm text-muted-foreground mt-1">{statsLine}</p>
+        {sourceUrl && (
+          <a
+            href={sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-primary hover:underline inline-flex items-center gap-1 mt-1 w-fit"
+          >
+            Liste exhaustive sur AN.fr
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        )}
+      </CardHeader>
+      <CardContent>
+        {/* Filters */}
+        <div
+          className="flex flex-wrap gap-2 mb-4"
+          role="group"
+          aria-label="Filtrer les amendements"
+        >
+          {(Object.keys(FILTER_LABELS) as AmendmentFilter[]).map((f) => (
+            <Button
+              key={f}
+              size="sm"
+              variant={filter === f ? "default" : "outline"}
+              onClick={() => selectFilter(f)}
+              aria-pressed={filter === f}
+            >
+              {FILTER_LABELS[f]}
+              {filterCount[f] !== undefined && ` (${filterCount[f]!.toLocaleString("fr-FR")})`}
+            </Button>
+          ))}
+        </div>
+
+        {/* List */}
+        {current && current.items.length > 0 ? (
+          <div className="space-y-3">
+            {current.items.map((a) => (
+              <div key={a.id} className="py-3 border-b last:border-0">
+                <div className="flex items-center gap-2 mb-1 flex-wrap">
+                  <Badge variant="outline" className="font-mono">
+                    N° {a.number}
+                  </Badge>
+                  <Badge className={AMENDMENT_STATUS_COLORS[a.status]}>
+                    {AMENDMENT_STATUS_LABELS[a.status]}
+                  </Badge>
+                  {a.articleLabel && (
+                    <span className="text-sm text-muted-foreground">{a.articleLabel}</span>
+                  )}
+                </div>
+                {a.authorName && (
+                  <p className="text-sm text-muted-foreground">
+                    Par {a.authorName}
+                    {a.authorType && ` (${a.authorType})`}
+                  </p>
+                )}
+                {a.excerpt && <p className="text-sm mt-2">{a.excerpt}</p>}
+              </div>
+            ))}
+          </div>
+        ) : (
+          !loading &&
+          !error && <p className="text-sm text-muted-foreground py-4">{FILTER_EMPTY[filter]}</p>
+        )}
+
+        {/* Loading / error / pagination */}
+        {error && (
+          <div className="text-sm text-muted-foreground py-4">
+            Le chargement a échoué.{" "}
+            <button
+              type="button"
+              onClick={() => load(filter, current?.page ?? 1)}
+              className="text-primary hover:underline"
+            >
+              Réessayer
+            </button>
+          </div>
+        )}
+
+        {current?.hasMore && (
+          <div className="mt-4 flex justify-center">
+            <Button variant="outline" size="sm" onClick={loadMore} disabled={loading}>
+              {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+              Voir plus
+            </Button>
+          </div>
+        )}
+
+        {loading && !current?.items.length && (
+          <div className="flex justify-center py-4">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {/* Cap reached: the list is deliberately bounded, point readers to AN.fr. */}
+        {filter === "with-content" && current?.capped && !current.hasMore && (
+          <p className="text-sm text-muted-foreground mt-4 text-center">
+            La liste affichée est volontairement limitée pour rester lisible. Pour consulter tous
+            les amendements,{" "}
+            {sourceUrl ? (
+              <a
+                href={sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                voir AN.fr
+              </a>
+            ) : (
+              "voir AN.fr"
+            )}
+            .
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/legislation/index.ts
+++ b/src/components/legislation/index.ts
@@ -6,3 +6,4 @@ export { DossierAuthors } from "./DossierAuthors";
 export { DossierFilterBar } from "./DossierFilterBar";
 export { DossierPPLStats } from "./DossierPPLStats";
 export { DossierVotesList } from "./DossierVotesList";
+export { DossierAmendments } from "./DossierAmendments";

--- a/src/lib/data/amendment-format.test.ts
+++ b/src/lib/data/amendment-format.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  amendmentNumberSortKey,
+  compareAmendmentNumbers,
+  formatArticleLabel,
+} from "./amendment-format";
+
+describe("amendmentNumberSortKey", () => {
+  it("extracts the embedded integer", () => {
+    expect(amendmentNumberSortKey("600")).toBe(600);
+    expect(amendmentNumberSortKey("600 (Rect)")).toBe(600);
+    expect(amendmentNumberSortKey("CD332")).toBe(332);
+    expect(amendmentNumberSortKey("I-390")).toBe(390);
+  });
+  it("returns null when there is no digit", () => {
+    expect(amendmentNumberSortKey("ABC")).toBeNull();
+    expect(amendmentNumberSortKey("")).toBeNull();
+  });
+});
+
+describe("compareAmendmentNumbers", () => {
+  it("sorts numerically rather than as strings", () => {
+    const input = ["10", "1", "100", "2", "1000"];
+    expect([...input].sort(compareAmendmentNumbers)).toEqual(["1", "2", "10", "100", "1000"]);
+  });
+  it("places a plain number before its rectified variant", () => {
+    expect(compareAmendmentNumbers("600", "600 (Rect)")).toBeLessThan(0);
+  });
+  it("orders commission-prefixed numbers by their integer part", () => {
+    // CE135 (135) before CD332 (332), regardless of the alphabetical prefix.
+    expect(["CD332", "CE135"].sort(compareAmendmentNumbers)).toEqual(["CE135", "CD332"]);
+  });
+  it("pushes digit-less values to the end", () => {
+    expect(["ABC", "5", "12"].sort(compareAmendmentNumbers)).toEqual(["5", "12", "ABC"]);
+  });
+});
+
+describe("formatArticleLabel", () => {
+  it("strips the insert-article formula and sentence-cases", () => {
+    expect(formatArticleLabel("APRÈS L'ARTICLE 11, insérer l'article suivant:")).toBe(
+      "Après l'article 11"
+    );
+  });
+  it("sentence-cases plain all-caps designations", () => {
+    expect(formatArticleLabel("ARTICLE 10")).toBe("Article 10");
+    expect(formatArticleLabel("ARTICLE PREMIER")).toBe("Article premier");
+    expect(formatArticleLabel("ARTICLE 9 BIS")).toBe("Article 9 bis");
+  });
+  it("leaves mixed-case input untouched", () => {
+    expect(formatArticleLabel("Article 10")).toBe("Article 10");
+  });
+});

--- a/src/lib/data/amendment-format.ts
+++ b/src/lib/data/amendment-format.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure formatting helpers for AN amendment numbers and article designations.
+ * Used by the curated dossier amendments view and unit-tested in isolation.
+ */
+
+/**
+ * Extract the first integer embedded in an AN amendment number, for numeric sort.
+ *
+ * AN numbers are not always plain integers: commission amendments are prefixed
+ * ("CD332", "CE135"), some carry a rectification suffix ("600 (Rect)"), a few use
+ * other separators ("I-390"). We sort on the embedded integer and fall back to a
+ * string compare for ties and digit-less values.
+ *
+ * @returns the integer, or null when the value contains no digit.
+ */
+export function amendmentNumberSortKey(value: string): number | null {
+  const match = value.match(/\d+/);
+  return match ? parseInt(match[0], 10) : null;
+}
+
+/**
+ * Compare two AN amendment numbers numerically, digit-less values last.
+ * Ties break on the original string so "600" precedes "600 (Rect)" deterministically.
+ */
+export function compareAmendmentNumbers(a: string, b: string): number {
+  const ka = amendmentNumberSortKey(a);
+  const kb = amendmentNumberSortKey(b);
+  if (ka === null && kb === null) return a.localeCompare(b, "fr");
+  if (ka === null) return 1;
+  if (kb === null) return -1;
+  if (ka !== kb) return ka - kb;
+  return a.localeCompare(b, "fr");
+}
+
+// AN appends this formula to amendments that insert a brand-new article; it adds
+// no information once the dispositif/exposé is shown, so we strip it.
+const INSERT_FORMULA = /,?\s*ins[eé]rer\s+l['’]article\s+suivant\s*:?\s*$/i;
+
+/**
+ * Turn AN's verbose, all-caps article designation into a short readable label.
+ *
+ * "APRÈS L'ARTICLE 11, insérer l'article suivant:" -> "Après l'article 11"
+ * "ARTICLE 10" -> "Article 10"; "ARTICLE PREMIER" -> "Article premier"
+ *
+ * Mixed-case input is left untouched (only AN's ALL-CAPS values are sentence-cased).
+ */
+export function formatArticleLabel(article: string): string {
+  let s = article.trim().replace(INSERT_FORMULA, "").trim();
+  if (s.length > 0 && !/[a-zà-ÿ]/.test(s)) {
+    s = s.toLowerCase();
+    s = s.charAt(0).toUpperCase() + s.slice(1);
+  }
+  return s;
+}

--- a/src/lib/data/dossier-amendments.ts
+++ b/src/lib/data/dossier-amendments.ts
@@ -1,0 +1,144 @@
+import { db } from "@/lib/db";
+import { extractText } from "@/lib/parsing/html-utils";
+import type { AmendmentStatus, Prisma } from "@/generated/prisma";
+import { compareAmendmentNumbers, formatArticleLabel } from "./amendment-format";
+
+export type AmendmentFilter = "adopted" | "rejected" | "with-content";
+
+export const AMENDMENT_FILTERS: AmendmentFilter[] = ["adopted", "rejected", "with-content"];
+export const AMENDMENTS_PAGE_SIZE = 20;
+/**
+ * Hard cap on the "with-content" filter: Poligraph helps readers understand a
+ * dossier, it is not a paginated mirror of AN.fr. Beyond this, link out to AN.
+ */
+export const ALL_WITH_CONTENT_CAP = 200;
+const EXCERPT_LENGTH = 400;
+
+export interface CuratedAmendment {
+  id: string;
+  number: string;
+  status: AmendmentStatus;
+  articleLabel: string | null;
+  authorName: string | null;
+  authorType: string | null;
+  excerpt: string | null;
+}
+
+export interface AmendmentStats {
+  total: number;
+  byStatus: Record<AmendmentStatus, number>;
+}
+
+export interface CuratedAmendmentsPage {
+  filter: AmendmentFilter;
+  items: CuratedAmendment[];
+  /** Total amendments matching the filter (clamped to the cap for "with-content"). */
+  total: number;
+  hasMore: boolean;
+  /** True when "with-content" matches more than the cap and we stopped at it. */
+  capped: boolean;
+}
+
+function filterWhere(dossierId: string, filter: AmendmentFilter): Prisma.AmendmentWhereInput {
+  // Boilerplate amendments (author + "insérer l'article suivant:" with no exposé
+  // nor dispositif) carry no citizen value and are excluded from every filter.
+  const base: Prisma.AmendmentWhereInput = {
+    dossierId,
+    OR: [{ summary: { not: null } }, { content: { not: null } }],
+  };
+  if (filter === "adopted") return { ...base, status: "ADOPTE" };
+  if (filter === "rejected") return { ...base, status: "REJETE" };
+  return base; // with-content: any status, content required
+}
+
+function toExcerpt(summary: string | null, content: string | null): string | null {
+  const raw = summary ?? content;
+  if (!raw) return null;
+  const text = extractText(raw);
+  if (text.length <= EXCERPT_LENGTH) return text;
+  return text.slice(0, EXCERPT_LENGTH).trimEnd() + "…";
+}
+
+/** Counts by status (and total) for the dossier's amendments. */
+export async function getAmendmentStats(dossierId: string): Promise<AmendmentStats> {
+  const grouped = await db.amendment.groupBy({
+    by: ["status"],
+    where: { dossierId },
+    _count: true,
+  });
+  const byStatus: Record<AmendmentStatus, number> = {
+    DEPOSE: 0,
+    ADOPTE: 0,
+    REJETE: 0,
+    RETIRE: 0,
+    TOMBE: 0,
+  };
+  let total = 0;
+  for (const g of grouped) {
+    byStatus[g.status] = g._count;
+    total += g._count;
+  }
+  return { total, byStatus };
+}
+
+/**
+ * One page of curated amendments for a dossier.
+ *
+ * Two-step to keep payloads small and the sort correct: (1) fetch lightweight
+ * {id, number} for every match and sort numerically in JS (Prisma can't ORDER BY a
+ * computed numeric key on a String column); (2) fetch the full rows for the page slice
+ * only. The "with-content" filter is clamped to ALL_WITH_CONTENT_CAP.
+ */
+export async function getCuratedAmendments(
+  dossierId: string,
+  filter: AmendmentFilter,
+  page: number // 1-based, matching parsePagination()
+): Promise<CuratedAmendmentsPage> {
+  const where = filterWhere(dossierId, filter);
+
+  const keys = await db.amendment.findMany({ where, select: { id: true, number: true } });
+  keys.sort((a, b) => compareAmendmentNumbers(a.number, b.number));
+
+  const capped = filter === "with-content" && keys.length > ALL_WITH_CONTENT_CAP;
+  const sorted = capped ? keys.slice(0, ALL_WITH_CONTENT_CAP) : keys;
+  const total = sorted.length;
+
+  const start = Math.max(0, page - 1) * AMENDMENTS_PAGE_SIZE;
+  const pageKeys = sorted.slice(start, start + AMENDMENTS_PAGE_SIZE);
+  const hasMore = start + AMENDMENTS_PAGE_SIZE < total;
+
+  if (pageKeys.length === 0) {
+    return { filter, items: [], total, hasMore: false, capped };
+  }
+
+  const rows = await db.amendment.findMany({
+    where: { id: { in: pageKeys.map((k) => k.id) } },
+    select: {
+      id: true,
+      number: true,
+      status: true,
+      article: true,
+      authorName: true,
+      authorType: true,
+      summary: true,
+      content: true,
+    },
+  });
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  // Preserve the numeric sort order from the key list.
+  const items: CuratedAmendment[] = pageKeys.map((k) => {
+    const r = byId.get(k.id)!;
+    return {
+      id: r.id,
+      number: r.number,
+      status: r.status,
+      articleLabel: r.article ? formatArticleLabel(extractText(r.article)) : null,
+      authorName: r.authorName ? extractText(r.authorName) : null,
+      authorType: r.authorType,
+      excerpt: toExcerpt(r.summary, r.content),
+    };
+  });
+
+  return { filter, items, total, hasMore, capped };
+}


### PR DESCRIPTION
## Pourquoi
La section Amendements affichait un dump brut (~4 000), trié comme du texte
(1, 10, 100, 1000…), avec des lignes vides « auteur + insérer l'article suivant: ».

## Quoi
- Stats par statut + lien liste exhaustive AN.fr
- Filtres Adoptés / Rejetés / Tous les amendements utiles (cap dur 200 → AN.fr)
- Boilerplate (ni exposé ni dispositif) masqué partout
- Tri numérique réel (gestion CD/CE et « (Rect) »)
- 1ʳᵉ page Adoptés en SSR (SEO/no-JS) ; pagination/filtres via Route Handler GET
  caché s-maxage=3600 (cohérent avec l'ISR de la page)

## Tests
Unitaires (tri, label, exclusion boilerplate) + typecheck + lint. Vérifié sur prod
(loi Duplomb, 3 977 amendements).

## Communication — APRÈS vérification visuelle post-déploiement
- [ ] Bluesky / Twitter   - [ ] HelloAsso   - [ ] Tipeee

## Audit — post-déploiement
- [ ] Lighthouse (page dossier)
- [ ] axe / a11y (onglets de filtre : focus, aria-pressed, contraste)
- [ ] Confirmer page statique/ISR (cache-control, ƒ→● au build)
