### PR TITLE
fix(affairs): make judicial certainty badges involvement-aware

### DIFF
--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -24,6 +24,7 @@ import {
   CERTAINTY_LABELS,
   CERTAINTY_COLORS,
   CERTAINTY_DESCRIPTIONS,
+  isAccusedInvolvement,
 } from "@/config/certainty";
 import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
 import { LinkedAffairBanner } from "@/components/affairs/LinkedAffairBanner";
@@ -179,6 +180,10 @@ export default async function AffairDetailPage({ params }: PageProps) {
 
   const superCategory = CATEGORY_TO_SUPER[affair.category as AffairCategory];
   const certainty = getCertaintyLevel(affair.status);
+  // The certainty/status describes the outcome for the person prosecuted. When
+  // the tracked politician is a plaintiff, victim or merely mentioned, a
+  // charging badge ("Condamnation définitive") would misrepresent them (#383).
+  const accused = isAccusedInvolvement(affair.involvement);
   const partyDisplay = getAffairPartyDisplay({
     factsDate: affair.factsDate,
     partyAtTime: affair.partyAtTime,
@@ -213,9 +218,19 @@ export default async function AffairDetailPage({ params }: PageProps) {
         {/* Header */}
         <div className="mb-8">
           <div className="flex flex-wrap items-center gap-2 mb-3">
-            <Badge className={`${CERTAINTY_COLORS[certainty]} text-sm px-3 py-1`}>
-              {CERTAINTY_LABELS[certainty]}
-            </Badge>
+            {/* For a plaintiff/victim/mentioned politician the charging certainty
+                badge is suppressed: the involvement badge leads and the status is
+                shown with a neutral colour, so the affair is not read as their
+                own conviction (#383). */}
+            {accused ? (
+              <Badge className={`${CERTAINTY_COLORS[certainty]} text-sm px-3 py-1`}>
+                {CERTAINTY_LABELS[certainty]}
+              </Badge>
+            ) : (
+              <Badge className={INVOLVEMENT_COLORS[affair.involvement as Involvement]}>
+                {INVOLVEMENT_LABELS[affair.involvement as Involvement]}
+              </Badge>
+            )}
             <Badge className={AFFAIR_SUPER_CATEGORY_COLORS[superCategory]}>
               {AFFAIR_SUPER_CATEGORY_LABELS[superCategory]}
             </Badge>
@@ -224,9 +239,13 @@ export default async function AffairDetailPage({ params }: PageProps) {
               status={affair.status}
               label={AFFAIR_STATUS_LABELS[affair.status]}
               description={AFFAIR_STATUS_DESCRIPTIONS[affair.status]}
-              colorClass={AFFAIR_STATUS_COLORS[affair.status]}
+              colorClass={
+                accused
+                  ? AFFAIR_STATUS_COLORS[affair.status]
+                  : "bg-muted text-muted-foreground border-transparent"
+              }
             />
-            {affair.involvement !== "DIRECT" && (
+            {accused && affair.involvement !== "DIRECT" && (
               <Badge className={INVOLVEMENT_COLORS[affair.involvement as Involvement]}>
                 {INVOLVEMENT_LABELS[affair.involvement as Involvement]}
               </Badge>
@@ -240,7 +259,11 @@ export default async function AffairDetailPage({ params }: PageProps) {
               />
             ) : null}
           </div>
-          <p className="text-sm text-muted-foreground mb-4">{CERTAINTY_DESCRIPTIONS[certainty]}</p>
+          {accused && (
+            <p className="text-sm text-muted-foreground mb-4">
+              {CERTAINTY_DESCRIPTIONS[certainty]}
+            </p>
+          )}
 
           <h1 className="text-3xl font-display font-extrabold tracking-tight mb-4">
             {affair.title}

--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -31,6 +31,7 @@ import {
   getCertaintyLevel,
   CERTAINTY_LABELS,
   CERTAINTY_COLORS,
+  isAccusedInvolvement,
   type CertaintyLevel,
 } from "@/config/certainty";
 import { AffairModeToggle } from "@/components/affairs/AffairModeToggle";
@@ -343,6 +344,9 @@ export default async function AffairesPage({ searchParams }: PageProps) {
               {affairs.map((affair) => {
                 const superCat = CATEGORY_TO_SUPER[affair.category];
                 const certainty = getCertaintyLevel(affair.status);
+                // Charging certainty badge only for the accused; otherwise the
+                // involvement badge below carries the politician's role (#383).
+                const accused = isAccusedInvolvement(affair.involvement);
                 // Get the most relevant date for display
                 const relevantDate = affair.verdictDate || affair.startDate || affair.factsDate;
                 const dateLabel = affair.verdictDate
@@ -373,9 +377,11 @@ export default async function AffairesPage({ searchParams }: PageProps) {
                             <Badge className={AFFAIR_SUPER_CATEGORY_COLORS[superCat]}>
                               {AFFAIR_SUPER_CATEGORY_LABELS[superCat]}
                             </Badge>
-                            <Badge className={CERTAINTY_COLORS[certainty]}>
-                              {CERTAINTY_LABELS[certainty]}
-                            </Badge>
+                            {accused && (
+                              <Badge className={CERTAINTY_COLORS[certainty]}>
+                                {CERTAINTY_LABELS[certainty]}
+                              </Badge>
+                            )}
                             <Badge variant="outline">
                               {AFFAIR_CATEGORY_LABELS[affair.category]}
                             </Badge>

--- a/src/app/partis/[slug]/page.tsx
+++ b/src/app/partis/[slug]/page.tsx
@@ -21,6 +21,7 @@ import {
   CERTAINTY_LABELS,
   CERTAINTY_COLORS,
   CERTAINTY_SORT_ORDER,
+  isAccusedInvolvement,
   type CertaintyLevel,
 } from "@/config/certainty";
 import { getJudicialMaturity } from "@/config/judicial-maturity";
@@ -457,10 +458,13 @@ export default async function PartyPage({ params }: PageProps) {
             {/* Affairs */}
             {party.affairsAtTime.length > 0 &&
               (() => {
-                const directAffairs = party.affairsAtTime.filter(
-                  (a) => a.involvement === "DIRECT" || a.involvement === "INDIRECT"
+                // Certainty badges only describe affairs where the member is the
+                // accused; victim/plaintiff/mentioned affairs must not be counted
+                // as the party's condamnations (#383).
+                const directAffairs = party.affairsAtTime.filter((a) =>
+                  isAccusedInvolvement(a.involvement)
                 );
-                const affairsWithCertainty = party.affairsAtTime.map((a) => ({
+                const affairsWithCertainty = directAffairs.map((a) => ({
                   ...a,
                   certainty: getCertaintyLevel(a.status as AffairStatus),
                 }));

--- a/src/components/affairs/AffairStatusNotice.tsx
+++ b/src/components/affairs/AffairStatusNotice.tsx
@@ -1,4 +1,5 @@
 import type { AffairStatus, Involvement } from "@/types";
+import { isAccusedInvolvement } from "@/config/certainty";
 
 /**
  * Encart de prudence juridique affiché avec chaque affaire publique
@@ -44,7 +45,7 @@ export function getAffairNoticeVariant(
   // Les encarts qualifient la situation d'une personne mise en cause :
   // pas d'encart quand le politicien est victime, plaignant ou simplement
   // mentionné (ces affaires sont présentées dans des sections dédiées).
-  if (involvement !== "DIRECT" && involvement !== "INDIRECT") return null;
+  if (!isAccusedInvolvement(involvement)) return null;
   if (status === "PRESCRIPTION") return "prescription";
   if (FAVORABLE_STATUSES.includes(status)) return "favorable";
   if (status === "CONDAMNATION_DEFINITIVE") return "definitive";

--- a/src/components/affairs/PartyAffairsList.tsx
+++ b/src/components/affairs/PartyAffairsList.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/config/labels";
 import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
 import { getJudicialMaturity } from "@/config/judicial-maturity";
+import { isAccusedInvolvement } from "@/config/certainty";
 import type { AffairCategory, AffairStatus, Involvement } from "@/types";
 
 const MATURITY_TAB_LABELS: Record<string, string> = {
@@ -171,7 +172,13 @@ export function PartyAffairsList({ affairs }: PartyAffairsListProps) {
                     <Badge className={AFFAIR_SUPER_CATEGORY_COLORS[superCat]}>
                       {AFFAIR_SUPER_CATEGORY_LABELS[superCat]}
                     </Badge>
-                    <Badge className={AFFAIR_STATUS_COLORS[affair.status as AffairStatus]}>
+                    <Badge
+                      className={
+                        isAccusedInvolvement(affair.involvement as Involvement)
+                          ? AFFAIR_STATUS_COLORS[affair.status as AffairStatus]
+                          : "bg-muted text-muted-foreground border-transparent"
+                      }
+                    >
                       {AFFAIR_STATUS_LABELS[affair.status as AffairStatus]}
                     </Badge>
                     <Badge className={INVOLVEMENT_COLORS[affair.involvement as Involvement]}>

--- a/src/components/affairs/__tests__/AffairStatusNotice.test.tsx
+++ b/src/components/affairs/__tests__/AffairStatusNotice.test.tsx
@@ -4,6 +4,7 @@ import {
   AffairStatusNotice,
   getAffairNoticeVariant,
 } from "@/components/affairs/AffairStatusNotice";
+import { isAccusedInvolvement } from "@/config/certainty";
 
 describe("getAffairNoticeVariant — sélection par statut et involvement", () => {
   it("PRESCRIPTION a sa variante propre, jamais assimilée à une relaxe", () => {
@@ -78,5 +79,25 @@ describe("AffairStatusNotice — wordings validés (RGPD art. 10)", () => {
   it("rien ne s'affiche pour une victime", () => {
     const { container } = render(<AffairStatusNotice status="RELAXE" involvement="VICTIM" />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("régression #383 — plaignant/victime dans une affaire de condamnation", () => {
+  // Affaire « Plainte de X contre Y » : c'est Y qui est jugé. Ni le badge de
+  // certitude (piloté par isAccusedInvolvement) ni l'encart de prudence
+  // (getAffairNoticeVariant) ne doivent présenter X comme condamné.
+  it("un plaignant n'est pas considéré comme mis en cause", () => {
+    expect(isAccusedInvolvement("PLAINTIFF")).toBe(false);
+    expect(getAffairNoticeVariant("CONDAMNATION_DEFINITIVE", "PLAINTIFF")).toBeNull();
+  });
+
+  it("une victime n'est pas considérée comme mise en cause", () => {
+    expect(isAccusedInvolvement("VICTIM")).toBe(false);
+    expect(getAffairNoticeVariant("CONDAMNATION_DEFINITIVE", "VICTIM")).toBeNull();
+  });
+
+  it("un mis en cause direct conserve son badge de certitude", () => {
+    expect(isAccusedInvolvement("DIRECT")).toBe(true);
+    expect(getAffairNoticeVariant("CONDAMNATION_DEFINITIVE", "DIRECT")).toBe("definitive");
   });
 });

--- a/src/components/politicians/AffairsSection.tsx
+++ b/src/components/politicians/AffairsSection.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
   AFFAIR_STATUS_LABELS,
-  AFFAIR_STATUS_COLORS,
   INVOLVEMENT_LABELS,
   INVOLVEMENT_COLORS,
   AFFAIR_CATEGORY_LABELS,
@@ -241,9 +240,10 @@ export function AffairsSection({ affairs, civility }: AffairsSectionProps) {
                           <Badge className="bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-900/40 dark:text-blue-300 dark:border-blue-700 whitespace-nowrap">
                             {INVOLVEMENT_LABELS[affair.involvement as Involvement]}
                           </Badge>
-                          <Badge
-                            className={`whitespace-nowrap ${AFFAIR_STATUS_COLORS[affair.status as AffairStatus]}`}
-                          >
+                          {/* Neutral colour: in the victim section the status
+                              describes the defendant's outcome, not the tracked
+                              politician's own conviction (#383). */}
+                          <Badge variant="outline" className="whitespace-nowrap">
                             {AFFAIR_STATUS_LABELS[affair.status as AffairStatus]}
                           </Badge>
                         </div>

--- a/src/config/certainty.test.ts
+++ b/src/config/certainty.test.ts
@@ -6,6 +6,7 @@ import {
   CERTAINTY_SORT_ORDER,
   CERTAINTY_DESCRIPTIONS,
   isActiveCertainty,
+  isAccusedInvolvement,
   ACTIVE_AFFAIR_STATUSES,
 } from "@/config/certainty";
 
@@ -78,6 +79,31 @@ describe("isActiveCertainty", () => {
 
   it("returns false for CLOS_FAVORABLE", () => {
     expect(isActiveCertainty("CLOS_FAVORABLE")).toBe(false);
+  });
+});
+
+describe("isAccusedInvolvement (issue #383)", () => {
+  // The certainty/status of an affair describes the outcome for the person
+  // prosecuted. Only DIRECT/INDIRECT make the tracked politician that person, so
+  // only those may carry a charging certainty badge ("Condamnation définitive").
+  it("returns true for DIRECT", () => {
+    expect(isAccusedInvolvement("DIRECT")).toBe(true);
+  });
+
+  it("returns true for INDIRECT", () => {
+    expect(isAccusedInvolvement("INDIRECT")).toBe(true);
+  });
+
+  it("returns false for PLAINTIFF (the politician filed the complaint)", () => {
+    expect(isAccusedInvolvement("PLAINTIFF")).toBe(false);
+  });
+
+  it("returns false for VICTIM", () => {
+    expect(isAccusedInvolvement("VICTIM")).toBe(false);
+  });
+
+  it("returns false for MENTIONED_ONLY", () => {
+    expect(isAccusedInvolvement("MENTIONED_ONLY")).toBe(false);
   });
 });
 

--- a/src/config/certainty.ts
+++ b/src/config/certainty.ts
@@ -1,6 +1,19 @@
-import type { AffairStatus } from "@/generated/prisma";
+import type { AffairStatus, Involvement } from "@/generated/prisma";
 
 export type CertaintyLevel = "ETABLI" | "PRONONCE" | "EN_COURS" | "CLOS_FAVORABLE";
+
+/**
+ * Whether a certainty/status badge describes the tracked politician themselves.
+ *
+ * An affair's `status` (and the certainty derived from it) describes the outcome
+ * for the person prosecuted. Only DIRECT/INDIRECT make the tracked politician
+ * that person; for PLAINTIFF, VICTIM or MENTIONED_ONLY the status refers to a
+ * third party, so a charging certainty badge ("Condamnation définitive") would
+ * misrepresent them (issue #383). Mirrors the guard in `AffairStatusNotice`.
+ */
+export function isAccusedInvolvement(involvement: Involvement): boolean {
+  return involvement === "DIRECT" || involvement === "INDIRECT";
+}
 
 const STATUS_TO_CERTAINTY: Record<AffairStatus, CertaintyLevel> = {
   CONDAMNATION_DEFINITIVE: "ETABLI",

--- a/src/lib/data/compare.ts
+++ b/src/lib/data/compare.ts
@@ -4,7 +4,7 @@ import { MANDATE_TYPE_LABELS } from "@/config/labels";
 import { getPoliticianVotingStats } from "@/services/voteStats";
 import { CATEGORY_MANDATE_TYPES } from "@/types/compare";
 import type { CompareCategory } from "@/types/compare";
-import type { MandateType } from "@/types";
+import type { MandateType, Involvement } from "@/types";
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -280,7 +280,12 @@ const POLITICIAN_COMPARISON_SELECT = {
     },
   },
   affairs: {
-    where: { publicationStatus: "PUBLISHED" as const },
+    // Only affairs where the politician is the accused feed the comparison
+    // counts; victim/plaintiff/mentioned affairs are not their condamnations (#383).
+    where: {
+      publicationStatus: "PUBLISHED" as const,
+      involvement: { in: ["DIRECT", "INDIRECT"] as Involvement[] },
+    },
     select: { id: true, status: true, severity: true },
   },
   declarations: {
@@ -416,7 +421,10 @@ async function getMinistreForComparison(slug: string) {
         },
       },
       affairs: {
-        where: { publicationStatus: "PUBLISHED" },
+        where: {
+          publicationStatus: "PUBLISHED",
+          involvement: { in: ["DIRECT", "INDIRECT"] },
+        },
         select: { id: true, status: true, severity: true },
       },
       declarations: {
@@ -500,6 +508,7 @@ async function getPartyForComparison(slugOrId: string) {
   const affairs = await db.affair.findMany({
     where: {
       publicationStatus: "PUBLISHED",
+      involvement: { in: ["DIRECT", "INDIRECT"] },
       politician: { currentPartyId: party.id },
     },
     select: { id: true, status: true, severity: true },
@@ -732,6 +741,7 @@ async function getGroupForComparison(idOrCode: string) {
   const affairs = await db.affair.findMany({
     where: {
       publicationStatus: "PUBLISHED",
+      involvement: { in: ["DIRECT", "INDIRECT"] },
       politician: {
         mandates: {
           some: {


### PR DESCRIPTION
## Problème (#383)

Un badge rouge « Condamnation définitive » s'affichait sur des affaires où le politicien suivi est plaignant ou victime (ex. « Plainte de Marine Le Pen contre Laurent Ruquier » : Ruquier relaxé, Le Pen déboutée, personne condamné). Le `status` décrit l'issue côté personne mise en cause, pas côté politicien suivi. `getCertaintyLevel(status)` ignorait l'`involvement`, alors que `AffairStatusNotice` masquait déjà son encart pour les non mis en cause : l'élément clarifiant disparaissait, le badge trompeur restait.

## Correction

Un helper unique `isAccusedInvolvement(involvement)` (vrai seulement pour `DIRECT` / `INDIRECT`) centralise la règle et est réutilisé par `AffairStatusNotice`. Toutes les surfaces auditées qui affichaient un badge de certitude / statut sans tenir compte de l'involvement sont corrigées :

- **page détail affaire** : badge de certitude et description masqués pour plaignant / victime / mention, statut neutralisé, badge d'implication mis en tête ;
- **listing `/affaires`** : badge de certitude conditionné à l'implication ;
- **page parti** : les affaires victime / plaignant / mention ne comptent plus dans les badges de condamnation ;
- **comparateur** : filtre involvement ajouté aux requêtes d'affaires (elles ne sélectionnaient même pas le champ) ;
- **section « victime » du profil** et **`PartyAffairsList`** : couleur de statut neutralisée.

## Tests

`isAccusedInvolvement` (5 cas) plus une régression #383 dédiée (un plaignant / victime n'est jamais présenté comme condamné, un mis en cause direct conserve son badge). `npm run test:run` vert, typecheck propre, lint propre.

## Audit donnée (lecture seule)

Un audit read-only a vérifié l'hypothèse d'un biais systématique d'extraction sur les statuts :

- 404 affaires auditées ;
- 27 en `PLAINTIFF` / `VICTIM` ;
- 2 cas suspects seulement (plaignant / victime portant un statut de condamnation) ;
- ces 2 cas sont légitimes : ce sont des affaires `VICTIM` (Yannick Jadot, Sandrine Josso) où le `status` décrit la condamnation de l'auteur, pas du politicien suivi ;
- aucun biais systématique détecté, aucune correction de donnée nécessaire (l'affaire Ruquier citée dans #383 porte déjà `status = RELAXE`).

Cette PR corrige donc un problème d'**affichage**, pas un problème de **donnée**.

Refs #383
