### PR TITLE
ops(rate-limit): make missing upstash explicit in production

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -31,6 +31,19 @@ Une seule issue ouverte à la fois par label : si la précédente n'est pas ferm
 
 Pour recevoir un email à chaque nouvelle issue, activer les notifications GitHub sur `ironlam/poligraph` (Settings → Notifications → Watching → Custom → Issues) ou s'abonner uniquement aux labels ci-dessus via GitHub Mobile ou RSS (`https://github.com/ironlam/poligraph/labels/sync-daily-failure`).
 
+### 1.3 Limitation de débit et mode dégradé
+
+- **Produit** : Upstash Redis (`@upstash/ratelimit`), piloté par `middleware.ts`. Cinq tiers : `general` 60/min, `search` 30/min, `export` 5/min, `admin` 30/min, `subscribe` 8/min. Décision pure et testée dans `src/lib/ratelimit/degraded-mode.ts`.
+- **Activation** : la limitation ne fonctionne que si `UPSTASH_REDIS_REST_URL` et `UPSTASH_REDIS_REST_TOKEN` sont définis côté Vercel.
+- **Mode dégradé (Upstash absent)** : le middleware ne retombe plus en silence. Comportement explicite :
+  - **hors production** (dev, preview, `VERCEL_ENV` ≠ `production`) : les requêtes passent, un log léger throttlé est émis. Pas d'alerte Sentry, pas de blocage.
+  - **en production** (`VERCEL_ENV=production`) :
+    - détection explicite et **alerte throttlée** (au plus une fois toutes les 5 minutes par instance) : `console.error` visible dans les logs Vercel, plus `Sentry.captureMessage(..., "warning")` ;
+    - le tier **`export` échoue fermé** (HTTP 503, `Retry-After: 60`) : c'est le seul endpoint lourd et vecteur de scraping sans dépendance opérateur, donc le bloquer pendant une panne est sûr et borné ;
+    - les autres tiers (`general`, `search`, `admin`, `subscribe`) **passent** : on évite de verrouiller l'admin et de casser le site public pendant une panne Upstash ;
+    - aucun en-tête public ne révèle l'état dégradé (ne pas signaler aux clients que la limitation est désactivée).
+- **Réaction à l'alerte** : restaurer `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` (Vercel → Settings → Environment Variables), puis redéployer ou attendre le prochain cold start. Vérifier l'état d'Upstash (https://status.upstash.com). Tant que la configuration manque, les exports restent en 503 ; le reste du site fonctionne sans limitation.
+
 ---
 
 ## 2. Variables d'environnement Sentry

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,14 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, type NextFetchEvent } from "next/server";
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
+import * as Sentry from "@sentry/nextjs";
+import {
+  resolveRateLimitMode,
+  degradedActionForTier,
+  isProductionRuntime,
+  shouldEmitDegradedAlert,
+  type RateLimitMode,
+} from "@/lib/ratelimit/degraded-mode";
 
 // ─── Rate limit tiers ────────────────────────────────────────────
 
