### PR TITLE
fix(stats): dédoublonne les mandats parlementaires courants

### DIFF
--- a/prisma/migrations/manual/add-mandate-current-type-unique.sql
+++ b/prisma/migrations/manual/add-mandate-current-type-unique.sql
@@ -1,0 +1,24 @@
+-- Partial unique index: at most ONE active PARLIAMENTARY mandate of a given type
+-- per politician. Prevents import duplicates (e.g. a Wikidata stub created
+-- alongside the official SENAT/ASSEMBLEE_NATIONALE mandate) that inflate the
+-- vote-by-theme aggregates in compute-stats.ts.
+--
+-- Scope of the constraint:
+--   - active mandates only (WHERE "isCurrent" = true);
+--   - DEPUTE / SENATEUR only. NOT all types on purpose: a politician legitimately
+--     has only one active seat per chamber, but other same-type situations are
+--     either legitimate or a different data-quality concern (e.g. homonym MAIRE
+--     of two communes, stale PRESIDENT_PARTI flags) that must not be force-failed
+--     here. Different types always coexist (legitimate cumul, e.g. DEPUTE + MAIRE);
+--   - historical mandates (isCurrent = false) are unconstrained.
+--
+-- Not expressible in schema.prisma without the `partialIndexes` preview feature,
+-- so it lives here (same pattern as the trigram / FTS indexes). Prisma db push
+-- leaves it alone (verified: it is not reported as drift by `prisma migrate diff`).
+--
+-- PREREQUISITE: deduplicate existing rows first (delete the duplicate stubs),
+-- otherwise creation fails with a unique-violation.
+CREATE UNIQUE INDEX IF NOT EXISTS "Mandate_current_type_uq"
+  ON "Mandate" ("politicianId", "type")
+  WHERE "isCurrent" = true
+    AND "type" IN ('DEPUTE'::"MandateType", 'SENATEUR'::"MandateType");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -363,6 +363,12 @@ model Mandate {
   @@index([isCurrent, type, departmentCode])
   @@index([departmentCode])
   @@index([partyId])
+  // NOTE: a partial UNIQUE index "Mandate_current_type_uq" on
+  // (politicianId, type) WHERE isCurrent = true AND type IN (DEPUTE, SENATEUR)
+  // is applied manually (see
+  // prisma/migrations/manual/add-mandate-current-type-unique.sql). Scoped to
+  // parliamentary types on purpose. Not declared here because partial indexes
+  // require the `partialIndexes` preview feature. db push leaves it untouched.
 }
 
 // Local mandate extension — 1:1 with Mandate for local-specific fields

