### PR TITLE
Scope le check data-quality affaires-sans-source aux affaires publiables

### DIFF
--- a/scripts/test-data-quality.ts
+++ b/scripts/test-data-quality.ts
@@ -30,12 +30,16 @@ const CHECKS: QualityCheck[] = [
   // === CRITICAL CHECKS ===
   {
     name: "affairs-without-sources",
-    description: "Affaires sans source (CRITIQUE - risque juridique)",
+    description: "Affaires publiables sans source (CRITIQUE - risque juridique)",
     critical: true,
     check: async () => {
+      // Only DRAFT/PUBLISHED affairs are a legal risk: they are public or about
+      // to be. ARCHIVED/EXCLUDED/REJECTED are hidden by design (rejected duplicates,
+      // wrong attributions, victim cases), where a missing source is expected.
       const affairs = await db.affair.findMany({
         where: {
           sources: { none: {} },
+          publicationStatus: { in: ["DRAFT", "PUBLISHED"] },
         },
         select: { id: true, title: true, politician: { select: { fullName: true } } },
       });


### PR DESCRIPTION
## Contexte

Le workflow **Quality Tests** (job « Data Quality », post-merge sur `main`, hors gate de PR) échoue depuis longtemps. Le seul check **critique** (`critical: true`, donc le seul qui fait `exit 1`) est `affairs-without-sources`, qui remontait **9 affaires sans source**.

## Diagnostic

Les 9 affaires sont **toutes `REJECTED`** (doublons, victime, attribution erronée) — donc **non publiques**. Le check les comptait car il interrogeait `db.affair` **sans filtre de statut** :

```ts
where: { sources: { none: {} } }
```

Or le « risque juridique » ne concerne que les affaires **publiables ou publiques**. `REJECTED` / `ARCHIVED` / `EXCLUDED` sont cachées par design, et une source absente y est normale. **Zéro affaire DRAFT ou PUBLISHED n'est sans source** → l'exposition réelle est nulle.

## Correctif

Scoper le check sur `DRAFT` / `PUBLISHED` :

```ts
where: {
  sources: { none: {} },
  publicationStatus: { in: ["DRAFT", "PUBLISHED"] },
}
```

Aucune donnée touchée. Aucune affaire modifiée.

## Vérification (read-only)

- `affairs sans source ET DRAFT/PUBLISHED` = **0**.
- `npx tsx scripts/test-data-quality.ts` → `[!] affairs-without-sources... ✅ (0)`, **exit code 0**.
- `tsc --noEmit --incremental false` clean.

Les 4 autres échecs (`senator-count`, `potential-duplicates`, `embeddings-coverage`, `old-mandates-still-current`) sont **non critiques** (`critical: false`) : ils ne cassent pas le build et ne sont pas dans le périmètre de cette PR.