### PR TITLE
Audit scrutin-debate mapping reliability

### DIFF
--- a/docs/DATA-MATCHING.md
+++ b/docs/DATA-MATCHING.md
@@ -367,7 +367,11 @@ mauvais, et le cas sentinelle `VTANR5L17V7183` / amendement 2084 (qui doit reste
 
 L'AN siège en 2-3 séances par jour, chacune étant un `DebateTranscript` distinct.
 Sous la règle stricte, tout numéro cité tombe donc sur un jour multi-transcripts et
-finit `ambiguous` : `matched` est quasi inatteignable. La métrique
-`uniquelyLocalizable` (numéro présent dans **une seule** séance du jour) mesure ce
-qu'un scoping **par séance** (et non par jour) pourrait promouvoir en `matched`.
-C'est le prérequis avant tout branchement sur `ScrutinAnalysis`.
+finit `ambiguous` : `matched` est quasi inatteignable.
+
+La métrique `uniquelyLocalizable` (numéro présent dans **une seule** séance du jour)
+est un **potentiel, pas une promesse** : elle dit « ces cas semblent localisables de
+façon unique », et non « autant d'analyses générables ». Un scoping **par séance**
+(et non par jour) côté ingestion pourrait les promouvoir en `matched` ; ils
+resteraient ensuite soumis aux garde-fous de génération. C'est le prérequis avant
+tout branchement sur `ScrutinAnalysis`.

--- a/docs/DATA-MATCHING.md
+++ b/docs/DATA-MATCHING.md
@@ -16,6 +16,7 @@ Comment Poligraph réconcilie les données de 14+ sources pour construire une fi
 - [Cas concrets](#6-cas-concrets)
 - [Ajouter une nouvelle source](#7-ajouter-une-nouvelle-source)
 - [Pièges connus](#8-pièges-connus)
+- [Rattachement scrutin ↔ débat](#9-rattachement-scrutin--débat)
 
 ---
 
@@ -303,3 +304,70 @@ Si le matching échoue (nom mal normalisé, accent différent), le sync peut cr�
 ### Champs vides dans le CSV HATVP
 
 Le champ `id_origine` est vide pour certains types de mandats (gouvernement, président, commune). C'est normal, le fallback par nom prend le relais.
+
+---
+
+## 9. Rattachement scrutin ↔ débat
+
+Le but : relier un scrutin (`Scrutin`) au bon extrait de compte rendu de séance
+(`DebateTranscript`), de façon **déterministe et auditable**, sans LLM. Ce
+rattachement conditionne la génération de `ScrutinAnalysis` (arguments POUR/CONTRE
+issus du débat). Il n'est volontairement **pas** branché sur la génération tant que
+l'audit ne prouve pas une qualité suffisante.
+
+### Pourquoi le lien historique est fragile
+
+`syncDebateTranscripts()` stocke **un transcript par séance** (clé `seanceRef`),
+tronqué à 5000 caractères, puis l'attache au **premier scrutin du jour sans débat**
+(`debate-transcripts.ts`, lien par date seule). Sur un jour à 100+ scrutins, la
+quasi-totalité reste sans débat et le rare scrutin lié peut l'être au mauvais.
+
+### Le matcher déterministe
+
+Pipeline pur, sans I/O ni modèle (`src/services/scrutin-substance/`) :
+
+1. `findAmendmentMention(text, refs)` (`debate-context.ts`) cherche dans le texte
+   une mention forte de l'amendement voté :
+   - `HIGH` : numéro d'amendement cité explicitement (« l'amendement no 2084 »).
+   - `MEDIUM` : auteur + article à proximité, sans numéro.
+   - `LOW` : auteur ou article seul. `NONE` : rien.
+   - `reinforced` : diagnostic, numéro **et** auteur/article proches (non requis).
+2. `resolveDebateContextForScrutin(id)` (`debate-context-resolver.ts`) rassemble
+   les transcripts **du même jour** (il ignore le lien `scrutinId` cassé), applique
+   le matcher, garde le meilleur. Ce sont des transcripts **same-day**, récupérés
+   par date seule : un transcript same-day n'est **pas** un rattachement prouvé. Le
+   resolver expose `candidateTranscriptCount` (> 1 = jour ambigu) et
+   `transcriptsMentioningAmendment` (= 1 = débat localisable à une seule séance).
+
+   Seul `HIGH` (numéro d'amendement cité) est une référence explicite suffisante. Un
+   article seul ne suffit pas : le cas 2084 mentionne l'article 22 mais jamais
+   l'amendement 2084, il reste donc `unsafe`.
+
+3. `classifyDebateMatch(...)` (`debate-mapping.ts`) rend un verdict strict :
+
+   | Classe      | Règle                                                         | Génération  |
+   | ----------- | ------------------------------------------------------------- | ----------- |
+   | `matched`   | `HIGH` **et** un seul transcript candidat le jour             | exploitable |
+   | `ambiguous` | `HIGH` multi-séances le même jour, **ou** `MEDIUM`            | skip        |
+   | `unsafe`    | transcript présent mais `LOW`/`NONE` (objet voté jamais cité) | skip        |
+   | `missing`   | aucun transcript candidat                                     | skip        |
+
+### Le script d'audit (read-only)
+
+```bash
+npx dotenv -e .env -- npx tsx scripts/audit-scrutin-debate-mapping.ts
+```
+
+Portée : key votes liés à un amendement (seul périmètre où le matcher par numéro
+prouve un lien). Sortie : périmètre, métriques par classe, exemples bons/ambigus/
+mauvais, et le cas sentinelle `VTANR5L17V7183` / amendement 2084 (qui doit rester
+`unsafe`). Aucune écriture, aucun appel modèle, aucun backfill.
+
+### Limite structurelle connue
+
+L'AN siège en 2-3 séances par jour, chacune étant un `DebateTranscript` distinct.
+Sous la règle stricte, tout numéro cité tombe donc sur un jour multi-transcripts et
+finit `ambiguous` : `matched` est quasi inatteignable. La métrique
+`uniquelyLocalizable` (numéro présent dans **une seule** séance du jour) mesure ce
+qu'un scoping **par séance** (et non par jour) pourrait promouvoir en `matched`.
+C'est le prérequis avant tout branchement sur `ScrutinAnalysis`.

--- a/scripts/audit-scrutin-debate-mapping.ts
+++ b/scripts/audit-scrutin-debate-mapping.ts
@@ -107,13 +107,15 @@ async function main(): Promise<void> {
   log(`  transcript sans mention (unsafe)      : ${t.unsafe}  (${pct(t.unsafe, t.scanned)})`);
   log(`  sans transcript same-day (missing)    : ${t.missing}  (${pct(t.missing, t.scanned)})`);
 
-  log("\nDIAGNOSTIC (recommandation)");
+  log("\nDIAGNOSTIC (potentiel, PAS une promesse)");
   log(
-    `  localisables de façon unique          : ${t.uniquelyLocalizable}  (${pct(t.uniquelyLocalizable, t.scanned)})`
+    `  cas qui SEMBLENT localisables de façon unique : ${t.uniquelyLocalizable}  (${pct(t.uniquelyLocalizable, t.scanned)})`
   );
-  log("  = HIGH dont le numéro n'apparaît que dans UNE séance du jour. Classés ambiguous");
-  log("    sous la règle stricte same-day, mais promouvables en matched si l'ingestion");
-  log("    scopait par séance plutôt que par jour.");
+  log("  = HIGH dont le numéro n'apparaît que dans UNE séance du jour. Ils restent");
+  log("    classés ambiguous sous la règle stricte same-day. Lecture correcte :");
+  log("    « ces cas semblent localisables », PAS « autant d'analyses générables ».");
+  log("    Les promouvoir en matched suppose un scoping par séance côté ingestion,");
+  log("    et resterait soumis aux garde-fous de génération.");
 
   printClass("BONS / matched", "matched", report.rows, examples);
   printClass("AMBIGUS / ambiguous", "ambiguous", report.rows, examples);

--- a/scripts/audit-scrutin-debate-mapping.ts
+++ b/scripts/audit-scrutin-debate-mapping.ts
@@ -1,0 +1,166 @@
+/**
+ * READ-ONLY audit: deterministic quality of the scrutin ↔ débat mapping.
+ *
+ * Scope = key votes (ScrutinImportance.isKeyVote) linked to an amendment, the
+ * only perimeter where the amendment-number matcher can prove a linkage. Each
+ * scrutin is classified matched / ambiguous / unsafe / missing (see
+ * src/services/scrutin-substance/debate-mapping.ts). No model call, NO DB write,
+ * no backfill. Safe to run locally.
+ *
+ *   npx dotenv -e .env -- npx tsx scripts/audit-scrutin-debate-mapping.ts
+ *   npx dotenv -e .env -- npx tsx scripts/audit-scrutin-debate-mapping.ts --limit 80
+ *   npx dotenv -e .env -- npx tsx scripts/audit-scrutin-debate-mapping.ts --examples 8
+ */
+import { db } from "@/lib/db";
+import {
+  auditKeyScrutinDebateMapping,
+  mapScrutinDebate,
+  type KeyScrutinMappingRow,
+} from "@/services/scrutin-substance/debate-context-resolver";
+import type { DebateMatchClass } from "@/services/scrutin-substance/debate-mapping";
+
+// Sentinel from the brief: must stay WITHOUT exploitable debate unless an exact
+// debate is proven. Expected verdict: "unsafe".
+const SENTINEL_EXTERNAL_ID = "VTANR5L17V7183";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.findIndex((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+  if (i < 0) return undefined;
+  const v = process.argv[i]!;
+  return v.includes("=") ? v.split("=").slice(1).join("=") : process.argv[i + 1];
+}
+
+function log(line = ""): void {
+  // eslint-disable-next-line no-console
+  console.log(line);
+}
+
+function pct(n: number, total: number): string {
+  if (total === 0) return "0%";
+  return `${((n / total) * 100).toFixed(1)}%`;
+}
+
+function printExample(r: KeyScrutinMappingRow): void {
+  log(
+    `  • ${r.externalId}  amdt ${r.amendmentNumber}  ${r.votingDate}  ` +
+      `[${r.confidence}, ${r.candidateTranscriptCount} CR/jour${r.reinforced ? ", renforcé" : ""}]`
+  );
+  log(`    ${r.classReason}`);
+  if (r.excerpt)
+    log(`    extrait: « ${r.excerpt.slice(0, 180)}${r.excerpt.length > 180 ? "…" : ""} »`);
+  if (r.slug) log(`    ${r.slug}`);
+}
+
+function printClass(
+  label: string,
+  klass: DebateMatchClass,
+  rows: KeyScrutinMappingRow[],
+  n: number
+): void {
+  const subset = rows.filter((r) => r.matchClass === klass).slice(0, n);
+  log(
+    `\n── ${label} (${rows.filter((r) => r.matchClass === klass).length}, ${subset.length} exemples) ──`
+  );
+  if (subset.length === 0) log("  (aucun)");
+  for (const r of subset) printExample(r);
+}
+
+async function main(): Promise<void> {
+  const limit = arg("limit") ? Number(arg("limit")) : undefined;
+  const examples = arg("examples") ? Number(arg("examples")) : 5;
+
+  log(`=== Audit rattachement scrutin ↔ débat (read-only)${limit ? ` (limit ${limit})` : ""} ===`);
+  log("Portée : key votes liés à un amendement. Aucun appel modèle, aucune écriture.\n");
+
+  const report = await auditKeyScrutinDebateMapping(limit ? { limit } : {});
+  const t = report.totals;
+
+  log("PÉRIMÈTRE");
+  log(`  key votes avec amendement      : ${report.scope.keyVotesWithAmendment}`);
+  log(
+    `  key votes SANS amendement      : ${report.scope.keyVotesWithoutAmendment}  (hors portée du matcher amendement)`
+  );
+  log(`  scrutins audités               : ${t.scanned}${limit ? ` (limité à ${limit})` : ""}`);
+
+  log("\nTRANSCRIPTS DISPONIBLES");
+  log(
+    `  avec transcript same-day              : ${t.withSameDayTranscript}  (${pct(t.withSameDayTranscript, t.scanned)})`
+  );
+  log("  ATTENTION : same-day = transcripts du même jour récupérés par date seule,");
+  log("    PAS un rattachement prouvé. 100% same-day ne veut pas dire 100% fiable.");
+
+  log("\nNIVEAU DE PREUVE (mention de l'objet voté dans le débat)");
+  log(
+    `  HIGH  numéro d'amendement explicitement cité : ${t.confidenceHigh}  (${pct(t.confidenceHigh, t.scanned)})`
+  );
+  log(
+    `  MEDIUM/LOW  auteur/article seulement         : ${t.confidenceMediumLow}  (${pct(t.confidenceMediumLow, t.scanned)})`
+  );
+  log("    (un article seul n'est PAS une référence explicite suffisante : cf. cas 2084)");
+  log(
+    `  NONE  aucun signal exploitable               : ${t.confidenceNone}  (${pct(t.confidenceNone, t.scanned)})`
+  );
+
+  log("\nCLASSES (rattachement scrutin ↔ débat)");
+  log(`  débat exploitable (matched)           : ${t.matched}  (${pct(t.matched, t.scanned)})`);
+  log(`  cas ambigus (ambiguous)               : ${t.ambiguous}  (${pct(t.ambiguous, t.scanned)})`);
+  log(`  transcript sans mention (unsafe)      : ${t.unsafe}  (${pct(t.unsafe, t.scanned)})`);
+  log(`  sans transcript same-day (missing)    : ${t.missing}  (${pct(t.missing, t.scanned)})`);
+
+  log("\nDIAGNOSTIC (recommandation)");
+  log(
+    `  localisables de façon unique          : ${t.uniquelyLocalizable}  (${pct(t.uniquelyLocalizable, t.scanned)})`
+  );
+  log("  = HIGH dont le numéro n'apparaît que dans UNE séance du jour. Classés ambiguous");
+  log("    sous la règle stricte same-day, mais promouvables en matched si l'ingestion");
+  log("    scopait par séance plutôt que par jour.");
+
+  printClass("BONS / matched", "matched", report.rows, examples);
+  printClass("AMBIGUS / ambiguous", "ambiguous", report.rows, examples);
+  printClass("MAUVAIS / unsafe (transcript mais pas de mention)", "unsafe", report.rows, examples);
+  printClass("MAUVAIS / missing (aucun transcript)", "missing", report.rows, examples);
+
+  // Sentinel: VTANR5L17V7183 / amendement 2084 must stay unsafe.
+  log(`\n── CAS SENTINELLE ${SENTINEL_EXTERNAL_ID} (amendement 2084) ──`);
+  const sentinel = await db.scrutin.findUnique({
+    where: { externalId: SENTINEL_EXTERNAL_ID },
+    select: {
+      id: true,
+      externalId: true,
+      slug: true,
+      votingDate: true,
+      analysis: { select: { id: true } },
+      amendmentLinks: { select: { amendment: { select: { number: true } } }, take: 1 },
+    },
+  });
+  if (!sentinel) {
+    log("  introuvable en base.");
+  } else {
+    const row = await mapScrutinDebate({
+      id: sentinel.id,
+      externalId: sentinel.externalId,
+      slug: sentinel.slug,
+      votingDate: sentinel.votingDate,
+      amendmentNumber: sentinel.amendmentLinks[0]?.amendment.number ?? "?",
+    });
+    log(`  analyse existante : ${sentinel.analysis ? "OUI" : "non"}`);
+    log(`  classe            : ${row.matchClass}  (attendu: unsafe)`);
+    printExample(row);
+    if (row.matchClass === "unsafe") {
+      log("  ✓ Conforme : reste sans débat exploitable, aucune analyse ne doit être générée.");
+    } else {
+      log(
+        `  ✗ ANOMALIE : classe ${row.matchClass} au lieu de unsafe, à investiguer avant tout branchement.`
+      );
+    }
+  }
+  log("");
+}
+
+main()
+  .catch((e) => {
+    // eslint-disable-next-line no-console
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => db.$disconnect());

--- a/src/services/scrutin-substance/__tests__/debate-context-resolver.test.ts
+++ b/src/services/scrutin-substance/__tests__/debate-context-resolver.test.ts
@@ -66,6 +66,29 @@ describe("resolveDebateContextForScrutin — same-day candidate scope (diagnosti
     expect(r.usableForGeneration).toBe(true); // HIGH, but still "à valider avant branchement"
   });
 
+  it("counts how many same-day transcripts mention the amendment (uniquely localizable when exactly 1)", async () => {
+    scrutinFindUnique.mockResolvedValue({
+      votingDate: new Date("2026-05-30"),
+      amendmentLinks: [{ amendment: { number: "2084", authorName: "Mme Lechon", article: "22" } }],
+    });
+    // Three same-day séances, only the afternoon one cites 2084.
+    transcriptFindMany.mockResolvedValue([
+      { seanceRef: "SEANCE-MATIN", content: "Discussion générale, aucun numéro ici." },
+      {
+        seanceRef: "SEANCE-APREM",
+        content: "La parole est à Mme Léchon pour l'amendement no 2084.",
+      },
+      { seanceRef: "SEANCE-SOIR", content: "Débat sur l'amendement no 999, sans rapport." },
+    ]);
+
+    const r = await resolveDebateContextForScrutin("s1");
+
+    expect(r.confidence).toBe("HIGH");
+    expect(r.candidateTranscriptCount).toBe(3);
+    expect(r.transcriptsMentioningAmendment).toBe(1);
+    expect(r.transcriptSeanceRef).toBe("SEANCE-APREM");
+  });
+
   it("keeps scope=same-day and reports NONE when no same-day candidate mentions the amendment", async () => {
     scrutinFindUnique.mockResolvedValue({
       votingDate: new Date("2026-05-30"),

--- a/src/services/scrutin-substance/__tests__/debate-context.test.ts
+++ b/src/services/scrutin-substance/__tests__/debate-context.test.ts
@@ -126,6 +126,41 @@ describe("findAmendmentMention — real public AN séance formats", () => {
   });
 });
 
+describe("findAmendmentMention — reinforced diagnostic (number + author/article)", () => {
+  it("sets reinforced=true when the amendment number AND the author appear together", () => {
+    const text =
+      "La parole est à Mme Léchon pour soutenir l'amendement no 2084 sur la transparence des coopératives.";
+    const r = findAmendmentMention(text, [
+      { number: "2084", authorSurname: "Lechon", article: "22" },
+    ]);
+    expect(r.confidence).toBe("HIGH");
+    expect(r.reinforced).toBe(true);
+  });
+
+  it("sets reinforced=true when the number AND the article appear together", () => {
+    const text =
+      "Sur l'amendement no 2084, à l'article 22, la commission donne un avis défavorable.";
+    const r = findAmendmentMention(text, [{ number: "2084", article: "APRÈS L'ARTICLE 22" }]);
+    expect(r.confidence).toBe("HIGH");
+    expect(r.reinforced).toBe(true);
+  });
+
+  it("keeps reinforced=false on a bare number match (no author, no article nearby)", () => {
+    const text = "L'amendement no 2084 est mis aux voix.";
+    const r = findAmendmentMention(text, [
+      { number: "2084", authorSurname: "Lechon", article: "22" },
+    ]);
+    expect(r.confidence).toBe("HIGH");
+    expect(r.reinforced).toBe(false);
+  });
+
+  it("keeps reinforced=false for NONE / non-HIGH verdicts", () => {
+    const none = findAmendmentMention("Discussion générale sans numéro.", [{ number: "2084" }]);
+    expect(none.confidence).toBe("NONE");
+    expect(none.reinforced).toBe(false);
+  });
+});
+
 describe("findAmendmentMention — MEDIUM (author + article, no number)", () => {
   it("flags author + article co-located without the number as MEDIUM (audit only)", () => {
     const text =

--- a/src/services/scrutin-substance/__tests__/debate-mapping.test.ts
+++ b/src/services/scrutin-substance/__tests__/debate-mapping.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { classifyDebateMatch } from "@/services/scrutin-substance/debate-mapping";
+
+describe("classifyDebateMatch — strict mapping (matched/ambiguous/missing/unsafe)", () => {
+  it("HIGH + exactly 1 candidate transcript → matched (exploitable)", () => {
+    const v = classifyDebateMatch({
+      hasCandidateTranscript: true,
+      candidateTranscriptCount: 1,
+      confidence: "HIGH",
+    });
+    expect(v.class).toBe("matched");
+    expect(v.exploitable).toBe(true);
+  });
+
+  it("HIGH but several same-day transcripts → ambiguous (session not proven)", () => {
+    const v = classifyDebateMatch({
+      hasCandidateTranscript: true,
+      candidateTranscriptCount: 3,
+      confidence: "HIGH",
+    });
+    expect(v.class).toBe("ambiguous");
+    expect(v.exploitable).toBe(false);
+  });
+
+  it("MEDIUM (author + article, no number) → ambiguous, never matched", () => {
+    const v = classifyDebateMatch({
+      hasCandidateTranscript: true,
+      candidateTranscriptCount: 1,
+      confidence: "MEDIUM",
+    });
+    expect(v.class).toBe("ambiguous");
+    expect(v.exploitable).toBe(false);
+  });
+
+  it("transcript present but NONE (no explicit mention) → unsafe", () => {
+    const v = classifyDebateMatch({
+      hasCandidateTranscript: true,
+      candidateTranscriptCount: 1,
+      confidence: "NONE",
+    });
+    expect(v.class).toBe("unsafe");
+    expect(v.exploitable).toBe(false);
+  });
+
+  it("transcript present but only LOW (author or article alone) → unsafe", () => {
+    const v = classifyDebateMatch({
+      hasCandidateTranscript: true,
+      candidateTranscriptCount: 2,
+      confidence: "LOW",
+    });
+    expect(v.class).toBe("unsafe");
+    expect(v.exploitable).toBe(false);
+  });
+
+  it("no candidate transcript at all → missing", () => {
+    const v = classifyDebateMatch({
+      hasCandidateTranscript: false,
+      candidateTranscriptCount: 0,
+      confidence: "NONE",
+    });
+    expect(v.class).toBe("missing");
+    expect(v.exploitable).toBe(false);
+  });
+
+  it("guards against count/flag mismatch: count 0 is treated as missing", () => {
+    const v = classifyDebateMatch({
+      hasCandidateTranscript: true,
+      candidateTranscriptCount: 0,
+      confidence: "HIGH",
+    });
+    expect(v.class).toBe("missing");
+  });
+
+  it("false positive protection: a same-day transcript that only echoes the dossier theme (NONE) is unsafe, never matched", () => {
+    // Mirrors the real 2084 case: transcript exists, dossier words present, but
+    // the amendment number is never cited → confidence NONE → must NOT be matched.
+    const v = classifyDebateMatch({
+      hasCandidateTranscript: true,
+      candidateTranscriptCount: 1,
+      confidence: "NONE",
+    });
+    expect(v.class).toBe("unsafe");
+    expect(v.exploitable).toBe(false);
+  });
+});

--- a/src/services/scrutin-substance/debate-context-resolver.ts
+++ b/src/services/scrutin-substance/debate-context-resolver.ts
@@ -19,6 +19,7 @@ import {
   type AmendmentMention,
   type DebateContextConfidence,
 } from "./debate-context";
+import { classifyDebateMatch, type DebateMatchClass } from "./debate-mapping";
 
 /** How candidate transcripts were gathered. Only "same-day" exists today;
  *  a future PR may add dossier/session disambiguation. */
@@ -32,6 +33,10 @@ export interface DebateContextResult extends AmendmentMention {
   candidateScope: CandidateScope;
   /** Number of same-day candidate transcripts considered. > 1 => ambiguous day. */
   candidateTranscriptCount: number;
+  /** How many of those candidates explicitly mention the amendment (HIGH). === 1
+   *  means the debate is uniquely localizable to a single séance, even on a
+   *  multi-séance day — the key signal for a future per-séance scoping. */
+  transcriptsMentioningAmendment: number;
 }
 
 const RANK: Record<DebateContextConfidence, number> = { HIGH: 3, MEDIUM: 2, LOW: 1, NONE: 0 };
@@ -77,10 +82,12 @@ export async function resolveDebateContextForScrutin(
     excerpt: null,
     matchedAmendmentNumber: null,
     usableForGeneration: false,
+    reinforced: false,
     transcriptSeanceRef: null,
     hasCandidateTranscript: false,
     candidateScope: "same-day",
     candidateTranscriptCount: 0,
+    transcriptsMentioningAmendment: 0,
   };
 
   if (!scrutin) return base;
@@ -102,12 +109,15 @@ export async function resolveDebateContextForScrutin(
   base.candidateTranscriptCount = candidates.length;
 
   let best = base;
+  let mentioning = 0;
   for (const t of candidates) {
     const m = findAmendmentMention(t.content, refs);
+    if (m.confidence === "HIGH") mentioning++;
     if (RANK[m.confidence] > RANK[best.confidence]) {
       best = { ...base, ...m, transcriptSeanceRef: t.seanceRef };
     }
   }
+  best.transcriptsMentioningAmendment = mentioning;
   return best;
 }
 
@@ -176,4 +186,149 @@ export async function auditDebateContextForAmendmentAnalyses(options?: {
   }
 
   return { scanned: scrutins.length, byConfidence, rows };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Key-vote mapping audit: the deterministic scrutin ↔ débat quality measurement.
+// Scope = key votes (ScrutinImportance.isKeyVote) that are linked to an amendment,
+// the only perimeter where the amendment-number matcher can prove a linkage.
+// Read-only: no write, no model call.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface KeyScrutinMappingRow {
+  scrutinId: string;
+  externalId: string;
+  slug: string | null;
+  votingDate: string; // YYYY-MM-DD
+  amendmentNumber: string;
+  matchClass: DebateMatchClass;
+  confidence: DebateContextConfidence;
+  hasCandidateTranscript: boolean;
+  candidateTranscriptCount: number;
+  reinforced: boolean;
+  /** HIGH where exactly one same-day séance cites the amendment: the debate is
+   *  uniquely localizable. Stays `ambiguous` under the strict rule, but measures
+   *  what a per-séance scoping could promote to `matched`. */
+  uniquelyLocalizable: boolean;
+  matchReason: string;
+  classReason: string;
+  transcriptSeanceRef: string | null;
+  excerpt: string | null;
+}
+
+export interface KeyScrutinMappingAudit {
+  scope: {
+    keyVotesWithAmendment: number;
+    keyVotesWithoutAmendment: number;
+  };
+  totals: {
+    scanned: number;
+    /** Transcripts gathered by date only (same-day), NOT a proven linkage. */
+    withSameDayTranscript: number;
+    /** HIGH: amendment number explicitly cited in the debate. The only proof. */
+    confidenceHigh: number;
+    /** MEDIUM/LOW: author/article only, never a sufficient explicit reference. */
+    confidenceMediumLow: number;
+    /** NONE: no exploitable signal, despite a same-day transcript. */
+    confidenceNone: number;
+    matched: number;
+    ambiguous: number;
+    unsafe: number;
+    missing: number;
+    /** Ambiguous cases a per-séance scoping could safely promote to matched. */
+    uniquelyLocalizable: number;
+  };
+  rows: KeyScrutinMappingRow[];
+}
+
+/** Resolve + classify a single scrutin into an auditable mapping row. */
+export async function mapScrutinDebate(scrutin: {
+  id: string;
+  externalId: string;
+  slug: string | null;
+  votingDate: Date;
+  amendmentNumber: string;
+}): Promise<KeyScrutinMappingRow> {
+  const ctx = await resolveDebateContextForScrutin(scrutin.id);
+  const verdict = classifyDebateMatch({
+    hasCandidateTranscript: ctx.hasCandidateTranscript,
+    candidateTranscriptCount: ctx.candidateTranscriptCount,
+    confidence: ctx.confidence,
+  });
+  return {
+    scrutinId: scrutin.id,
+    externalId: scrutin.externalId,
+    slug: scrutin.slug,
+    votingDate: scrutin.votingDate.toISOString().slice(0, 10),
+    amendmentNumber: scrutin.amendmentNumber,
+    matchClass: verdict.class,
+    confidence: ctx.confidence,
+    hasCandidateTranscript: ctx.hasCandidateTranscript,
+    candidateTranscriptCount: ctx.candidateTranscriptCount,
+    reinforced: ctx.reinforced,
+    uniquelyLocalizable: ctx.confidence === "HIGH" && ctx.transcriptsMentioningAmendment === 1,
+    matchReason: ctx.reason,
+    classReason: verdict.reason,
+    transcriptSeanceRef: ctx.transcriptSeanceRef,
+    excerpt: ctx.excerpt,
+  };
+}
+
+export async function auditKeyScrutinDebateMapping(options?: {
+  limit?: number;
+}): Promise<KeyScrutinMappingAudit> {
+  const [keyVotesWithAmendment, keyVotesWithoutAmendment] = await Promise.all([
+    db.scrutin.count({
+      where: { importance: { isKeyVote: true }, amendmentLinks: { some: {} } },
+    }),
+    db.scrutin.count({
+      where: { importance: { isKeyVote: true }, amendmentLinks: { none: {} } },
+    }),
+  ]);
+
+  const scrutins = await db.scrutin.findMany({
+    where: { importance: { isKeyVote: true }, amendmentLinks: { some: {} } },
+    orderBy: { votingDate: "desc" },
+    select: {
+      id: true,
+      externalId: true,
+      slug: true,
+      votingDate: true,
+      amendmentLinks: { select: { amendment: { select: { number: true } } }, take: 1 },
+    },
+    ...(options?.limit ? { take: options.limit } : {}),
+  });
+
+  const rows: KeyScrutinMappingRow[] = [];
+  for (const s of scrutins) {
+    rows.push(
+      await mapScrutinDebate({
+        id: s.id,
+        externalId: s.externalId,
+        slug: s.slug,
+        votingDate: s.votingDate,
+        amendmentNumber: s.amendmentLinks[0]?.amendment.number ?? "?",
+      })
+    );
+  }
+
+  const count = (c: DebateMatchClass): number => rows.filter((r) => r.matchClass === c).length;
+
+  return {
+    scope: { keyVotesWithAmendment, keyVotesWithoutAmendment },
+    totals: {
+      scanned: rows.length,
+      withSameDayTranscript: rows.filter((r) => r.hasCandidateTranscript).length,
+      confidenceHigh: rows.filter((r) => r.confidence === "HIGH").length,
+      confidenceMediumLow: rows.filter((r) => r.confidence === "MEDIUM" || r.confidence === "LOW")
+        .length,
+      confidenceNone: rows.filter((r) => r.confidence === "NONE").length,
+      matched: count("matched"),
+      ambiguous: count("ambiguous"),
+      unsafe: count("unsafe"),
+      missing: count("missing"),
+      uniquelyLocalizable: rows.filter((r) => r.uniquelyLocalizable).length,
+    },
+    rows,
+  };
 }

--- a/src/services/scrutin-substance/debate-context.ts
+++ b/src/services/scrutin-substance/debate-context.ts
@@ -25,6 +25,9 @@ export interface AmendmentMention {
   matchedAmendmentNumber: string | null;
   /** Only HIGH is trustworthy enough to feed a future generation. */
   usableForGeneration: boolean;
+  /** Diagnostic only: a HIGH match where the author or article is also cited near
+   *  the number. Strengthens confidence but is NEVER required to classify. */
+  reinforced: boolean;
 }
 
 const NONE: AmendmentMention = {
@@ -33,6 +36,7 @@ const NONE: AmendmentMention = {
   excerpt: null,
   matchedAmendmentNumber: null,
   usableForGeneration: false,
+  reinforced: false,
 };
 
 function escapeRegExp(s: string): string {
@@ -106,6 +110,21 @@ function articleIndexIn(folded: string, articleNum: string): number {
   return m ? m.index : -1;
 }
 
+/** Diagnostic: does the author surname or article number appear within ~300 chars
+ *  of the number match? Reinforces a HIGH, never required to classify it. */
+function reinforcedNear(folded: string, idx: number, amd: AmendmentRef): boolean {
+  const win = folded.slice(Math.max(0, idx - 300), idx + 300);
+  const surname =
+    amd.authorSurname && amd.authorSurname.trim().length >= 3
+      ? foldLower(amd.authorSurname.trim())
+      : "";
+  const articleNum = amd.article ? extractArticleNumber(amd.article) : null;
+  const hasSurname = surname.length > 0 && win.includes(surname);
+  const hasArticle =
+    articleNum != null && new RegExp(`article\\s+${escapeRegExp(articleNum)}(?![\\d])`).test(win);
+  return hasSurname || hasArticle;
+}
+
 export function findAmendmentMention(
   transcriptText: string,
   amendments: AmendmentRef[]
@@ -125,6 +144,7 @@ export function findAmendmentMention(
         excerpt: windowAround(spaced, idx),
         matchedAmendmentNumber: amd.number,
         usableForGeneration: true,
+        reinforced: reinforcedNear(folded, idx, amd),
       };
     }
   }
@@ -147,6 +167,7 @@ export function findAmendmentMention(
         excerpt: windowAround(spaced, Math.min(surnameIdx, articleIdx)),
         matchedAmendmentNumber: amd.number,
         usableForGeneration: false,
+        reinforced: false,
       };
     }
     if (!low && (surnameIdx >= 0 || articleIdx >= 0)) {
@@ -156,6 +177,7 @@ export function findAmendmentMention(
         excerpt: windowAround(spaced, surnameIdx >= 0 ? surnameIdx : articleIdx),
         matchedAmendmentNumber: amd.number,
         usableForGeneration: false,
+        reinforced: false,
       };
     }
   }

--- a/src/services/scrutin-substance/debate-mapping.ts
+++ b/src/services/scrutin-substance/debate-mapping.ts
@@ -1,0 +1,75 @@
+/**
+ * PURE classifier: turns a debate-context resolution into a deterministic,
+ * auditable verdict on whether a scrutin is reliably linked to the right debate.
+ *
+ * Strict mapping (no LLM, no I/O):
+ *   - matched   : amendment number cited (HIGH) AND a single same-day transcript
+ *                 → the only class an exploitable debate can come from.
+ *   - ambiguous : number cited but several same-day transcripts (session not
+ *                 proven), OR author+article proximity without the number (MEDIUM).
+ *   - unsafe    : a transcript exists but never cites the voted amendment (LOW/NONE)
+ *                 → the 2084 case: do NOT attribute, skip.
+ *   - missing   : no candidate transcript for that day at all.
+ *
+ * Only `matched` is exploitable. Everything else means "skip" for generation.
+ */
+import type { DebateContextConfidence } from "./debate-context";
+
+export type DebateMatchClass = "matched" | "ambiguous" | "missing" | "unsafe";
+
+export interface DebateMatchInput {
+  hasCandidateTranscript: boolean;
+  candidateTranscriptCount: number;
+  confidence: DebateContextConfidence;
+}
+
+export interface DebateMatchVerdict {
+  class: DebateMatchClass;
+  reason: string;
+  /** True only for `matched`: a single same-day transcript explicitly cites the amendment. */
+  exploitable: boolean;
+}
+
+export function classifyDebateMatch(input: DebateMatchInput): DebateMatchVerdict {
+  const { candidateTranscriptCount, confidence } = input;
+
+  if (!input.hasCandidateTranscript || candidateTranscriptCount <= 0) {
+    return {
+      class: "missing",
+      reason: "Aucun compte rendu de séance candidat ce jour-là.",
+      exploitable: false,
+    };
+  }
+
+  if (confidence === "HIGH") {
+    if (candidateTranscriptCount === 1) {
+      return {
+        class: "matched",
+        reason:
+          "Numéro d'amendement cité explicitement dans l'unique compte rendu candidat du jour.",
+        exploitable: true,
+      };
+    }
+    return {
+      class: "ambiguous",
+      reason: `Numéro cité, mais ${candidateTranscriptCount} comptes rendus le même jour : la séance exacte n'est pas prouvée.`,
+      exploitable: false,
+    };
+  }
+
+  if (confidence === "MEDIUM") {
+    return {
+      class: "ambiguous",
+      reason:
+        "Auteur et article à proximité, sans le numéro d'amendement : rattachement non prouvé.",
+      exploitable: false,
+    };
+  }
+
+  // LOW or NONE while a transcript exists: the voted amendment is never cited.
+  return {
+    class: "unsafe",
+    reason: "Compte rendu présent mais sans mention explicite de l'amendement voté.",
+    exploitable: false,
+  };
+}


### PR DESCRIPTION
## Objectif

Construire un rattachement **déterministe et auditable** entre un scrutin et le
bon extrait de débat parlementaire, et **mesurer** sa fiabilité avant tout
branchement sur la génération de `ScrutinAnalysis`. Aucun backfill, aucune
régénération, aucune écriture en base. Les garde-fous #392/#393/#394 restent
intacts (le pipeline de génération n'utilise pas ce resolver).

## Cause racine du bug actuel

`syncDebateTranscripts()` stocke un transcript **par séance** (tronqué à 5000
caractères) puis l'attache au **premier scrutin du jour sans débat**, par date
seule. Sur les 195 jours à plusieurs scrutins (jusqu'à 195 le même jour), la
quasi-totalité des scrutins reste sans débat et le rare scrutin lié l'est souvent
au mauvais.

## Ce que cette PR ajoute (read-only)

- `debate-mapping.ts` : classifieur **pur** `matched / ambiguous / unsafe / missing`.
- `debate-context-resolver.ts` : `auditKeyScrutinDebateMapping()` + `mapScrutinDebate()`,
  et un compteur `transcriptsMentioningAmendment` (débat localisable à une seule séance).
- `debate-context.ts` : champ diagnostic `reinforced` (numéro + auteur/article), non requis pour `matched`.
- `scripts/audit-scrutin-debate-mapping.ts` : script d'audit read-only.
- `docs/DATA-MATCHING.md` : section 9.

## Règle de classement (stricte)

| Classe | Règle |
| --- | --- |
| `matched` | HIGH (n° d'amendement cité) **et** un seul transcript same-day |
| `ambiguous` | HIGH multi-séances le même jour, **ou** MEDIUM |
| `unsafe` | transcript présent mais LOW/NONE (objet voté jamais cité) |
| `missing` | aucun transcript same-day |

## Chiffres (261 key votes liés à un amendement)

- Niveau de preuve : HIGH 142 (54,4%), MEDIUM/LOW 91 (34,9%), NONE 28 (10,7%).
- Classes : matched **0**, ambiguous 156, unsafe 105, missing 0.
- Localisables de façon unique (diagnostic) : **100 (38,3%)**.
- Cas sentinelle `VTANR5L17V7183` / amendement 2084 : reste **`unsafe`** (mentionne l'article 22, jamais le n° 2084).

## Recommandation

Ne pas brancher sur `ScrutinAnalysis` maintenant : `matched = 0`. Le verrou est
**l'ingestion**, pas le matcher :
1. scoper par **séance exacte** (heure de séance vs `Scrutin.votingDate`), ce qui
   promouvrait les 100 cas `uniquelyLocalizable` en `matched` ;
2. lever la **troncature à 5000 caractères** (ou indexer par intervention) pour
   récupérer une grande part des 105 `unsafe`.

## Vérification

- 33 tests verts (matcher, classifieur, resolver), couvrant : numéro explicite,
  article, plusieurs scrutins le même jour, ambigu, sans débat, faux positif basé
  sur le dossier.
- `tsc` propre sur le code touché, ESLint clean, aucun appel LLM dans la décision
  de rattachement.

```bash
npx dotenv -e .env -- npx tsx scripts/audit-scrutin-debate-mapping.ts
```
