### PR TITLE
Skip l'analyse des enjeux sans transcript de débat

### DIFF
--- a/src/services/sync/__tests__/scrutin-analysis-guard.test.ts
+++ b/src/services/sync/__tests__/scrutin-analysis-guard.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Controlled DB + Mistral mocks: no real database, no network.
+const findMany = vi.fn();
+const upsert = vi.fn();
+vi.mock("@/lib/db", () => ({
+  db: {
+    scrutin: { findMany: (...a: unknown[]) => findMany(...a) },
+    scrutinAnalysis: { upsert: (...a: unknown[]) => upsert(...a) },
+  },
+}));
+
+const callMistral = vi.fn();
+const extractMistralText = vi.fn();
+const parseMistralJSON = vi.fn();
+vi.mock("@/lib/api/mistral", () => ({
+  callMistral: (...a: unknown[]) => callMistral(...a),
+  extractMistralText: (...a: unknown[]) => extractMistralText(...a),
+  parseMistralJSON: (...a: unknown[]) => parseMistralJSON(...a),
+}));
+
+import { generateScrutinAnalysis } from "../scrutin-analysis";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function keyVoteScrutin(debate: string | null): any {
+  return {
+    id: "s1",
+    title: "l'amendement n° 2084 de Mme Lechon après l'article 22 ...",
+    result: "REJECTED",
+    votesFor: 37,
+    votesAgainst: 38,
+    votesAbstain: 2,
+    groupPositions: [
+      {
+        group: { name: "Rassemblement National", code: "RN" },
+        position: "POUR",
+        forCount: 34,
+        againstCount: 0,
+        abstainCount: 0,
+      },
+    ],
+    debateTranscripts: debate ? [{ content: debate }] : [],
+    dossierLegislatif: { title: "Projet de loi d'urgence agricole" },
+  };
+}
+
+describe("generateScrutinAnalysis — no-debate guard", () => {
+  beforeEach(() => {
+    findMany.mockReset();
+    upsert.mockReset();
+    callMistral.mockReset();
+    extractMistralText.mockReset();
+    parseMistralJSON.mockReset();
+  });
+
+  it("skips a scrutin with no usable debate transcript: no model call, no write", async () => {
+    findMany.mockResolvedValue([keyVoteScrutin(null)]);
+
+    const res = await generateScrutinAnalysis({ limit: 10 });
+
+    expect(callMistral).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+    expect(res.generated).toBe(0);
+    expect(res.skipped).toBeGreaterThanOrEqual(1);
+  });
+
+  it("still generates when a debate transcript is available", async () => {
+    findMany.mockResolvedValue([
+      keyVoteScrutin("M. X a défendu le texte en séance ; Mme Y s'y est opposée."),
+    ]);
+    callMistral.mockResolvedValue({});
+    extractMistralText.mockReturnValue("{}");
+    parseMistralJSON.mockReturnValue({
+      argumentsFor: "Les partisans ont mis en avant la transparence.",
+      argumentsAgainst: "Les opposants ont pointé une complexité accrue.",
+    });
+
+    const res = await generateScrutinAnalysis({ limit: 10 });
+
+    expect(callMistral).toHaveBeenCalledTimes(1);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(res.generated).toBe(1);
+  });
+});

--- a/src/services/sync/scrutin-analysis.ts
+++ b/src/services/sync/scrutin-analysis.ts
@@ -175,6 +175,16 @@ export async function generateScrutinAnalysis(
 
   for (const s of scrutins) {
     try {
+      // Per-group arguments must come from a real debate. With no usable
+      // transcript the model has no argumentative source and fabricates group
+      // positions (see scrutin 2084). Skip rather than invent: no model call,
+      // no write. A future PR will also anchor the topic on the linked amendment.
+      const debateExcerpt = s.debateTranscripts[0]?.content?.trim();
+      if (!debateExcerpt) {
+        skipped++;
+        continue;
+      }
+
       const prompt = buildAnalysisPrompt({
         title: s.title,
         result: s.result,
@@ -188,7 +198,7 @@ export async function generateScrutinAnalysis(
           againstCount: gp.againstCount,
           abstainCount: gp.abstainCount,
         })),
-        debateExcerpt: s.debateTranscripts[0]?.content ?? null,
+        debateExcerpt,
         dossierContext: s.dossierLegislatif?.title ?? null,
       });
 


### PR DESCRIPTION
## Hotfix ciblé

Le bloc « Les enjeux du vote » (`ScrutinAnalysis.argumentsFor/argumentsAgainst`) affichait des arguments pour/contre **fabriqués** quand aucun débat n'était disponible.

Cas réel ([scrutin 2084](https://poligraph.fr/parlement/votes/2026-05-30-l-amendement-n-2084-de-mme-lechon-apres-l-article-22-du-projet-de-loi-d-urgence-pour-la-protection-et-la)) : `sourceType: STRUCTURED_DATA`, `debateTranscripts: 0`. Le seul input du modèle était le libellé procédural + les compteurs de votes. Il a inventé des arguments sur l'interdiction d'importations à bas prix, avec de fausses attributions (« référence aux débats sur l'article 22 ») alors qu'aucun débat n'était fourni.

## Correctif (minimal)

Dans `generateScrutinAnalysis`, si aucun `debateTranscript` exploitable n'est disponible : on ne construit pas le prompt, on n'appelle pas le modèle, on ne persiste rien (`skipped++`).

C'est volontairement minimal. La refonte complète (`scrutin-analysis`) suivra dans une PR dédiée : ancrage sur `resolveSubstanceSources` (l'amendement = « ce qui est voté »), débats = « pourquoi les groupes votent », audit dry-run des 159 analyses amendment-linked, garde-fous de cohérence.

## Tests

`npx vitest run src/services/sync/__tests__/scrutin-analysis-guard.test.ts` → 2 passed :
- pas de débat → aucun appel modèle, aucune écriture, `skipped`
- débat présent → génération inchangée

## Suivi prod

La ligne `ScrutinAnalysis` du scrutin 2084 sera supprimée une fois ce garde-fou déployé, pour masquer immédiatement le bloc faux. Le garde-fou empêche le cron quotidien de le re-fabriquer. Aucun backfill dans cette PR.