### PR TITLE
fix(admin-affairs): surface moderation failures and preserve rejection reasons

### DIFF
--- a/src/app/admin/affaires/page.tsx
+++ b/src/app/admin/affaires/page.tsx
@@ -25,6 +25,11 @@ import {
   Scale,
 } from "lucide-react";
 import { AffairesPageSkeleton } from "./_components/AffairesPageSkeleton";
+import {
+  buildApplyAiPayload,
+  buildBulkPayload,
+  summarizeModerationResult,
+} from "@/lib/admin/moderation-payload";
 import type { PublicationStatus } from "@/generated/prisma";
 
 interface AffairItem {
@@ -93,6 +98,7 @@ export default function AdminAffairsPage() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [applyingAI, setApplyingAI] = useState(false);
   const [enrichingId, setEnrichingId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<{ ok: boolean; message: string } | null>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   // Read state from URL
@@ -146,15 +152,20 @@ export default function AdminAffairsPage() {
   async function handleBulk(action: "publish" | "reject" | "delete", rejectionReason?: string) {
     if (selected.size === 0) return;
     setBulkLoading(true);
+    setFeedback(null);
     try {
       const res = await fetch("/api/admin/affaires/bulk", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ids: [...selected], action, rejectionReason }),
+        body: JSON.stringify(buildBulkPayload(action, [...selected], rejectionReason)),
       });
+      const data = await res.json().catch(() => ({}));
       if (res.ok) {
+        setFeedback(summarizeModerationResult(data));
         setSelected(new Set());
         fetchData();
+      } else {
+        setFeedback({ ok: false, message: "Échec de l'action groupée. Réessayez." });
       }
     } finally {
       setBulkLoading(false);
@@ -162,20 +173,24 @@ export default function AdminAffairsPage() {
   }
 
   async function handleApplyAI(recommendation: "PUBLISH" | "REJECT") {
-    const reviewIds = affairs
-      .flatMap((a) => a.moderationReviews)
-      .filter((r) => r.recommendation === recommendation)
-      .map((r) => r.id);
-    if (reviewIds.length === 0) return;
+    const payload = buildApplyAiPayload(affairs, recommendation);
+    if (payload.ids.length === 0) return;
 
     setApplyingAI(true);
+    setFeedback(null);
     try {
       const res = await fetch("/api/admin/affaires/moderate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ reviewIds, action: "apply" }),
+        body: JSON.stringify(payload),
       });
-      if (res.ok) fetchData();
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        setFeedback(summarizeModerationResult(data));
+        fetchData();
+      } else {
+        setFeedback({ ok: false, message: "Échec de l'application des recommandations IA." });
+      }
     } finally {
       setApplyingAI(false);
     }
@@ -232,6 +247,29 @@ export default function AdminAffairsPage() {
           </Link>
         </Button>
       </div>
+
+      {/* Moderation feedback (surfaces publish-guard failures, #364) */}
+      {feedback && (
+        <div
+          role={feedback.ok ? "status" : "alert"}
+          aria-live="polite"
+          className={`flex items-start justify-between gap-3 rounded-lg border p-3 text-sm ${
+            feedback.ok
+              ? "border-emerald-200 bg-emerald-50 text-emerald-800"
+              : "border-amber-300 bg-amber-50 text-amber-900"
+          }`}
+        >
+          <span>{feedback.message}</span>
+          <button
+            type="button"
+            onClick={() => setFeedback(null)}
+            aria-label="Masquer le message"
+            className="shrink-0 opacity-60 hover:opacity-100"
+          >
+            Fermer
+          </button>
+        </div>
+      )}
 
       {/* Tabs */}
       <div

--- a/src/components/admin/AffairForm.tsx
+++ b/src/components/admin/AffairForm.tsx
@@ -16,6 +16,7 @@ import {
   PUBLICATION_STATUS_OPTIONS,
 } from "@/config/labels";
 import { LinkedAffairSelect } from "@/components/admin/LinkedAffairSelect";
+import { formatAffairFormError } from "@/lib/admin/moderation-payload";
 import type { AffairStatus, AffairCategory, Involvement, SourceType } from "@/types";
 import type { PublicationStatus } from "@/generated/prisma";
 
@@ -170,19 +171,9 @@ export function AffairForm({ politicians, initialData }: AffairFormProps) {
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        // Handle Zod flattened errors (object) vs simple string errors
-        if (data.error && typeof data.error === "object") {
-          const flat = data.error;
-          const messages: string[] = [...(flat.formErrors || [])];
-          if (flat.fieldErrors) {
-            for (const [field, errs] of Object.entries(flat.fieldErrors)) {
-              if (Array.isArray(errs)) messages.push(`${field}: ${errs.join(", ")}`);
-            }
-          }
-          throw new Error(messages.join(" | ") || "Erreur de validation");
-        }
-        throw new Error(data.error || "Erreur lors de la sauvegarde");
+        const data = await response.json().catch(() => ({}));
+        // Surfaces publish-guard reasons (422), Zod errors, and plain messages.
+        throw new Error(formatAffairFormError(data));
       }
 
       router.push("/admin/affaires");

--- a/src/lib/admin/moderation-payload.test.ts
+++ b/src/lib/admin/moderation-payload.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildApplyAiPayload,
+  buildBulkPayload,
+  summarizeModerationResult,
+  formatAffairFormError,
+  type AffairForAi,
+} from "./moderation-payload";
+import { moderateAffairSchema, bulkAffairSchema } from "@/lib/security/schemas/affair";
+
+/**
+ * Regression suite for issue #364: the admin moderation UI sent payloads the
+ * API could not accept, lost the rejection reason, and ignored the publish
+ * guard's structured failures. These tests round-trip the built payloads
+ * through the real server schemas, so they fail if the contract drifts again.
+ */
+const AFFAIRS: AffairForAi[] = [
+  { id: "affair-1", moderationReviews: [{ recommendation: "PUBLISH" }] },
+  { id: "affair-2", moderationReviews: [{ recommendation: "REJECT" }] },
+  {
+    id: "affair-3",
+    moderationReviews: [{ recommendation: "PUBLISH" }, { recommendation: "NEEDS_REVIEW" }],
+  },
+];
+
+describe("buildApplyAiPayload (#364 — apply AI button)", () => {
+  it("collects affair ids (not review ids) for the matching recommendation", () => {
+    expect(buildApplyAiPayload(AFFAIRS, "PUBLISH").ids).toEqual(["affair-1", "affair-3"]);
+    expect(buildApplyAiPayload(AFFAIRS, "REJECT").ids).toEqual(["affair-2"]);
+  });
+
+  it("maps the recommendation to the schema action", () => {
+    expect(buildApplyAiPayload(AFFAIRS, "PUBLISH").action).toBe("publish");
+    expect(buildApplyAiPayload(AFFAIRS, "REJECT").action).toBe("reject");
+  });
+
+  it("produces a payload the server schema accepts", () => {
+    expect(moderateAffairSchema.safeParse(buildApplyAiPayload(AFFAIRS, "PUBLISH")).success).toBe(
+      true
+    );
+  });
+
+  it("documents the bug: the legacy {reviewIds, action:'apply'} payload is rejected", () => {
+    expect(moderateAffairSchema.safeParse({ reviewIds: ["r1"], action: "apply" }).success).toBe(
+      false
+    );
+  });
+});
+
+describe("buildBulkPayload (#364 — rejection reason preserved)", () => {
+  it("carries the rejection reason under `value`, the field the route reads", () => {
+    const parsed = bulkAffairSchema.parse(
+      buildBulkPayload("reject", ["a1", "a2"], "Source absente")
+    );
+    expect(parsed.value).toBe("Source absente");
+  });
+
+  it("documents the bug: the legacy `rejectionReason` field is stripped to undefined", () => {
+    const legacy = bulkAffairSchema.parse({ ids: ["a1"], action: "reject", rejectionReason: "x" });
+    expect(legacy.value).toBeUndefined();
+  });
+
+  it("omits `value` when no reason is supplied", () => {
+    const payload = buildBulkPayload("publish", ["a1"]);
+    expect(payload.value).toBeUndefined();
+    expect(bulkAffairSchema.safeParse(payload).success).toBe(true);
+  });
+});
+
+describe("summarizeModerationResult (#364 — no false success)", () => {
+  it("reports success when nothing failed", () => {
+    const r = summarizeModerationResult({ updated: 3, failed: [] });
+    expect(r.ok).toBe(true);
+    expect(r.message).toContain("3");
+  });
+
+  it("surfaces the publish-guard failures instead of a false success", () => {
+    const r = summarizeModerationResult({
+      updated: 0,
+      failed: [{ id: "a1", reasons: ["aucune source vérifiable"] }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toContain("aucune source vérifiable");
+  });
+
+  it("reports a partial success (some published, some blocked)", () => {
+    const r = summarizeModerationResult({
+      updated: 2,
+      failed: [{ id: "a3", reasons: ["rattachement non validé"] }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toContain("2");
+    expect(r.message).toContain("rattachement non validé");
+  });
+
+  it("handles the delete response shape", () => {
+    expect(summarizeModerationResult({ deleted: 5 }).ok).toBe(true);
+  });
+});
+
+describe("formatAffairFormError (#364 — publish-guard reasons)", () => {
+  it("surfaces the 422 publish-guard reasons", () => {
+    const msg = formatAffairFormError({
+      error: "Affaire non publiable",
+      reasons: ["aucune source vérifiable", "rattachement non validé"],
+      fieldsSaved: true,
+    });
+    expect(msg).toContain("aucune source vérifiable");
+    expect(msg).toContain("rattachement non validé");
+  });
+
+  it("falls back to a plain string error", () => {
+    expect(formatAffairFormError({ error: "Erreur serveur" })).toContain("Erreur serveur");
+  });
+
+  it("flattens a Zod object error", () => {
+    const msg = formatAffairFormError({
+      error: { formErrors: ["Erreur globale"], fieldErrors: { title: ["requis"] } },
+    });
+    expect(msg).toContain("Erreur globale");
+    expect(msg).toContain("title");
+  });
+});

--- a/src/lib/admin/moderation-payload.ts
+++ b/src/lib/admin/moderation-payload.ts
@@ -1,0 +1,130 @@
+/**
+ * Client-side contract helpers for the admin affairs moderation UI (issue #364).
+ *
+ * The page used to send payloads the API could not accept, lost the rejection
+ * reason, and ignored the publish guard's `failed[]` list. These pure helpers
+ * build the exact shapes the server schemas expect and turn the responses into
+ * user-facing messages, so the contract is covered by unit tests rather than
+ * buried inside the component.
+ */
+
+export type AiRecommendation = "PUBLISH" | "REJECT";
+
+export interface AffairForAi {
+  id: string;
+  moderationReviews: { recommendation: "PUBLISH" | "REJECT" | "NEEDS_REVIEW" }[];
+}
+
+/** Matches `moderateAffairSchema` (ids = affair ids, action enum). */
+export interface ModeratePayload {
+  ids: string[];
+  action: "publish" | "exclude" | "reject" | "archive";
+}
+
+/** Matches `bulkAffairSchema` (action string, optional `value`). */
+export interface BulkPayload {
+  ids: string[];
+  action: string;
+  value?: string;
+}
+
+const RECOMMENDATION_TO_ACTION: Record<AiRecommendation, ModeratePayload["action"]> = {
+  PUBLISH: "publish",
+  REJECT: "reject",
+};
+
+/**
+ * Build the `/moderate` payload that applies an AI recommendation. Collects the
+ * AFFAIR ids (not the moderation-review ids) whose review matches the
+ * recommendation, and maps the recommendation to the schema action.
+ */
+export function buildApplyAiPayload(
+  affairs: AffairForAi[],
+  recommendation: AiRecommendation
+): ModeratePayload {
+  const ids = affairs
+    .filter((a) => a.moderationReviews.some((r) => r.recommendation === recommendation))
+    .map((a) => a.id);
+  return { ids, action: RECOMMENDATION_TO_ACTION[recommendation] };
+}
+
+/**
+ * Build the `/bulk` payload. The rejection reason travels under `value`, the
+ * field the route reads (`rejectionReason = typeof value === "string" ? ...`).
+ */
+export function buildBulkPayload(
+  action: "publish" | "reject" | "delete",
+  ids: string[],
+  rejectionReason?: string
+): BulkPayload {
+  return {
+    ids,
+    action,
+    ...(rejectionReason ? { value: rejectionReason } : {}),
+  };
+}
+
+export interface ModerationResult {
+  updated?: number;
+  deleted?: number;
+  failed?: { id: string; reasons: string[] }[];
+}
+
+/**
+ * Turn a `/moderate` or `/bulk` response into a user-facing message. When the
+ * publish guard blocked items, the message reports it instead of a false
+ * success.
+ */
+export function summarizeModerationResult(result: ModerationResult): {
+  ok: boolean;
+  message: string;
+} {
+  const failed = result.failed ?? [];
+  const processed = result.updated ?? result.deleted ?? 0;
+
+  if (failed.length === 0) {
+    return { ok: true, message: `${processed} affaire(s) traitée(s).` };
+  }
+
+  const reasons = [...new Set(failed.flatMap((f) => f.reasons))];
+  const reasonSuffix = reasons.length > 0 ? ` : ${reasons.join(", ")}` : "";
+  return {
+    ok: false,
+    message: `${processed} traitée(s), ${failed.length} bloquée(s) par le garde-fou de publication${reasonSuffix}.`,
+  };
+}
+
+interface AffairFormErrorBody {
+  error?: unknown;
+  reasons?: unknown;
+  fieldsSaved?: unknown;
+}
+
+/**
+ * Format the error message for a failed affair save. Surfaces the publish
+ * guard's actionable `reasons[]` (HTTP 422), flattens Zod object errors, and
+ * falls back to a plain string error.
+ */
+export function formatAffairFormError(data: AffairFormErrorBody): string {
+  if (Array.isArray(data.reasons) && data.reasons.length > 0) {
+    const reasons = data.reasons.filter((r): r is string => typeof r === "string");
+    const prefix = typeof data.error === "string" ? data.error : "Affaire non publiable";
+    return `${prefix} : ${reasons.join(", ")}`;
+  }
+
+  if (data.error && typeof data.error === "object") {
+    const flat = data.error as {
+      formErrors?: string[];
+      fieldErrors?: Record<string, string[] | undefined>;
+    };
+    const messages: string[] = [...(flat.formErrors ?? [])];
+    if (flat.fieldErrors) {
+      for (const [field, errs] of Object.entries(flat.fieldErrors)) {
+        if (Array.isArray(errs)) messages.push(`${field}: ${errs.join(", ")}`);
+      }
+    }
+    return messages.join(" | ") || "Erreur de validation";
+  }
+
+  return typeof data.error === "string" ? data.error : "Erreur lors de la sauvegarde";
+}


### PR DESCRIPTION
## Problème (#364)

Trois contrats client / serveur cassés dans la modération admin des affaires, tous silencieux :

1. **Bouton « appliquer les recommandations IA »** : l'UI envoyait `{ reviewIds, action: "apply" }` alors que le schéma attend `{ ids, action ∈ publish|exclude|reject|archive }` (et des ids d'affaire, pas de review). Résultat : HTTP 400 systématique avalé par `if (res.ok)`, le bouton ne faisait rien.
2. **Motif de rejet perdu** : l'UI envoyait `rejectionReason`, mais le schéma et la route lisent `value`. Le champ était retiré par Zod, le motif jamais persisté.
3. **Faux succès** : les routes renvoient `{ updated, failed: [{ id, reasons }] }`, mais l'UI ne lisait jamais le corps. Une publication bloquée par le garde-fou RGPD apparaissait comme un succès.

S'ajoute le formulaire d'édition (`AffairForm`) qui n'affichait pas les `reasons[]` du 422 du garde-fou : le modérateur ne voyait pas pourquoi la publication était refusée.

## Correction

Extraction des contrats dans un module pur testé `src/lib/admin/moderation-payload.ts` :

- `buildApplyAiPayload` : collecte les ids d'**affaire** correspondant à la recommandation et mappe `PUBLISH` / `REJECT` vers l'action du schéma ;
- `buildBulkPayload` : place le motif de rejet sous `value`, le champ lu par la route ;
- `summarizeModerationResult` : transforme `{ updated, failed }` en message, en remontant les blocages du garde-fou (plus de faux succès) ;
- `formatAffairFormError` : remonte les `reasons[]` du 422.

La page et `AffairForm` consomment ces helpers, et un encart de retour (succès / blocages) est affiché.

Aucune modification de la base, du schéma ni des routes API : seuls le client et le formatage d'erreur changent.

## Tests

14 cas dans `moderation-payload.test.ts`, dont des tests de **contrat** qui valident les payloads construits contre les vrais schémas Zod serveur (`moderateAffairSchema`, `bulkAffairSchema`) et documentent les payloads défaillants d'origine. `npm run typecheck` propre, `npm run lint` propre, `npm run test:run` vert.

Closes #364