--- a/src/services/sync/__tests__/careers-dedup.test.ts
+++ b/src/services/sync/__tests__/careers-dedup.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { MandateType, DataSource } from "@/generated/prisma";
+import { isDuplicateMandateCandidate } from "../careers-dedup";
+
+describe("isDuplicateMandateCandidate", () => {
+  it("skips an active parliamentary candidate when an active same-type mandate already exists, even from a non-authoritative source with a distant start date", () => {
+    // Regression: a politician already has one active SENATEUR mandate (e.g. an
+    // official one whose source was not yet set, or a prior Wikidata import). A
+    // second active SENATEUR with a start date >30 days apart must NOT be created
+    // — it would breach the one-active-mandate-per-type invariant and inflate the
+    // vote-by-theme aggregates.
+    const existing = [
+      {
+        type: MandateType.SENATEUR,
+        source: null,
+        startDate: "2020-01-01",
+        isCurrent: true,
+      },
+    ];
+    const candidate = {
+      type: MandateType.SENATEUR,
+      startDate: new Date("2020-10-01"),
+      isCurrent: true,
+    };
+    expect(isDuplicateMandateCandidate(existing, candidate)).toBe(true);
+  });
+
+  it("skips when an authoritative SENAT/AN mandate of the same type exists", () => {
+    const existing = [
+      {
+        type: MandateType.DEPUTE,
+        source: DataSource.ASSEMBLEE_NATIONALE,
+        startDate: "2024-07-08",
+        isCurrent: true,
+      },
+    ];
+    const candidate = {
+      type: MandateType.DEPUTE,
+      startDate: new Date("2024-01-01"),
+      isCurrent: true,
+    };
+    expect(isDuplicateMandateCandidate(existing, candidate)).toBe(true);
+  });
+
+  it("allows a different mandate type (cumul DEPUTE + other type is legitimate)", () => {
+    const existing = [
+      {
+        type: MandateType.SENATEUR,
+        source: DataSource.SENAT,
+        startDate: "2020-10-01",
+        isCurrent: true,
+      },
+    ];
+    const candidate = {
+      type: MandateType.MAIRE,
+      startDate: new Date("2020-10-01"),
+      isCurrent: true,
+    };
+    expect(isDuplicateMandateCandidate(existing, candidate)).toBe(false);
+  });
+
+  it("allows backfilling a historical (ended) parliamentary mandate that does not overlap an existing one", () => {
+    // Candidate is NOT active, existing active one starts far later → the
+    // active-active rule does not apply and the 30-day tolerance lets the
+    // historical row through.
+    const existing = [
+      {
+        type: MandateType.SENATEUR,
+        source: null,
+        startDate: "2020-10-01",
+        isCurrent: true,
+      },
+    ];
+    const candidate = {
+      type: MandateType.SENATEUR,
+      startDate: new Date("2008-09-21"),
+      isCurrent: false,
+    };
+    expect(isDuplicateMandateCandidate(existing, candidate)).toBe(false);
+  });
+
+  it("keeps the 30-day start tolerance for non-parliamentary types", () => {
+    const existing = [
+      {
+        type: MandateType.MAIRE,
+        source: DataSource.RNE,
+        startDate: "2020-05-20",
+        isCurrent: true,
+      },
+    ];
+    expect(
+      isDuplicateMandateCandidate(existing, {
+        type: MandateType.MAIRE,
+        startDate: new Date("2020-05-25"),
+        isCurrent: true,
+      })
+    ).toBe(true);
+    expect(
+      isDuplicateMandateCandidate(existing, {
+        type: MandateType.MAIRE,
+        startDate: new Date("2021-05-25"),
+        isCurrent: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/src/services/sync/careers-dedup.ts
+++ b/src/services/sync/careers-dedup.ts
@@ -33,6 +33,14 @@ export interface MandateCandidateForGuard {
  * any active same-type mandate regardless of source or start date. Authoritative
  * SENAT/AN data also always wins over Wikidata. Other types fall back to a
  * 30-day start-date tolerance.
+ *
+ * NOTE: this guard and the partial unique index Mandate_current_type_uq enforce
+ * related but different invariants. The index is the AUTHORITATIVE guarantee: it
+ * rejects any second active same-type parliamentary mandate at write time,
+ * regardless of source or dates. This guard is a best-effort pre-check whose main
+ * job is to skip the create so the sync does not hit that index (no P2002 noise);
+ * it also defers to authoritative SENAT/AN data and a 30-day tolerance for
+ * non-parliamentary types.
  */
 export function isDuplicateMandateCandidate(
   existingMandates: ExistingMandateForGuard[],

--- a/src/services/sync/careers-dedup.ts
+++ b/src/services/sync/careers-dedup.ts
@@ -1,0 +1,59 @@
+import { MandateType, DataSource } from "@/generated/prisma";
+
+export const PARLIAMENTARY_MANDATE_TYPES: MandateType[] = [
+  MandateType.DEPUTE,
+  MandateType.SENATEUR,
+];
+
+const AUTHORITATIVE_PARLIAMENTARY_SOURCES: DataSource[] = [
+  DataSource.SENAT,
+  DataSource.ASSEMBLEE_NATIONALE,
+];
+
+export interface ExistingMandateForGuard {
+  type: MandateType;
+  source: DataSource | null;
+  startDate: Date | string | null;
+  isCurrent: boolean;
+}
+
+export interface MandateCandidateForGuard {
+  type: MandateType;
+  startDate: Date;
+  isCurrent: boolean;
+}
+
+/**
+ * Whether a Wikidata mandate candidate duplicates an existing mandate and must
+ * be skipped before creation.
+ *
+ * Parliamentary mandates (DEPUTE/SENATEUR): a politician can hold at most one
+ * ACTIVE mandate of a given type — also enforced at the DB level by the
+ * Mandate_current_type partial unique index — so an active candidate duplicates
+ * any active same-type mandate regardless of source or start date. Authoritative
+ * SENAT/AN data also always wins over Wikidata. Other types fall back to a
+ * 30-day start-date tolerance.
+ */
+export function isDuplicateMandateCandidate(
+  existingMandates: ExistingMandateForGuard[],
+  candidate: MandateCandidateForGuard
+): boolean {
+  const isParliamentary = PARLIAMENTARY_MANDATE_TYPES.includes(candidate.type);
+
+  return existingMandates.some((m) => {
+    if (m.type !== candidate.type) return false;
+
+    if (isParliamentary) {
+      // Two active mandates of the same type cannot coexist.
+      if (candidate.isCurrent && m.isCurrent) return true;
+      // Authoritative parliamentary source always wins over Wikidata.
+      if (m.source && AUTHORITATIVE_PARLIAMENTARY_SOURCES.includes(m.source)) return true;
+    }
+
+    if (!m.startDate) return false;
+    const existingStart = new Date(m.startDate);
+    const diffDays =
+      Math.abs(existingStart.getTime() - candidate.startDate.getTime()) / (1000 * 60 * 60 * 24);
+    return diffDays < 30;
+  });
+}

--- a/src/services/sync/careers.ts
+++ b/src/services/sync/careers.ts
@@ -12,6 +12,7 @@ import { db } from "@/lib/db";
 import { MandateType, DataSource, PartyRole } from "@/generated/prisma";
 import { setCurrentParty, setPartyRole } from "@/services/politician";
 import { WIKIDATA_SPARQL_RATE_LIMIT_MS } from "@/config/rate-limits";
+import { isDuplicateMandateCandidate } from "./careers-dedup";
 
 export interface CareersSyncResult {
   processed: number;
@@ -257,31 +258,16 @@ export async function syncCareers(options?: {
           continue;
         }
 
-        // Check if mandate already exists:
-        // 1. For DEPUTE/SENATEUR: skip if an authoritative source (SENAT/AN) mandate
-        //    already exists — Wikidata is lower priority for parliamentary mandates
-        // 2. For other types: check within 30-day tolerance
-        const isParliamentary =
-          mandateInfo.type === MandateType.DEPUTE || mandateInfo.type === MandateType.SENATEUR;
-        const authoritativeSources: DataSource[] = [
-          DataSource.SENAT,
-          DataSource.ASSEMBLEE_NATIONALE,
-        ];
-
-        const existingMandate = politician.mandates.find((m) => {
-          if (m.type !== mandateInfo.type) return false;
-          // For parliamentary mandates, any authoritative-source mandate wins
-          if (isParliamentary && m.source && authoritativeSources.includes(m.source)) {
-            return true;
-          }
-          // Date-based check (30-day tolerance)
-          if (!m.startDate) return false;
-          const existingStart = new Date(m.startDate);
-          const diff = Math.abs(existingStart.getTime() - startDate.getTime());
-          return diff / (1000 * 60 * 60 * 24) < 30;
-        });
-
-        if (existingMandate) {
+        // Skip if this candidate duplicates an existing mandate (see
+        // careers-dedup.ts). For DEPUTE/SENATEUR a politician can hold only one
+        // active mandate of a given type; other types use a 30-day tolerance.
+        if (
+          isDuplicateMandateCandidate(politician.mandates, {
+            type: mandateInfo.type,
+            startDate,
+            isCurrent: !endDate,
+          })
+        ) {
           stats.mandatesSkipped++;
           continue;
         }

--- a/src/services/sync/compute-stats.ts
+++ b/src/services/sync/compute-stats.ts
@@ -272,13 +272,21 @@ async function computeThemeDistributionPerPolitician(
       COUNT(*)::int as total
     FROM "Vote" v
     JOIN "Scrutin" s ON s.id = v."scrutinId"
-    JOIN "Mandate" m ON m."politicianId" = v."politicianId"
-      AND m."isCurrent" = true
-      AND m.type IN ('DEPUTE'::"MandateType", 'SENATEUR'::"MandateType")
     WHERE s.theme IS NOT NULL
       AND v.position IN ('POUR', 'CONTRE', 'ABSTENTION')
-      AND v."votingDate" >= m."startDate"
-      AND (m."endDate" IS NULL OR v."votingDate" <= m."endDate")
+      -- Scope votes to a current parliamentary mandate period. EXISTS (semi-join)
+      -- counts each vote ONCE even when a politician has several isCurrent mandate
+      -- rows whose periods both contain votingDate (e.g. an import duplicate). A
+      -- plain JOIN would emit one row per matching mandate and double the counts.
+      AND EXISTS (
+        SELECT 1
+        FROM "Mandate" m
+        WHERE m."politicianId" = v."politicianId"
+          AND m."isCurrent" = true
+          AND m.type IN ('DEPUTE'::"MandateType", 'SENATEUR'::"MandateType")
+          AND v."votingDate" >= m."startDate"
+          AND (m."endDate" IS NULL OR v."votingDate" <= m."endDate")
+      )
     GROUP BY v."politicianId", s.theme
   `;
 


### PR DESCRIPTION
## Contexte
11 politiciens avaient 2 mandats `isCurrent=true` du même type parlementaire : le mandat officiel (SENAT/AN, avec `MandateParliamentary`) + un stub WIKIDATA créé par `careers.ts` (sans `MandateParliamentary`). `computeThemeDistributionPerPolitician` joignait `Mandate` sans passer par `MandateParliamentary`, comptant le stub et doublant les `themeDistribution`.

## Correctifs
- **compute-stats** : votes-par-thème en semi-join `EXISTS` (chaque vote compté une fois, fin du fan-out sur mandats multiples).
- **careers-dedup** : guard extrait en fonction pure `isDuplicateMandateCandidate` (un seul mandat parlementaire actif par type) + tests.
- **Index unique partiel** `Mandate_current_type_uq` sur `(politicianId, type) WHERE isCurrent AND type IN (DEPUTE, SENATEUR)`.
- **Données prod** : 11 stubs Wikidata supprimés, `sync:compute-stats` rejoué.

## Validation
- Godard `cmkjo0w5v…` : 3412 → **1706**
- Muller-Bronn `cmksfdm3i…` : 734 → **367**
- `COUNT(DISTINCT Vote.id)` identique avant/après ; inflation globale → 0.
- Le « 36M lignes » du brief ne se reproduit pas (inflation réelle ~0,37%) ; la cohésion de groupe était déjà saine (INNER JOIN `MandateParliamentary`).

## ⚠️ Note reviewer
L'index unique partiel est un **fichier SQL manuel** (`prisma/migrations/manual/add-mandate-current-type-unique.sql`), PAS une migration Prisma standard (index partiels = preview feature en Prisma 7.7). Confirmé non-droppé par `db push` (`migrate diff` = empty migration). À appliquer manuellement sur tout nouvel environnement.

## Suivi
Issue data-quality liée (doublons `isCurrent` MAIRE / PRESIDENT_PARTI) : #406