@@ -46,6 +54,83 @@ function getLimiter(tier: RateLimitTier): Ratelimit | null {
 
   limiters.set(tier, limiter);
   return limiter;
+}
+
+// ─── Degraded-mode alerting (Lot 3A) ─────────────────────────────
+
+const DEGRADED_ALERT_THROTTLE_MS = 5 * 60 * 1000; // 5 min
+let lastDegradedAlertAt: number | null = null;
+
+/**
+ * Surface that rate limiting is degraded (Upstash unconfigured or unreachable).
+ * Throttled so it fires at most once per window per edge instance, never per
+ * request. In production the signal is a console error (visible in Vercel logs)
+ * plus a Sentry warning; outside production a single light log. The Sentry event
+ * is flushed via `event.waitUntil` because an edge isolate can freeze right after
+ * the response, which would otherwise drop the in-flight event. No public header
+ * is emitted, to avoid telling clients that throttling is off.
+ */
+function reportDegradedMode(
+  mode: RateLimitMode,
+  tier: RateLimitTier,
+  pathname: string,
+  event: NextFetchEvent
+): void {
+  if (mode === "enforced") return;
+  const now = Date.now();
+  if (!shouldEmitDegradedAlert(lastDegradedAlertAt, now, DEGRADED_ALERT_THROTTLE_MS)) {
+    return;
+  }
+  lastDegradedAlertAt = now;
+
+  const detail = `Upstash indisponible, limitation de débit désactivée (tier=${tier}, route=${pathname})`;
+  if (mode === "degraded-prod") {
+    // eslint-disable-next-line no-console -- deliberate ops signal (Vercel logs)
+    console.error(`[ratelimit] PRODUCTION ${detail}`);
+    Sentry.captureMessage(`Rate limiting dégradé : ${detail}`, "warning");
+    event.waitUntil(Sentry.flush(2000));
+  } else {
+    // eslint-disable-next-line no-console -- deliberate ops signal (dev)
+    console.warn(`[ratelimit] ${detail} (hors production, fallback autorisé)`);
+  }
+}
+
+/**
+ * Build the response for the degraded path (Upstash unavailable): throttled
+ * alert, then fail the export tier closed (503) in production while letting
+ * everything else through. Shared by the unconfigured and the runtime-outage
+ * branches so both follow the same explicit policy.
+ */
+function degradedResponse(
+  tier: RateLimitTier,
+  pathname: string,
+  request: NextRequest,
+  event: NextFetchEvent
+): NextResponse {
+  const mode = resolveRateLimitMode(false, isProductionRuntime(process.env));
+  reportDegradedMode(mode, tier, pathname, event);
+
+  if (degradedActionForTier(mode, tier) === "block") {
+    const blocked = NextResponse.json(
+      { error: "Limitation de débit indisponible. Réessayez plus tard." },
+      {
+        status: 503,
+        headers: {
+          "Retry-After": "60",
+          ...(isV1Route(pathname) ? CORS_HEADERS : {}),
+        },
+      }
+    );
+    applySubscribeCors(request, blocked);
+    return blocked;
+  }
+
+  const response = NextResponse.next();
+  if (isV1Route(pathname)) {
+    Object.entries(CORS_HEADERS).forEach(([k, v]) => response.headers.set(k, v));
+  }
+  applySubscribeCors(request, response);
+  return response;
 }
 
 // ─── Route → tier mapping ────────────────────────────────────────
@@ -113,7 +198,7 @@ function applySubscribeCors(request: NextRequest, response: NextResponse): void 
 
 // ─── Middleware ───────────────────────────────────────────────────
 
