### PR TITLE
Matcher pur + resolver read-only débat ↔ scrutin (calibration AN initiale)

### DIFF
--- a/scripts/audit-debate-context.ts
+++ b/scripts/audit-debate-context.ts
@@ -1,0 +1,50 @@
+/**
+ * READ-ONLY audit: for amendment-linked scrutins that have a "Les enjeux"
+ * analysis, report whether a candidate debate transcript actually mentions the
+ * voted amendment, and how strongly. No model call, NO DB write.
+ *
+ *   npx dotenv -e .env -- npx tsx scripts/audit-debate-context.ts --limit 50
+ */
+import { db } from "@/lib/db";
+import { auditDebateContextForAmendmentAnalyses } from "@/services/scrutin-substance/debate-context-resolver";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.findIndex((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+  if (i < 0) return undefined;
+  const v = process.argv[i]!;
+  return v.includes("=") ? v.split("=").slice(1).join("=") : process.argv[i + 1];
+}
+function log(line = ""): void {
+  // eslint-disable-next-line no-console
+  console.log(line);
+}
+
+async function main(): Promise<void> {
+  const limit = arg("limit") ? Number(arg("limit")) : undefined;
+  log(
+    `=== Debate context audit (amendment-linked analyses)${limit ? ` — limit ${limit}` : ""} ===\n`
+  );
+
+  const report = await auditDebateContextForAmendmentAnalyses(limit ? { limit } : {});
+
+  log(`scanned : ${report.scanned}`);
+  log(
+    `HIGH=${report.byConfidence.HIGH}  MEDIUM=${report.byConfidence.MEDIUM}  LOW=${report.byConfidence.LOW}  NONE=${report.byConfidence.NONE}`
+  );
+  const usable = report.rows.filter((r) => r.usableForGeneration).length;
+  log(`usableForGeneration (HIGH only) : ${usable}\n`);
+
+  // Show the HIGH matches (the only ones a future generation could trust).
+  for (const r of report.rows.filter((r) => r.confidence === "HIGH")) {
+    log(`─ HIGH  amendement ${r.amendment}  ${r.slug ?? r.scrutinId}`);
+    log(`  ${r.excerpt}`);
+  }
+}
+
+main()
+  .catch((e) => {
+    // eslint-disable-next-line no-console
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/audit-debate-context.ts
+++ b/scripts/audit-debate-context.ts
@@ -27,12 +27,15 @@ async function main(): Promise<void> {
 
   const report = await auditDebateContextForAmendmentAnalyses(limit ? { limit } : {});
 
+  log("candidate transcript scope = same-day only, not yet dossier/session-disambiguated.\n");
   log(`scanned : ${report.scanned}`);
   log(
     `HIGH=${report.byConfidence.HIGH}  MEDIUM=${report.byConfidence.MEDIUM}  LOW=${report.byConfidence.LOW}  NONE=${report.byConfidence.NONE}`
   );
   const usable = report.rows.filter((r) => r.usableForGeneration).length;
-  log(`usableForGeneration (HIGH only) : ${usable}\n`);
+  const ambiguousDay = report.rows.filter((r) => r.candidateTranscriptCount > 1).length;
+  log(`usableForGeneration (HIGH only) : ${usable}`);
+  log(`jours ambigus (plusieurs transcripts candidats le même jour) : ${ambiguousDay}\n`);
 
   // Show the HIGH matches (the only ones a future generation could trust).
   for (const r of report.rows.filter((r) => r.confidence === "HIGH")) {

--- a/src/services/scrutin-substance/__tests__/debate-context-resolver.test.ts
+++ b/src/services/scrutin-substance/__tests__/debate-context-resolver.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+
+// db is imported by the resolver module but never queried by extractAuthorSurname.
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { extractAuthorSurname } from "@/services/scrutin-substance/debate-context-resolver";
+
+describe("extractAuthorSurname", () => {
+  it("cleans AN HTML entities and the civility prefix, keeps the first surname", () => {
+    expect(extractAuthorSurname("Mme&#160;Lechon,  M.&#160;Allisio, M.&#160;Amblard")).toBe(
+      "Lechon"
+    );
+    expect(extractAuthorSurname("M. de Fleurian")).toBe("de Fleurian");
+    expect(extractAuthorSurname("Mme Pannier-Runacher")).toBe("Pannier-Runacher");
+  });
+
+  it("returns null for empty / too-short names", () => {
+    expect(extractAuthorSurname(null)).toBeNull();
+    expect(extractAuthorSurname("")).toBeNull();
+    expect(extractAuthorSurname("M. Li")).toBeNull();
+  });
+});

--- a/src/services/scrutin-substance/__tests__/debate-context-resolver.test.ts
+++ b/src/services/scrutin-substance/__tests__/debate-context-resolver.test.ts
@@ -1,9 +1,18 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// db is imported by the resolver module but never queried by extractAuthorSurname.
-vi.mock("@/lib/db", () => ({ db: {} }));
+const scrutinFindUnique = vi.fn();
+const transcriptFindMany = vi.fn();
+vi.mock("@/lib/db", () => ({
+  db: {
+    scrutin: { findUnique: (...a: unknown[]) => scrutinFindUnique(...a) },
+    debateTranscript: { findMany: (...a: unknown[]) => transcriptFindMany(...a) },
+  },
+}));
 
-import { extractAuthorSurname } from "@/services/scrutin-substance/debate-context-resolver";
+import {
+  extractAuthorSurname,
+  resolveDebateContextForScrutin,
+} from "@/services/scrutin-substance/debate-context-resolver";
 
 describe("extractAuthorSurname", () => {
   it("cleans AN HTML entities and the civility prefix, keeps the first surname", () => {
@@ -18,5 +27,64 @@ describe("extractAuthorSurname", () => {
     expect(extractAuthorSurname(null)).toBeNull();
     expect(extractAuthorSurname("")).toBeNull();
     expect(extractAuthorSurname("M. Li")).toBeNull();
+  });
+});
+
+describe("resolveDebateContextForScrutin — same-day candidate scope (diagnostic only)", () => {
+  beforeEach(() => {
+    scrutinFindUnique.mockReset();
+    transcriptFindMany.mockReset();
+  });
+
+  it("finds a HIGH across several same-day candidates but flags scope=same-day (NOT a definitive linkage)", async () => {
+    scrutinFindUnique.mockResolvedValue({
+      votingDate: new Date("2026-05-30"),
+      amendmentLinks: [
+        { amendment: { number: "2084", authorName: "Mme Lechon", article: "APRÈS L'ARTICLE 22" } },
+      ],
+    });
+    // Two debates the SAME DAY: a different one, and the one that mentions 2084.
+    transcriptFindMany.mockResolvedValue([
+      { seanceRef: "SEANCE-A", content: "Sur un autre texte, l'amendement no 12 est rejeté." },
+      {
+        seanceRef: "SEANCE-B",
+        content:
+          "La parole est à Mme Léchon pour soutenir l'amendement no 2084 sur la transparence des coopératives.",
+      },
+    ]);
+
+    const r = await resolveDebateContextForScrutin("s1");
+
+    expect(r.confidence).toBe("HIGH");
+    expect(r.matchedAmendmentNumber).toBe("2084");
+    expect(r.transcriptSeanceRef).toBe("SEANCE-B");
+    // The whole point of this PR: the candidate scope stays same-day, and there
+    // were several candidates that day → this is NOT a dossier/session
+    // disambiguated linkage, only a diagnostic candidate.
+    expect(r.candidateScope).toBe("same-day");
+    expect(r.candidateTranscriptCount).toBe(2);
+    expect(r.usableForGeneration).toBe(true); // HIGH, but still "à valider avant branchement"
+  });
+
+  it("keeps scope=same-day and reports NONE when no same-day candidate mentions the amendment", async () => {
+    scrutinFindUnique.mockResolvedValue({
+      votingDate: new Date("2026-05-30"),
+      amendmentLinks: [{ amendment: { number: "2084", authorName: "Mme Lechon", article: "22" } }],
+    });
+    transcriptFindMany.mockResolvedValue([
+      {
+        seanceRef: "SEANCE-A",
+        content: "Discussion générale, aucun numéro d'amendement cité ici.",
+      },
+      { seanceRef: "SEANCE-B", content: "Débat sur l'amendement no 999, sans rapport." },
+    ]);
+
+    const r = await resolveDebateContextForScrutin("s1");
+
+    expect(r.confidence).toBe("NONE");
+    expect(r.usableForGeneration).toBe(false);
+    expect(r.candidateScope).toBe("same-day");
+    expect(r.candidateTranscriptCount).toBe(2);
+    expect(r.hasCandidateTranscript).toBe(true);
   });
 });

--- a/src/services/scrutin-substance/__tests__/debate-context.test.ts
+++ b/src/services/scrutin-substance/__tests__/debate-context.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { findAmendmentMention } from "@/services/scrutin-substance/debate-context";
+
+// Realistic AN séance snippet style: "l'amendement no <n>" (letter o, typographic ').
+const filler = (label: string) => ` ${label} `.repeat(40);
+
+describe("findAmendmentMention — HIGH (explicit number)", () => {
+  it("matches an explicit 'amendement no 2084' → HIGH, usable, bounded excerpt", () => {
+    const text = `M. le président : La parole est à Mme Léchon, pour soutenir l'amendement no 2084, qui impose la transparence de la répartition de la valeur dans les coopératives agricoles.`;
+    const r = findAmendmentMention(text, [
+      { number: "2084", authorSurname: "Lechon", article: "22" },
+    ]);
+    expect(r.confidence).toBe("HIGH");
+    expect(r.usableForGeneration).toBe(true);
+    expect(r.matchedAmendmentNumber).toBe("2084");
+    expect(r.excerpt).toContain("2084");
+    expect(r.excerpt!.length).toBeLessThan(text.length + 1);
+  });
+
+  it("handles variants: n°, numéro, nos X et Y, narrow/non-breaking spaces", () => {
+    const variants = [
+      "Sur l'amendement n° 2084, la commission donne un avis défavorable.",
+      "L'amendement numéro 2084 est mis aux voix.",
+      "Je mets aux voix les amendements nos 2080 et 2084.",
+      "l'amendement no 2084 est adopté.", // non-breaking space
+    ];
+    for (const text of variants) {
+      const r = findAmendmentMention(text, [{ number: "2084" }]);
+      expect(r.confidence, text).toBe("HIGH");
+    }
+  });
+
+  it("matches non purely-numeric amendment numbers (CL8, I-390, '600 (Rect)')", () => {
+    expect(
+      findAmendmentMention("Sur l'amendement no CL8, avis favorable.", [{ number: "CL8" }])
+        .confidence
+    ).toBe("HIGH");
+    expect(
+      findAmendmentMention("L'amendement no I-390 est retiré.", [{ number: "I-390" }]).confidence
+    ).toBe("HIGH");
+    expect(
+      findAmendmentMention("Je mets aux voix l'amendement no 600.", [{ number: "600 (Rect)" }])
+        .confidence
+    ).toBe("HIGH");
+  });
+
+  it("does not match a number embedded in a longer number (2084 ≠ 20840 / 1691)", () => {
+    const r = findAmendmentMention("Sur l'amendement no 1691 et l'amendement no 20840.", [
+      { number: "2084" },
+    ]);
+    expect(r.confidence).not.toBe("HIGH");
+  });
+});
+
+describe("findAmendmentMention — reject vague / absent", () => {
+  it("rejects a same-dossier passage with no clear amendment mention → NONE", () => {
+    const text =
+      "Nous examinons le projet de loi d'urgence pour la souveraineté agricole, un texte attendu par la profession.";
+    const r = findAmendmentMention(text, [
+      { number: "2084", authorSurname: "Lechon", article: "22" },
+    ]);
+    expect(r.confidence).toBe("NONE");
+    expect(r.usableForGeneration).toBe(false);
+    expect(r.excerpt).toBeNull();
+  });
+
+  it("returns NONE on an empty transcript", () => {
+    expect(findAmendmentMention("", [{ number: "2084" }]).confidence).toBe("NONE");
+    expect(findAmendmentMention("   \n  ", [{ number: "2084" }]).confidence).toBe("NONE");
+  });
+});
+
+describe("findAmendmentMention — multiple amendments in one séance", () => {
+  it("bounds the excerpt around the right amendment, not its neighbours", () => {
+    const text =
+      `l'amendement no 2080 vise à interdire les importations de produits agricoles à bas prix.` +
+      filler("blabla") +
+      `l'amendement no 2084 impose la transparence de la répartition de la valeur dans les coopératives agricoles.` +
+      filler("autre") +
+      `l'amendement no 2090 concerne l'étiquetage.`;
+    const r = findAmendmentMention(text, [{ number: "2084" }]);
+    expect(r.confidence).toBe("HIGH");
+    expect(r.matchedAmendmentNumber).toBe("2084");
+    expect(r.excerpt).toContain("coopératives agricoles");
+    expect(r.excerpt).not.toContain("interdire les importations");
+    expect(r.excerpt).not.toContain("étiquetage");
+  });
+});
+
+describe("findAmendmentMention — scrutin 2084 non-regression", () => {
+  it("HIGH only when the debate genuinely mentions amendment 2084", () => {
+    const text =
+      "La parole est à Mme Léchon pour l'amendement no 2084 sur la transparence des coopératives.";
+    expect(
+      findAmendmentMention(text, [{ number: "2084", authorSurname: "Lechon" }]).confidence
+    ).toBe("HIGH");
+  });
+
+  it("does NOT attribute a same-séance import-ban debate (other amendment) to 2084", () => {
+    // The real 2026-05-30 transcript does not mention 2084/Léchon/article 22.
+    const text =
+      "Sur l'amendement no 249, M. Allisio défend l'interdiction des importations de produits agricoles à bas prix ne respectant pas les normes sociales et environnementales.";
+    const r = findAmendmentMention(text, [
+      { number: "2084", authorSurname: "Lechon", article: "22" },
+    ]);
+    expect(r.confidence).toBe("NONE");
+    expect(r.usableForGeneration).toBe(false);
+  });
+});
+
+describe("findAmendmentMention — real public AN séance formats", () => {
+  // Verbatim excerpts from public Assemblée nationale séance transcripts.
+  it("matches a number inside a real 'amendements nos X, Y, Z et W' list", () => {
+    const text =
+      "Mme la présidente : Sur les amendements nos 22, 25, 23 et 27, je suis saisie par le groupe La France insoumise-Nouveau Front populaire de demandes de scrutin public.";
+    expect(findAmendmentMention(text, [{ number: "23" }]).confidence).toBe("HIGH");
+    expect(findAmendmentMention(text, [{ number: "27" }]).confidence).toBe("HIGH");
+    expect(findAmendmentMention(text, [{ number: "999" }]).confidence).toBe("NONE");
+  });
+
+  it("matches a real 'discussion commune' list 'amendements, nos 1403, 1984 et 1977'", () => {
+    const text =
+      "Nous en venons à trois amendements, nos 1403, 1984 et 1977, pouvant être soumis à une discussion commune. Sur l'amendement no 1403, je suis saisie d'une demande de scrutin public.";
+    expect(findAmendmentMention(text, [{ number: "1403" }]).confidence).toBe("HIGH");
+    expect(findAmendmentMention(text, [{ number: "1977" }]).confidence).toBe("HIGH");
+  });
+});
+
+describe("findAmendmentMention — MEDIUM (author + article, no number)", () => {
+  it("flags author + article co-located without the number as MEDIUM (audit only)", () => {
+    const text =
+      "Mme Léchon a longuement défendu, à l'article 22, une obligation de transparence pour les coopératives agricoles.";
+    const r = findAmendmentMention(text, [
+      { number: "2084", authorSurname: "Lechon", article: "APRÈS L'ARTICLE 22" },
+    ]);
+    expect(r.confidence).toBe("MEDIUM");
+    expect(r.usableForGeneration).toBe(false);
+  });
+});

--- a/src/services/scrutin-substance/debate-context-resolver.ts
+++ b/src/services/scrutin-substance/debate-context-resolver.ts
@@ -1,7 +1,12 @@
 /**
  * READ-ONLY resolver around the pure `findAmendmentMention` matcher. For a
- * scrutin, it gathers the same-day candidate transcripts and returns the best
+ * scrutin, it gathers the SAME-DAY candidate transcripts and returns the best
  * mention with a bounded excerpt and a confidence. NO model call, NO DB write.
+ *
+ * CANDIDATE SCOPE = same-day only, NOT yet dossier/session-disambiguated. A HIGH
+ * therefore proves the amendment number appears in a same-day transcript, NOT
+ * that this transcript is the right one when several debates/dossiers coexist on
+ * the same day. `candidateTranscriptCount > 1` flags that ambiguity.
  *
  * PROVISIONAL: depends on the per-séance transcript linkage (a transcript is
  * stored per day) and on the matcher's regex, both still to be hardened. Use for
@@ -15,10 +20,18 @@ import {
   type DebateContextConfidence,
 } from "./debate-context";
 
+/** How candidate transcripts were gathered. Only "same-day" exists today;
+ *  a future PR may add dossier/session disambiguation. */
+export type CandidateScope = "same-day";
+
 export interface DebateContextResult extends AmendmentMention {
   scrutinId: string;
   transcriptSeanceRef: string | null;
   hasCandidateTranscript: boolean;
+  /** Always "same-day" for now — see module header. Never a definitive linkage. */
+  candidateScope: CandidateScope;
+  /** Number of same-day candidate transcripts considered. > 1 => ambiguous day. */
+  candidateTranscriptCount: number;
 }
 
 const RANK: Record<DebateContextConfidence, number> = { HIGH: 3, MEDIUM: 2, LOW: 1, NONE: 0 };
@@ -66,6 +79,8 @@ export async function resolveDebateContextForScrutin(
     usableForGeneration: false,
     transcriptSeanceRef: null,
     hasCandidateTranscript: false,
+    candidateScope: "same-day",
+    candidateTranscriptCount: 0,
   };
 
   if (!scrutin) return base;
@@ -84,6 +99,7 @@ export async function resolveDebateContextForScrutin(
   });
 
   base.hasCandidateTranscript = candidates.length > 0;
+  base.candidateTranscriptCount = candidates.length;
 
   let best = base;
   for (const t of candidates) {
@@ -100,6 +116,9 @@ export interface DebateContextAuditRow {
   slug: string | null;
   amendment: string;
   hasCandidateTranscript: boolean;
+  /** Always "same-day": candidates are not yet dossier/session-disambiguated. */
+  candidateScope: CandidateScope;
+  candidateTranscriptCount: number;
   confidence: DebateContextConfidence;
   usableForGeneration: boolean;
   reason: string;
@@ -147,6 +166,8 @@ export async function auditDebateContextForAmendmentAnalyses(options?: {
       slug: s.slug,
       amendment: s.amendmentLinks[0]?.amendment.number ?? "?",
       hasCandidateTranscript: ctx.hasCandidateTranscript,
+      candidateScope: ctx.candidateScope,
+      candidateTranscriptCount: ctx.candidateTranscriptCount,
       confidence: ctx.confidence,
       usableForGeneration: ctx.usableForGeneration,
       reason: ctx.reason,

--- a/src/services/scrutin-substance/debate-context-resolver.ts
+++ b/src/services/scrutin-substance/debate-context-resolver.ts
@@ -1,0 +1,158 @@
+/**
+ * READ-ONLY resolver around the pure `findAmendmentMention` matcher. For a
+ * scrutin, it gathers the same-day candidate transcripts and returns the best
+ * mention with a bounded excerpt and a confidence. NO model call, NO DB write.
+ *
+ * PROVISIONAL: depends on the per-séance transcript linkage (a transcript is
+ * stored per day) and on the matcher's regex, both still to be hardened. Use for
+ * read-only audit only; do NOT wire into generation yet.
+ */
+import { db } from "@/lib/db";
+import {
+  findAmendmentMention,
+  type AmendmentRef,
+  type AmendmentMention,
+  type DebateContextConfidence,
+} from "./debate-context";
+
+export interface DebateContextResult extends AmendmentMention {
+  scrutinId: string;
+  transcriptSeanceRef: string | null;
+  hasCandidateTranscript: boolean;
+}
+
+const RANK: Record<DebateContextConfidence, number> = { HIGH: 3, MEDIUM: 2, LOW: 1, NONE: 0 };
+
+/** First author's surname, cleaned of AN HTML entities and civility prefix. */
+export function extractAuthorSurname(authorName: string | null | undefined): string | null {
+  if (!authorName) return null;
+  const cleaned = authorName
+    .replace(/&#160;|&nbsp;/gi, " ")
+    .replace(/&[a-z0-9#]+;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const first = cleaned.split(",")[0]?.trim() ?? "";
+  const noCiv = first.replace(/^(mmes?|mm\.?|m\.?|mlle)\s+/i, "").trim();
+  return noCiv.length >= 3 ? noCiv : null;
+}
+
+function dayBounds(d: Date): { start: Date; end: Date } {
+  const start = new Date(d);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(d);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+
+export async function resolveDebateContextForScrutin(
+  scrutinId: string
+): Promise<DebateContextResult> {
+  const scrutin = await db.scrutin.findUnique({
+    where: { id: scrutinId },
+    select: {
+      votingDate: true,
+      amendmentLinks: {
+        select: { amendment: { select: { number: true, authorName: true, article: true } } },
+      },
+    },
+  });
+
+  const base: DebateContextResult = {
+    scrutinId,
+    confidence: "NONE",
+    reason: "Aucune mention claire de l'amendement dans le débat.",
+    excerpt: null,
+    matchedAmendmentNumber: null,
+    usableForGeneration: false,
+    transcriptSeanceRef: null,
+    hasCandidateTranscript: false,
+  };
+
+  if (!scrutin) return base;
+
+  const refs: AmendmentRef[] = scrutin.amendmentLinks.map((l) => ({
+    number: l.amendment.number,
+    authorSurname: extractAuthorSurname(l.amendment.authorName),
+    article: l.amendment.article,
+  }));
+  if (refs.length === 0) return base;
+
+  const { start, end } = dayBounds(scrutin.votingDate);
+  const candidates = await db.debateTranscript.findMany({
+    where: { date: { gte: start, lte: end } },
+    select: { seanceRef: true, content: true },
+  });
+
+  base.hasCandidateTranscript = candidates.length > 0;
+
+  let best = base;
+  for (const t of candidates) {
+    const m = findAmendmentMention(t.content, refs);
+    if (RANK[m.confidence] > RANK[best.confidence]) {
+      best = { ...base, ...m, transcriptSeanceRef: t.seanceRef };
+    }
+  }
+  return best;
+}
+
+export interface DebateContextAuditRow {
+  scrutinId: string;
+  slug: string | null;
+  amendment: string;
+  hasCandidateTranscript: boolean;
+  confidence: DebateContextConfidence;
+  usableForGeneration: boolean;
+  reason: string;
+  excerpt: string | null;
+}
+
+export interface DebateContextAudit {
+  scanned: number;
+  byConfidence: Record<DebateContextConfidence, number>;
+  rows: DebateContextAuditRow[];
+}
+
+/**
+ * READ-ONLY audit over amendment-linked scrutins that already have an analysis.
+ * For each, reports whether a candidate transcript exists and how strongly it
+ * mentions the voted amendment. No write, no model call.
+ */
+export async function auditDebateContextForAmendmentAnalyses(options?: {
+  limit?: number;
+}): Promise<DebateContextAudit> {
+  const scrutins = await db.scrutin.findMany({
+    where: { amendmentLinks: { some: {} }, analysis: { isNot: null } },
+    orderBy: { votingDate: "desc" },
+    select: {
+      id: true,
+      slug: true,
+      amendmentLinks: { select: { amendment: { select: { number: true } } }, take: 1 },
+    },
+    ...(options?.limit ? { take: options.limit } : {}),
+  });
+
+  const byConfidence: Record<DebateContextConfidence, number> = {
+    HIGH: 0,
+    MEDIUM: 0,
+    LOW: 0,
+    NONE: 0,
+  };
+  const rows: DebateContextAuditRow[] = [];
+
+  for (const s of scrutins) {
+    const ctx = await resolveDebateContextForScrutin(s.id);
+    byConfidence[ctx.confidence]++;
+    rows.push({
+      scrutinId: s.id,
+      slug: s.slug,
+      amendment: s.amendmentLinks[0]?.amendment.number ?? "?",
+      hasCandidateTranscript: ctx.hasCandidateTranscript,
+      confidence: ctx.confidence,
+      usableForGeneration: ctx.usableForGeneration,
+      reason: ctx.reason,
+      excerpt: ctx.excerpt,
+    });
+  }
+
+  return { scanned: scrutins.length, byConfidence, rows };
+}

--- a/src/services/scrutin-substance/debate-context.ts
+++ b/src/services/scrutin-substance/debate-context.ts
@@ -1,0 +1,163 @@
+/**
+ * PURE matcher: given a debate transcript (séance text) and the amendment(s) a
+ * scrutin voted on, decide whether the text contains a STRONG, verifiable mention
+ * of that amendment, and extract a BOUNDED excerpt.
+ *
+ * PROVISIONAL: regex calibrated on real AN séance transcripts ("l'amendement no
+ * 2084", "amendements nos 27, 16 et 23"), but still to be confirmed against a
+ * wider sample before the resolver is trusted for anything but read-only audit.
+ * No DB, no model, no I/O — fully unit-testable.
+ */
+
+export type DebateContextConfidence = "HIGH" | "MEDIUM" | "LOW" | "NONE";
+
+export interface AmendmentRef {
+  number: string;
+  authorSurname?: string | null;
+  article?: string | null;
+}
+
+export interface AmendmentMention {
+  confidence: DebateContextConfidence;
+  reason: string;
+  /** Bounded window around the match, never the whole transcript. */
+  excerpt: string | null;
+  matchedAmendmentNumber: string | null;
+  /** Only HIGH is trustworthy enough to feed a future generation. */
+  usableForGeneration: boolean;
+}
+
+const NONE: AmendmentMention = {
+  confidence: "NONE",
+  reason: "Aucune mention claire de l'amendement dans le débat.",
+  excerpt: null,
+  matchedAmendmentNumber: null,
+  usableForGeneration: false,
+};
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Lowercase + fold French accents + normalise unusual spaces. LENGTH-PRESERVING
+ *  (each replacement is 1 char → 1 char) so indices map 1:1 to `normalizeSpaces`. */
+function foldLower(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[àâä]/g, "a")
+    .replace(/[éèêë]/g, "e")
+    .replace(/[îï]/g, "i")
+    .replace(/[ôö]/g, "o")
+    .replace(/[ùûü]/g, "u")
+    .replace(/ç/g, "c")
+    .replace(/[   ]/g, " ");
+}
+
+/** NBSP variants → regular space. LENGTH-PRESERVING. Keeps original case/accents
+ *  for excerpt extraction. */
+function normalizeSpaces(s: string): string {
+  return s.replace(/[   ]/g, " ");
+}
+
+/** "600 (Rect)" → "600" ; "CL8" → "CL8" ; "I-390" → "I-390" ; "2084" → "2084". */
+function coreNumber(n: string): string {
+  return n.replace(/\s*\(.*?\)\s*$/, "").trim();
+}
+
+function windowAround(text: string, idx: number, before = 120, after = 220): string {
+  const start = Math.max(0, idx - before);
+  const end = Math.min(text.length, idx + after);
+  return text.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Index (in folded/spaced coordinates) of an explicit "amendement(s) n.. <number>"
+ * mention, or -1. Scans each "amendement(s) n" anchor and looks for the number as
+ * a standalone token within a short window after it (covers "no 2084", "n° 2084",
+ * "numéro 2084", "nos 27, 16 et 2084").
+ */
+function highMatchIndex(folded: string, core: string): number {
+  const token = foldLower(core);
+  const numRe = new RegExp(`(?<![\\w-])${escapeRegExp(token)}(?![\\w-])`);
+  // Allow a comma between "amendements" and the "n" prefix: real séance text
+  // says "amendements, nos 1403, 1984 et 1977".
+  const anchorRe = /\bamendements?[\s,]+n/g;
+  let m: RegExpExecArray | null;
+  while ((m = anchorRe.exec(folded)) !== null) {
+    const winStart = m.index + m[0].length;
+    const win = folded.slice(winStart, winStart + 45);
+    const nm = numRe.exec(win);
+    if (nm) return winStart + nm.index;
+  }
+  return -1;
+}
+
+function extractArticleNumber(article: string): string | null {
+  const f = foldLower(article);
+  const re = /(?:article\s+)?(\d+(?:\s*(?:bis|ter|quater|quinquies))?)/;
+  const m = f.match(/article\s+(\d+(?:\s*(?:bis|ter|quater|quinquies))?)/) ?? f.match(re);
+  return m ? m[1].replace(/\s+/g, " ").trim() : null;
+}
+
+function articleIndexIn(folded: string, articleNum: string): number {
+  const re = new RegExp(`article\\s+${escapeRegExp(articleNum)}(?![\\d])`);
+  const m = re.exec(folded);
+  return m ? m.index : -1;
+}
+
+export function findAmendmentMention(
+  transcriptText: string,
+  amendments: AmendmentRef[]
+): AmendmentMention {
+  if (!transcriptText || !transcriptText.trim() || amendments.length === 0) return NONE;
+
+  const spaced = normalizeSpaces(transcriptText);
+  const folded = foldLower(spaced);
+
+  // HIGH: explicit amendment number. Strongest, the only "usable" signal.
+  for (const amd of amendments) {
+    const idx = highMatchIndex(folded, coreNumber(amd.number));
+    if (idx >= 0) {
+      return {
+        confidence: "HIGH",
+        reason: `Numéro d'amendement « ${amd.number} » cité explicitement dans le débat.`,
+        excerpt: windowAround(spaced, idx),
+        matchedAmendmentNumber: amd.number,
+        usableForGeneration: true,
+      };
+    }
+  }
+
+  // MEDIUM / LOW: author + article proximity, never usable for generation.
+  let low: AmendmentMention | null = null;
+  for (const amd of amendments) {
+    const surname =
+      amd.authorSurname && amd.authorSurname.trim().length >= 3
+        ? foldLower(amd.authorSurname.trim())
+        : "";
+    const articleNum = amd.article ? extractArticleNumber(amd.article) : null;
+    const surnameIdx = surname ? folded.indexOf(surname) : -1;
+    const articleIdx = articleNum ? articleIndexIn(folded, articleNum) : -1;
+
+    if (surnameIdx >= 0 && articleIdx >= 0 && Math.abs(surnameIdx - articleIdx) <= 300) {
+      return {
+        confidence: "MEDIUM",
+        reason: "Auteur et article cités à proximité, sans le numéro d'amendement.",
+        excerpt: windowAround(spaced, Math.min(surnameIdx, articleIdx)),
+        matchedAmendmentNumber: amd.number,
+        usableForGeneration: false,
+      };
+    }
+    if (!low && (surnameIdx >= 0 || articleIdx >= 0)) {
+      low = {
+        confidence: "LOW",
+        reason: "Signal faible (auteur ou article seul), non exploitable pour la génération.",
+        excerpt: windowAround(spaced, surnameIdx >= 0 ? surnameIdx : articleIdx),
+        matchedAmendmentNumber: amd.number,
+        usableForGeneration: false,
+      };
+    }
+  }
+
+  return low ?? NONE;
+}

--- a/src/services/scrutin-substance/debate-context.ts
+++ b/src/services/scrutin-substance/debate-context.ts
@@ -96,7 +96,8 @@ function extractArticleNumber(article: string): string | null {
   const f = foldLower(article);
   const re = /(?:article\s+)?(\d+(?:\s*(?:bis|ter|quater|quinquies))?)/;
   const m = f.match(/article\s+(\d+(?:\s*(?:bis|ter|quater|quinquies))?)/) ?? f.match(re);
-  return m ? m[1].replace(/\s+/g, " ").trim() : null;
+  const captured = m?.[1];
+  return captured ? captured.replace(/\s+/g, " ").trim() : null;
 }
 
 function articleIndexIn(folded: string, articleNum: string): number {


### PR DESCRIPTION
> **Matcher pur + resolver read-only + audit calibré sur premiers formats AN réels, non encore branché à la génération.**
> Draft : ne pas passer ready ni merger. À relire avant toute discussion de branchement.

## 1. Objectif

- Identifier des **candidats** de rattachement transcript ↔ scrutin ↔ amendement.
- Produire des **extraits bornés** autour d'une preuve textuelle forte.
- **Préparer un audit**, pas générer des analyses.

## 2. Garanties

- Aucun write prod.
- Aucun appel modèle.
- Aucune migration.
- Aucune persistance.
- Aucun branchement dans `generateScrutinAnalysis`.
- Aucun backfill.
- Audit **read-only** uniquement.

## 3. Doctrine de confiance

- `HIGH` : mention explicite du numéro d'amendement → candidat fort.
- `MEDIUM` : auteur + article cités à proximité, sans le numéro → **audit seulement**.
- `LOW` : signal faible (auteur ou article seul) → non exploitable.
- `NONE` : rejet.
- `usableForGeneration: true` **uniquement pour `HIGH`**, et même `HIGH` reste **à valider avant tout branchement réel**.

## 4. Calibration (sur DB réelle)

Formats AN réels observés et gérés :
- `l'amendement no 2084` (lettre `n`+`o`, **pas** `n°`)
- `amendements, nos 1403, 1984 et 1977` (virgule après « amendements », liste)

Le matcher gère aussi `n°`/`numéro`/`nos`, espaces insécables, numéros non purement numériques (`CL8`, `I-390`, `600 (Rect)`), les bornes (2084 ≠ 20840/1691) et les accents auteur (`Lechon` ↔ `Léchon`).

Les **fixtures réelles AN sont publiques et minimales** (1-2 phrases de comptes rendus de séance publics). Cette calibration a déjà **corrigé un bug de virgule** (`amendements, nos …` n'était pas reconnu).

## 5. Limites assumées

- L'extrait se centre encore souvent sur la **mention procédurale** du scrutin/amendement (« scrutin public »), pas forcément sur l'argument de fond.
- Certains transcripts semblent **tronqués autour de 5000 caractères** (la séance du 2026-05-30 ne contient pas le débat de l'amendement 2084).
- Le resolver **ne doit pas être considéré comme fiable pour générer** tant que ces limites ne sont pas traitées ou explicitement acceptées.

## 6. Tests / audit

- **14 tests verts** (matcher : mention explicite, vague → NONE, absent → NONE, multi-amendements → extrait borné, non-régression 2084, variants/non-numériques, formats réels AN, MEDIUM ; + nettoyage `extractAuthorSurname`).
- Audit live **read-only** : `limit 30 → HIGH=14, MEDIUM=1, LOW=13, NONE=2`.
- Compteurs prod **inchangés avant/après** : 167 transcripts, 324 analyses (zéro write).

## Fichiers

- `src/services/scrutin-substance/debate-context.ts` — matcher pur `findAmendmentMention`.
- `src/services/scrutin-substance/debate-context-resolver.ts` — `resolveDebateContextForScrutin` + `auditDebateContextForAmendmentAnalyses` (read-only).
- `scripts/audit-debate-context.ts` — audit read-only.
- Tests associés.