### PR TITLE
Explain the legislative journey on dossiers page

### DIFF
--- a/src/app/parlement/dossiers/page.tsx
+++ b/src/app/parlement/dossiers/page.tsx
@@ -4,7 +4,12 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { isFeatureEnabled } from "@/lib/feature-flags";
 import { Card, CardContent } from "@/components/ui/card";
-import { DossierCard, DossierFilterBar, DossierPPLStats } from "@/components/legislation";
+import {
+  DossierCard,
+  DossierFilterBar,
+  DossierPPLStats,
+  LegislativeJourney,
+} from "@/components/legislation";
 import { getPPLStats } from "@/lib/data/legislation";
 import {
   DOSSIER_STATUS_LABELS,
@@ -201,8 +206,36 @@ export default async function AssembleePage({ searchParams }: PageProps) {
           </CardContent>
         </Card>
 
+        {/* How a bill moves through Parliament */}
+        <LegislativeJourney />
+
         {/* PPL Stats */}
         <DossierPPLStats stats={pplStats} />
+
+        {/* Status legend — placed before the list so badges are understood upfront */}
+        <Card className="mb-8">
+          <CardContent className="pt-6">
+            <h2 className="font-semibold mb-3">Comprendre les statuts</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+              {(Object.keys(DOSSIER_STATUS_LABELS) as DossierStatus[]).map((status) => (
+                <div key={status} className="flex items-start gap-2">
+                  <span className="shrink-0">{DOSSIER_STATUS_ICONS[status]}</span>
+                  <div>
+                    <span className="font-medium">{DOSSIER_STATUS_LABELS[status]}</span>
+                    <span className="text-muted-foreground">
+                      {" "}
+                      &mdash; {DOSSIER_STATUS_DESCRIPTIONS[status]}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground mt-4">
+              Les statuts sont simplifiés à partir des données disponibles. Le détail officiel reste
+              accessible via le lien Assemblée nationale sur chaque dossier.
+            </p>
+          </CardContent>
+        </Card>
 
         {/* Filter bar */}
         <DossierFilterBar
@@ -291,29 +324,8 @@ export default async function AssembleePage({ searchParams }: PageProps) {
           </Card>
         )}
 
-        {/* Status legend */}
-        <Card className="mt-8">
-          <CardContent className="pt-6">
-            <h2 className="font-semibold mb-3">Comprendre les statuts</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-              {(Object.keys(DOSSIER_STATUS_LABELS) as DossierStatus[]).map((status) => (
-                <div key={status} className="flex items-start gap-2">
-                  <span className="shrink-0">{DOSSIER_STATUS_ICONS[status]}</span>
-                  <div>
-                    <span className="font-medium">{DOSSIER_STATUS_LABELS[status]}</span>
-                    <span className="text-muted-foreground">
-                      {" "}
-                      &mdash; {DOSSIER_STATUS_DESCRIPTIONS[status]}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
         {/* Info box */}
-        <Card className="mt-4 bg-blue-50 border-blue-200 dark:bg-blue-950 dark:border-blue-800">
+        <Card className="mt-8 bg-blue-50 border-blue-200 dark:bg-blue-950 dark:border-blue-800">
           <CardContent className="pt-6">
             <h2 className="font-semibold text-blue-900 dark:text-blue-100 mb-2">
               À propos des données

--- a/src/components/legislation/LegislativeJourney.tsx
+++ b/src/components/legislation/LegislativeJourney.tsx
@@ -1,0 +1,66 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Route } from "lucide-react";
+
+// Plain-language steps of the French legislative procedure. Copy lives in a data
+// array (not JSX) so apostrophes stay unescaped and the markup stays compact.
+const JOURNEY_STEPS: { label: string; description: string }[] = [
+  {
+    label: "Dépôt",
+    description: "Le texte est enregistré au Parlement, mais pas forcément examiné.",
+  },
+  {
+    label: "Commission",
+    description: "Les députés ou sénateurs étudient et amendent le texte avant le débat.",
+  },
+  {
+    label: "Séance publique",
+    description: "Le texte est débattu puis voté en public dans l'hémicycle.",
+  },
+  {
+    label: "Navette",
+    description: "L'Assemblée et le Sénat s'échangent le texte pour aboutir à une version commune.",
+  },
+  {
+    label: "Adoption définitive",
+    description:
+      "Le Parlement a terminé l'examen, parfois après une commission mixte paritaire (CMP).",
+  },
+  {
+    label: "Conseil constitutionnel & promulgation",
+    description:
+      "Contrôle éventuel, puis publication au Journal officiel : le texte entre en vigueur.",
+  },
+];
+
+export function LegislativeJourney() {
+  return (
+    <Card className="mb-8">
+      <CardContent className="pt-6">
+        <h2 className="font-semibold mb-1 flex items-center gap-2">
+          <Route className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          Comment lire le parcours d&apos;un texte ?
+        </h2>
+        <p className="text-sm text-muted-foreground mb-4 max-w-3xl">
+          La plupart des textes suivent ces étapes, mais toutes ne sont pas franchies : un texte
+          peut être rejeté, retiré ou rester sans suite à n&apos;importe quel moment.
+        </p>
+        <ol className="grid gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
+          {JOURNEY_STEPS.map((step, i) => (
+            <li key={step.label} className="flex gap-3">
+              <span
+                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold tabular-nums"
+                aria-hidden="true"
+              >
+                {i + 1}
+              </span>
+              <div className="text-sm">
+                <span className="font-medium">{step.label}</span>
+                <p className="text-muted-foreground">{step.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/legislation/index.ts
+++ b/src/components/legislation/index.ts
@@ -5,5 +5,6 @@ export { DossierTimeline } from "./DossierTimeline";
 export { DossierAuthors } from "./DossierAuthors";
 export { DossierFilterBar } from "./DossierFilterBar";
 export { DossierPPLStats } from "./DossierPPLStats";
+export { LegislativeJourney } from "./LegislativeJourney";
 export { DossierVotesList } from "./DossierVotesList";
 export { DossierAmendments } from "./DossierAmendments";

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -721,7 +721,7 @@ export const DOSSIER_STATUS_DESCRIPTIONS: Record<DossierStatus, string> = {
   EN_COMMISSION: "Rapport de commission rendu, en attente de passage en séance.",
   EN_COURS: "Texte en discussion active : séance publique, navette ou CMP.",
   CONSEIL_CONSTITUTIONNEL: "Texte soumis au Conseil constitutionnel.",
-  ADOPTE: "Texte adopté définitivement et promulgué.",
+  ADOPTE: "Texte adopté définitivement par le Parlement, lorsque cette information est disponible.",
   REJETE: "Texte rejeté par le Parlement.",
   RETIRE: "Texte retiré par son auteur.",
   CADUQUE: "Texte devenu caduc à la fin de la législature précédente.",


### PR DESCRIPTION
- Adds a pedagogical legislative journey block to explain how a text moves through Parliament.
- Moves the status legend before the filters so users understand statuses before reading dossier cards.
- Clarifies that a deposited text is not necessarily examined.
- Updates the ADOPTE status description to avoid conflating parliamentary adoption and promulgation.
- Adds a caution note that statuses are simplified from available data.
- No DB/schema changes.
