### PR TITLE
fix(affairs): prevent weak press attribution from attaching to politician profiles

### DIFF
--- a/src/lib/affair-matching/__tests__/attribution-guard.test.ts
+++ b/src/lib/affair-matching/__tests__/attribution-guard.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import { assessPressAttribution } from "../attribution-guard";
+
+/**
+ * Regression suite for issue #376: the press sync must not attach a judicial
+ * affair to a politician who is merely quoted, commenting, locally in charge,
+ * or a homonym. These cases are the ones observed in production (5-8 June 2026).
+ *
+ * The guard runs at creation time, independently of the LLM's `involvement`
+ * field, and only ever BLOCKS an attachment — it never creates one.
+ */
+describe("assessPressAttribution (issue #376)", () => {
+  it("attaches when the politician is explicitly mis en cause", () => {
+    const text =
+      "Jérôme Barella a été mis en examen pour détournement de fonds publics. " +
+      "Le maire de la commune a réagi à cette annonce.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Jérôme",
+      lastName: "Barella",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(true);
+    expect(result.verdict).toBe("ATTACH");
+  });
+
+  it("blocks a minister who only reacts to the affair", () => {
+    const text =
+      "Une enquête a été ouverte après l'agression. Gérald Darmanin, ministre de " +
+      "l'Intérieur, a réagi en dénonçant ces violences et a appelé au calme.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Gérald",
+      lastName: "Darmanin",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("REACTION_ONLY");
+  });
+
+  it("blocks the local mayor who is not a party to the affair", () => {
+    const text =
+      "Les faits se sont déroulés dans une école de la ville. Pierre Lefort, maire de " +
+      "la commune, interrogé par la presse, a exprimé son émotion et son soutien aux victimes.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Pierre",
+      lastName: "Lefort",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("REACTION_ONLY");
+  });
+
+  it("blocks a first-name homonym even when someone with that surname is mis en cause", () => {
+    // Resolved politician is "Jean Louis Renon" but the article is about
+    // "Jean-Guy Renon", a different person who shares the surname.
+    const text =
+      "Jean-Guy Renon, adjoint au maire d'Ondres, a été mis en examen pour prise " +
+      "illégale d'intérêts.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Jean Louis",
+      lastName: "Renon",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("HOMONYM_OR_SURNAME_ONLY");
+  });
+
+  it("blocks a surname-only mention (full name never appears)", () => {
+    const text =
+      "Selon nos informations, Philippe aurait été entendu par les enquêteurs dans " +
+      "le cadre de cette affaire.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Édouard",
+      lastName: "Philippe",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("HOMONYM_OR_SURNAME_ONLY");
+  });
+
+  it("blocks when the politician's name is entirely absent from the text", () => {
+    const text =
+      "Une enquête pour violences sexuelles sur mineurs vise un animateur " +
+      "périscolaire. Les faits remontent à plusieurs mois.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Gérald",
+      lastName: "Darmanin",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("NAME_ABSENT");
+  });
+
+  it("does not mistake a speech verb (a condamné) for a conviction", () => {
+    // "a condamné ces agressions" is a statement, not a sentence handed down.
+    const text =
+      "Le ministre Gérald Darmanin a condamné ces agressions lors d'une conférence " +
+      "de presse et a salué le travail des forces de l'ordre.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Gérald",
+      lastName: "Darmanin",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("REACTION_ONLY");
+  });
+
+  it("attaches when the full name appears with a passive conviction", () => {
+    const text =
+      "Édouard Philippe a été condamné en première instance pour détournement de " +
+      "fonds publics au Havre.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Édouard",
+      lastName: "Philippe",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(true);
+    expect(result.verdict).toBe("ATTACH");
+  });
+
+  it("attaches a minister who is themselves mis en examen (mise en cause wins over the ministre framing)", () => {
+    const text =
+      "Le ministre Éric Dupond, mis en examen pour prise illégale d'intérêts, " +
+      "conteste les faits qui lui sont reprochés.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Éric",
+      lastName: "Dupond",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(true);
+    expect(result.verdict).toBe("ATTACH");
+  });
+
+  it("treats an empty surname as non-attributable", () => {
+    const result = assessPressAttribution({
+      text: "Un texte quelconque.",
+      firstName: "Jean",
+      lastName: "",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("NAME_ABSENT");
+  });
+
+  it("falls back to surname matching when no first name is on record", () => {
+    const text = "Mme Vautrin a été placée en garde à vue dans cette affaire de détournement.";
+    const result = assessPressAttribution({
+      text,
+      firstName: null,
+      lastName: "Vautrin",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(true);
+    expect(result.verdict).toBe("ATTACH");
+  });
+
+  // A VICTIM/PLAINTIFF politician is legitimately a party even when the text
+  // frames them through their function ("le maire de ..."). The reaction-only
+  // block applies to the perpetrator claim (DIRECT/INDIRECT), not to victims.
+  it("attaches a victim mayor even when framed by reaction/function markers", () => {
+    // "le maire de" + "a exprimé" would block a DIRECT (perpetrator) claim, but
+    // for a VICTIM the institutional framing is legitimate, not a false positive.
+    const text =
+      "Le maire de la commune, Pierre Lefort, a exprimé son inquiétude après avoir " +
+      "été victime de menaces de mort et avoir porté plainte.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Pierre",
+      lastName: "Lefort",
+      involvement: "VICTIM",
+    });
+    expect(result.attach).toBe(true);
+    expect(result.verdict).toBe("ATTACH");
+  });
+
+  it("would block that same framing if the involvement claimed the politician was the perpetrator", () => {
+    const text =
+      "Le maire de la commune, Pierre Lefort, a exprimé son inquiétude après avoir " +
+      "été victime de menaces de mort et avoir porté plainte.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Pierre",
+      lastName: "Lefort",
+      involvement: "DIRECT",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("REACTION_ONLY");
+  });
+
+  it("still blocks a homonym for a VICTIM involvement (wrong person)", () => {
+    const text = "Jean-Guy Renon a porté plainte après avoir été menacé.";
+    const result = assessPressAttribution({
+      text,
+      firstName: "Jean Louis",
+      lastName: "Renon",
+      involvement: "PLAINTIFF",
+    });
+    expect(result.attach).toBe(false);
+    expect(result.verdict).toBe("HOMONYM_OR_SURNAME_ONLY");
+  });
+});

--- a/src/lib/affair-matching/attribution-guard.ts
+++ b/src/lib/affair-matching/attribution-guard.ts
@@ -1,0 +1,197 @@
+/**
+ * Press attribution guard (issue #376).
+ *
+ * The deterministic affair-matching resolver answers "does the text mention this
+ * person?" — not "is this person a party to the procedure?". A minister who
+ * reacts to an affair, the mayor of the commune where the facts happened, or a
+ * homonym sharing the surname can all clear the resolver's SAME threshold on a
+ * full-name match alone. This guard runs at creation time, before any DB write,
+ * and BLOCKS those attachments. It never creates an attachment.
+ *
+ * It is intentionally conservative: when the evidence that the politician is a
+ * party to the affair is weak or ambiguous, the affair is not attached.
+ */
+
+export type AttributionVerdict =
+  | "ATTACH"
+  | "NAME_ABSENT"
+  | "HOMONYM_OR_SURNAME_ONLY"
+  | "REACTION_ONLY";
+
+/**
+ * Involvement levels the guard understands. Only DIRECT/INDIRECT claim the
+ * politician is the perpetrator, so only those get the reaction-only block.
+ */
+export type GuardInvolvement = "DIRECT" | "INDIRECT" | "VICTIM" | "PLAINTIFF" | "MENTIONED_ONLY";
+
+export interface AttributionGuardInput {
+  /** Full text of the article analysed by the press pipeline. */
+  text: string;
+  /** Resolved politician's first name, or null when unknown. */
+  firstName: string | null;
+  /** Resolved politician's last name. */
+  lastName: string;
+  /** Detected involvement; decides whether the reaction-only block applies. */
+  involvement: GuardInvolvement;
+}
+
+export interface AttributionGuardResult {
+  verdict: AttributionVerdict;
+  attach: boolean;
+  reason: string;
+}
+
+/** Window (in characters) scanned on each side of a surname occurrence. */
+const CONTEXT_WINDOW = 160;
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Patterns showing the named person is a party to the procedure (defendant,
+ * suspect, convicted). "condamné" is matched only in sentence forms
+ * ("a été condamné", "condamné à/pour") so a speech act ("a condamné ces
+ * faits") is NOT counted as a conviction.
+ */
+const MISE_EN_CAUSE_PATTERNS: RegExp[] = [
+  /\bmise?s? en examen\b/,
+  /\bmise?s? en cause\b/,
+  /\bpoursuivi(?:e|s|es)?\b/,
+  /\binculp(?:e|ee|es|ees)\b/,
+  /\bprevenu(?:e|s|es)?\b/,
+  /\bgarde a vue\b/,
+  /\bgardee? a vue\b/,
+  /\bplace(?:e|s|es)? en (?:garde a vue|detention)\b/,
+  /\b(?:a ete|ete|est|sera|fut|avait ete) condamne(?:e|s|es)?\b/,
+  /\bcondamne(?:e|s|es)? (?:a|pour|le|en|par)\b/,
+  /\bjuge(?:e|s|es)? pour\b/,
+  /\brenvoye(?:e|s|es)? (?:devant|en correctionnelle)\b/,
+  /\bdefere(?:e|s|es)?\b/,
+  /\becroue(?:e|s|es)?\b/,
+  /\bcomparai?t\b/,
+  /\bvise(?:e|s|es)? par (?:une enquete|des poursuites|une information judiciaire)\b/,
+  /\bsoupconne(?:e|s|es)? d(?:e|')\b/,
+  /\baccuse(?:e|s|es)? d(?:e|')\b/,
+  /\binterpelle(?:e|s|es)?\b/,
+  /\bmis en cause\b/,
+  /\bmandat de depot\b/,
+];
+
+/**
+ * Patterns showing the named person only reacts to or comments on the affair,
+ * or is named purely through an institutional function.
+ */
+const REACTION_PATTERNS: RegExp[] = [
+  /\ba reagi\b/,
+  /\breagit\b/,
+  /\ba declare\b/,
+  /\bdeclare que\b/,
+  /\ba denonce\b/,
+  /\bdenonce\b/,
+  /\ba condamne (?:ce|ces|cet|cette|les|l |la|le )/,
+  /\ba estime\b/,
+  /\ba regrette\b/,
+  /\ba salue\b/,
+  /\ba appele\b/,
+  /\bappelle au\b/,
+  /\ba exprime\b/,
+  /\ba indique\b/,
+  /\ba precise\b/,
+  /\ba affirme\b/,
+  /\ba reclame\b/,
+  /\bs(?:'|e )est dit\b/,
+  /\binterroge(?:e|s|es)? par\b/,
+  /\ble maire de\b/,
+  /\bla maire de\b/,
+  /\b(?:le|la) ministre\b/,
+  /\bau nom de la (?:commune|ville)\b/,
+];
+
+function matchesAny(haystack: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(haystack));
+}
+
+function result(
+  verdict: AttributionVerdict,
+  attach: boolean,
+  reason: string
+): AttributionGuardResult {
+  return { verdict, attach, reason };
+}
+
+/**
+ * Decide whether a press-detected affair may be attached to the resolved
+ * politician. Pure function, no DB/AI access.
+ */
+export function assessPressAttribution(input: AttributionGuardInput): AttributionGuardResult {
+  const text = normalize(input.text);
+  const lastName = normalize(input.lastName);
+
+  if (!lastName) {
+    return result("NAME_ABSENT", false, "Resolved politician has no usable last name");
+  }
+
+  const surnameRe = new RegExp(`\\b${escapeRegExp(lastName)}\\b`, "g");
+  const surnameMatches = [...text.matchAll(surnameRe)];
+  if (surnameMatches.length === 0) {
+    return result("NAME_ABSENT", false, `Last name "${input.lastName}" absent from the article`);
+  }
+
+  // Homonym / surname-only guard: when a first name is on record, the full name
+  // (first + last, adjacent) must appear, otherwise we cannot tell this person
+  // from a homonym or a surname-only mention.
+  const firstName = input.firstName ? normalize(input.firstName) : "";
+  if (firstName) {
+    const firstTokens = firstName.split(" ").filter(Boolean).map(escapeRegExp);
+    const fullNameRe = new RegExp(`\\b${firstTokens.join("\\s+")}\\s+${escapeRegExp(lastName)}\\b`);
+    if (!fullNameRe.test(text)) {
+      return result(
+        "HOMONYM_OR_SURNAME_ONLY",
+        false,
+        `Full name "${input.firstName} ${input.lastName}" not found; only the surname appears (homonym risk)`
+      );
+    }
+  }
+
+  // Participation analysis on the windows around every surname occurrence.
+  let hasMiseEnCause = false;
+  let hasReaction = false;
+  for (const match of surnameMatches) {
+    const index = match.index ?? 0;
+    const window = text.slice(
+      Math.max(0, index - CONTEXT_WINDOW),
+      index + lastName.length + CONTEXT_WINDOW
+    );
+    if (matchesAny(window, MISE_EN_CAUSE_PATTERNS)) hasMiseEnCause = true;
+    if (matchesAny(window, REACTION_PATTERNS)) hasReaction = true;
+  }
+
+  if (hasMiseEnCause) {
+    return result("ATTACH", true, "Mise en cause markers found near the politician's name");
+  }
+
+  // The reaction-only block only applies when the affair claims the politician
+  // is the perpetrator. A VICTIM/PLAINTIFF is legitimately a party even when the
+  // text frames them through their institutional function.
+  const claimsPerpetrator = input.involvement === "DIRECT" || input.involvement === "INDIRECT";
+  if (claimsPerpetrator && hasReaction) {
+    return result(
+      "REACTION_ONLY",
+      false,
+      "Politician appears only as a commenter / institutional function, not a party"
+    );
+  }
+
+  return result("ATTACH", true, "Politician named with no commentary-only framing");
+}

--- a/src/lib/affair-matching/index.ts
+++ b/src/lib/affair-matching/index.ts
@@ -20,3 +20,10 @@ export type {
   AffairSignalContext,
 } from "./signals/types";
 export { AffairSignalTier } from "./signals/types";
+export {
+  assessPressAttribution,
+  type AttributionGuardInput,
+  type AttributionGuardResult,
+  type AttributionVerdict,
+  type GuardInvolvement,
+} from "./attribution-guard";

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -26,7 +26,7 @@ import { findMatchingAffairs } from "@/services/affairs/matching";
 import { syncMetadata } from "@/lib/sync";
 import { classifyArticleTier, type ArticleTier } from "@/config/press-keywords";
 import { MIN_CONFIDENCE_THRESHOLD } from "@/config/press-analysis";
-import { resolveAffairPolitician } from "@/lib/affair-matching";
+import { resolveAffairPolitician, assessPressAttribution } from "@/lib/affair-matching";
 
 // ============================================
 // TYPES
@@ -254,6 +254,40 @@ export async function syncPressAnalysis(
         }
 
         const politicianId = resolveResult.topCandidateId;
+
+        // Attribution guard (issue #376): the resolver only confirms the name is
+        // in the article, not that this politician is a party to the procedure.
+        // Block attachments to commenters, the local mayor, reacting ministers
+        // and homonyms before any DB write, independently of the LLM-reported
+        // involvement.
+        const resolvedPolitician = await db.politician.findUnique({
+          where: { id: politicianId },
+          select: { firstName: true, lastName: true, fullName: true },
+        });
+        if (resolvedPolitician) {
+          const attribution = assessPressAttribution({
+            text: analysisContent,
+            firstName: resolvedPolitician.firstName,
+            lastName: resolvedPolitician.lastName,
+            involvement: detected.involvement,
+          });
+          if (!attribution.attach) {
+            if (verbose) {
+              console.log(
+                `  - Attribution bloquée (${attribution.verdict}) : ${resolvedPolitician.fullName} → "${detected.title}" ignoré`
+              );
+            }
+            await rejectWeakAttribution(
+              article.id,
+              politicianId,
+              detected,
+              attribution.verdict,
+              dryRun
+            );
+            stats.affairsRejected++;
+            continue;
+          }
+        }
 
         // Try to match with existing affairs
         const matches = await findMatchingAffairs({
@@ -613,6 +647,32 @@ async function rejectLowConfidenceAffair(
       politicianId,
       politicianName: detected.politicianName,
       detectedAffair: JSON.parse(JSON.stringify(detected)),
+      confidenceScore: detected.confidenceScore,
+    },
+  });
+}
+
+/**
+ * Log an affair detection rejected by the attribution guard (issue #376):
+ * the resolved politician is only commenting, locally in charge, reacting, or a
+ * homonym, so the affair is not attached to their profile. The guard verdict is
+ * stored alongside the detection for moderation audit.
+ */
+async function rejectWeakAttribution(
+  articleId: string,
+  politicianId: string | null,
+  detected: DetectedAffair,
+  verdict: string,
+  dryRun: boolean
+): Promise<void> {
+  if (dryRun) return;
+
+  await db.pressAnalysisRejection.create({
+    data: {
+      articleId,
+      politicianId,
+      politicianName: detected.politicianName,
+      detectedAffair: JSON.parse(JSON.stringify({ ...detected, attributionVerdict: verdict })),
       confidenceScore: detected.confidenceScore,
     },
   });


### PR DESCRIPTION
## Problème (#376)

Le sync presse créait des affaires judiciaires (`Affair` en `DRAFT`) sur le profil d'un élu seulement cité dans l'article, sans qu'il soit partie à la procédure. Cas observés en production (5-8 juin) : affaire accolée au ministre qui réagit ou au maire de la commune, rattachement à un homonyme.

Le resolver déterministe répond « ce nom figure-t-il dans le texte ? », pas « cette personne est-elle mise en cause ? ». Un nom complet exact suffit à dépasser le seuil d'auto-rattachement (`NAME_FULL_EXACT` 5.2 >= `SAME_THRESHOLD` 5.0), et `RoleContextSignal` récompense même le rôle « maire de [commune] ». Le seul garde-fou d'implication était l'`involvement` renvoyé par le LLM, suivi aveuglément.

## Correction

Un garde-fou déterministe et pur, `assessPressAttribution`, tourne dans le sync presse **avant toute écriture en base**, indépendamment de l'`involvement` du LLM. Il ne fait que **bloquer**, jamais créer. Il écarte :

- le ministre ou le maire qui commente / réagit (cadrage par la fonction ou verbes de réaction, sans verbe de mise en cause) ;
- l'homonyme de prénom (nom complet non adjacent dans le texte) ;
- le nom de famille seul ;
- le nom totalement absent du texte.

Précédence : l'homonyme est écarté en premier (jamais le mauvais profil), puis la mise en cause prime sur la réaction. La distinction « a été condamné » (peine) et « a condamné ces faits » (parole) est gérée explicitement. Pour les victimes et plaignants, le blocage « réaction seule » ne s'applique pas (une victime cadrée par sa fonction reste légitime). Les détections écartées sont tracées dans `PressAnalysisRejection` pour l'audit de modération.

Le scoring du resolver partagé n'est pas modifié : Judilibre, discover-affairs et l'admin gardent leur comportement.

## Tests

14 cas reproduisant les scénarios de l'issue (réaction ministre, maire du lieu, homonymie, nom seul, nom absent, mise en cause légitime, victime cadrée par sa fonction, distinction peine / parole). `npm run test:run` vert, typecheck et lint propres.

## Cas non couverts (assumés)

- Mention factuelle terse sans aucun marqueur : laissée passer (création en `DRAFT`, revue humaine).
- Faux `VICTIM` / `PLAINTIFF` (commentateur étiqueté victime par le LLM) : non bloqué par la logique réaction, seulement par les contrôles nom / homonyme.
- Repli « statut à attribuer » : non implémenté (nécessiterait une migration de schéma).

Closes #376