-export async function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest, event: NextFetchEvent) {
   const pathname = request.nextUrl.pathname;
 
   // CORS preflight for v1 API
@@ -130,17 +215,23 @@ export async function middleware(request: NextRequest) {
 
   const limiter = getLimiter(tier);
   if (!limiter) {
-    // Upstash not configured — allow through
-    const response = NextResponse.next();
-    if (isV1Route(pathname)) {
-      Object.entries(CORS_HEADERS).forEach(([k, v]) => response.headers.set(k, v));
-    }
-    applySubscribeCors(request, response);
-    return response;
+    // Upstash not configured: explicit degraded mode instead of a silent
+    // fallback (Lot 3A).
+    return degradedResponse(tier, pathname, request, event);
   }
 
   const ip = getClientIp(request);
-  const { success, limit, remaining, reset } = await limiter.limit(ip);
+  let success: boolean;
+  let limit: number;
+  let remaining: number;
+  let reset: number;
+  try {
+    ({ success, limit, remaining, reset } = await limiter.limit(ip));
+  } catch {
+    // Upstash configured but unreachable at runtime: degrade gracefully through
+    // the same explicit policy instead of throwing a 500 on every API tier.
+    return degradedResponse(tier, pathname, request, event);
+  }
 
   if (!success) {
     const retryAfter = Math.ceil((reset - Date.now()) / 1000);

--- a/src/lib/ratelimit/degraded-mode.test.ts
+++ b/src/lib/ratelimit/degraded-mode.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  isProductionRuntime,
+  resolveRateLimitMode,
+  degradedActionForTier,
+  shouldEmitDegradedAlert,
+} from "./degraded-mode";
+
+/**
+ * Lot 3A: the rate-limit middleware used to fall back silently when Upstash was
+ * unconfigured. These tests lock in the explicit degraded-mode decision logic:
+ * dev allows through quietly, production allows through with a throttled alert,
+ * and the export tier fails closed in production only.
+ */
+describe("isProductionRuntime", () => {
+  it("trusts VERCEL_ENV when present", () => {
+    expect(isProductionRuntime({ VERCEL_ENV: "production" })).toBe(true);
+    expect(isProductionRuntime({ VERCEL_ENV: "preview" })).toBe(false);
+    expect(isProductionRuntime({ VERCEL_ENV: "development" })).toBe(false);
+  });
+
+  it("falls back to NODE_ENV only when VERCEL_ENV is absent", () => {
+    expect(isProductionRuntime({ NODE_ENV: "production" })).toBe(true);
+    expect(isProductionRuntime({ NODE_ENV: "development" })).toBe(false);
+    expect(isProductionRuntime({})).toBe(false);
+  });
+
+  it("a preview build (NODE_ENV=production, VERCEL_ENV=preview) is not production", () => {
+    expect(isProductionRuntime({ VERCEL_ENV: "preview", NODE_ENV: "production" })).toBe(false);
+  });
+});
+
+describe("resolveRateLimitMode", () => {
+  it("enforces when a limiter is available, regardless of environment", () => {
+    expect(resolveRateLimitMode(true, true)).toBe("enforced");
+    expect(resolveRateLimitMode(true, false)).toBe("enforced");
+  });
+
+  it("degrades to prod mode when the limiter is missing in production", () => {
+    expect(resolveRateLimitMode(false, true)).toBe("degraded-prod");
+  });
+
+  it("degrades to dev mode when the limiter is missing outside production", () => {
+    expect(resolveRateLimitMode(false, false)).toBe("degraded-dev");
+  });
+});
+
+describe("degradedActionForTier", () => {
+  it("fails the export tier closed in production (heavy abuse vector)", () => {
+    expect(degradedActionForTier("degraded-prod", "export")).toBe("block");
+  });
+
+  it("never locks operators out of admin, nor breaks public search", () => {
+    expect(degradedActionForTier("degraded-prod", "admin")).toBe("allow");
+    expect(degradedActionForTier("degraded-prod", "search")).toBe("allow");
+    expect(degradedActionForTier("degraded-prod", "general")).toBe("allow");
+    expect(degradedActionForTier("degraded-prod", "subscribe")).toBe("allow");
+  });
+
+  it("never fails closed outside production (dev keeps working)", () => {
+    expect(degradedActionForTier("degraded-dev", "export")).toBe("allow");
+  });
+
+  it("allows through when enforcing (the limiter handles it)", () => {
+    expect(degradedActionForTier("enforced", "export")).toBe("allow");
+  });
+});
+
+describe("shouldEmitDegradedAlert (throttle, no per-request spam)", () => {
+  const THROTTLE = 5 * 60 * 1000;
+
+  it("always emits the very first alert", () => {
+    expect(shouldEmitDegradedAlert(null, 1_000, THROTTLE)).toBe(true);
+  });
+
+  it("suppresses alerts inside the throttle window", () => {
+    expect(shouldEmitDegradedAlert(1_000, 1_000 + THROTTLE - 1, THROTTLE)).toBe(false);
+  });
+
+  it("emits again once the throttle window has elapsed", () => {
+    expect(shouldEmitDegradedAlert(1_000, 1_000 + THROTTLE, THROTTLE)).toBe(true);
+  });
+});

--- a/src/lib/ratelimit/degraded-mode.ts
+++ b/src/lib/ratelimit/degraded-mode.ts
@@ -1,0 +1,55 @@
+/**
+ * Degraded-mode policy for the rate-limit middleware (Lot 3A).
+ *
+ * When Upstash is not configured the middleware cannot rate limit. This module
+ * holds the pure decision logic so the behaviour is explicit and unit-tested:
+ *
+ * - development / preview: allow through, light throttled log, no fail-closed;
+ * - production: allow through (so an Upstash outage never blocks the whole site
+ *   nor locks operators out of admin), but emit a throttled alert and fail the
+ *   `export` tier closed. `export` is the one heavy abuse / scraping vector with
+ *   no operator dependency, so blocking it during an outage is safe and bounded.
+ */
+
+export type RateLimitMode = "enforced" | "degraded-dev" | "degraded-prod";
+
+export type DegradedAction = "allow" | "block";
+
+/**
+ * Tiers that fail closed (HTTP 503) when rate limiting is degraded in
+ * production. Deliberately limited to `export`: blocking admin would lock
+ * operators out during an outage, and blocking search/general would break the
+ * public site.
+ */
+const FAIL_CLOSED_TIERS: ReadonlySet<string> = new Set(["export"]);
+
+/**
+ * Vercel marks preview builds with `NODE_ENV=production`, so `VERCEL_ENV` is the
+ * reliable production discriminator; fall back to `NODE_ENV` only off-platform.
+ */
+export function isProductionRuntime(env: { VERCEL_ENV?: string; NODE_ENV?: string }): boolean {
+  if (env.VERCEL_ENV) return env.VERCEL_ENV === "production";
+  return env.NODE_ENV === "production";
+}
+
+export function resolveRateLimitMode(hasLimiter: boolean, isProduction: boolean): RateLimitMode {
+  if (hasLimiter) return "enforced";
+  return isProduction ? "degraded-prod" : "degraded-dev";
+}
+
+export function degradedActionForTier(mode: RateLimitMode, tier: string): DegradedAction {
+  if (mode === "degraded-prod" && FAIL_CLOSED_TIERS.has(tier)) return "block";
+  return "allow";
+}
+
+/**
+ * Whether to emit the degraded-mode alert now. Throttled so the signal fires at
+ * most once per window instead of once per request.
+ */
+export function shouldEmitDegradedAlert(
+  lastAlertAt: number | null,
+  now: number,
+  throttleMs: number
+): boolean {
+  return lastAlertAt === null || now - lastAlertAt >= throttleMs;
+}


### PR DESCRIPTION
## Problème

Si `UPSTASH_REDIS_REST_URL` ou `UPSTASH_REDIS_REST_TOKEN` sont absents, le middleware laissait passer toutes les requêtes en silence (aucun log, aucun signal). Acceptable en dev, trop discret en production : une panne ou une rotation de secret désactivait toute la limitation de débit sans alerte.

## Comportement choisi

La logique de décision est extraite dans un module pur testé `src/lib/ratelimit/degraded-mode.ts`. Le middleware applique :

- **hors production** (dev, preview) : les requêtes passent, log léger throttlé. Pas de Sentry, pas de blocage.
- **en production** (`VERCEL_ENV=production`), Upstash indisponible :
  - **alerte throttlée** (au plus une fois toutes les 5 minutes par instance edge) : `console.error` (logs Vercel) plus `Sentry.captureMessage(..., "warning")`, ce dernier flushé via `event.waitUntil` (sinon l'isolate edge gèle après la réponse et l'événement est perdu) ;
  - le tier **`export` échoue fermé (503)** : seul endpoint lourd et vecteur de scraping sans dépendance opérateur, le bloquer pendant une panne est sûr et borné ;
  - les autres tiers (`general`, `search`, `admin`, `subscribe`) **passent** : pas de verrouillage de l'admin, pas de site public cassé ;
  - aucun en-tête public ne révèle l'état dégradé.

Deux modes de panne sont couverts par la même politique : Upstash **non configuré** (variable absente) et Upstash **injoignable au runtime** (`limiter.limit()` qui lève une exception, ce qui renvoyait auparavant un 500 sur tous les tiers).

## Pourquoi pas fail-closed partout

Bloquer brutalement tout le site lors d'une panne Upstash serait un déni de service auto-infligé, et bloquer l'admin verrouillerait les opérateurs au pire moment. Le choix est donc fail-open avec alerte obligatoire, plus un fail-closed ciblé sur le seul tier où c'est justifié.

## Revue adversariale

Le diff a été passé en revue sous trois angles (correctness, edge-runtime / ops, sécurité / abus). Deux points retenus et corrigés avant cette PR : le flush Sentry manquant (sans lui l'alerte prod ne partait jamais sur edge) et la panne Upstash runtime non gérée (500 sur tous les tiers).

## Tests

13 cas unitaires sur la logique de décision (`isProductionRuntime`, `resolveRateLimitMode`, `degradedActionForTier`, throttle). `npm run typecheck` propre, `npm run lint` propre (les deux `console` sont des signaux ops explicites, marqués `eslint-disable`), `npm run test:run` vert (1649).

`docs/RUNBOOK.md` §1.3 documente le mode dégradé et la réaction à l'alerte.

Note : pas de numéro d'issue dédié (ce chantier vient de l'audit technique, pas d'une issue GitHub). Lot 3B (budget IA) reste hors de cette branche.
