### PR TITLE
Show where each dossier stands on dossier cards

### DIFF
--- a/src/components/legislation/DossierCard.tsx
+++ b/src/components/legislation/DossierCard.tsx
@@ -3,8 +3,9 @@ import { Card, CardContent } from "@/components/ui/card";
 import { MarkdownText } from "@/components/ui/markdown";
 import { StatusBadge } from "./StatusBadge";
 import { CategoryBadge } from "./CategoryBadge";
+import { DOSSIER_STATUS_SITUATIONS } from "@/config/labels";
 import type { DossierStatus, ThemeCategory } from "@/generated/prisma";
-import { ExternalLink, FileText, Scale } from "lucide-react";
+import { ExternalLink, FileText, Milestone, Scale } from "lucide-react";
 
 interface DossierCardProps {
   id: string;
@@ -114,10 +115,22 @@ export function DossierCard({
             )}
           </div>
 
+          {/* Où ça en est — situation derived solely from DossierStatus */}
+          <div className="flex items-start gap-2 text-sm">
+            <Milestone
+              className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <p className="text-muted-foreground">{DOSSIER_STATUS_SITUATIONS[status]}</p>
+          </div>
+
           {/* Summary */}
           {summary && (
-            <div className="text-sm text-muted-foreground line-clamp-4">
-              <MarkdownText>{summary}</MarkdownText>
+            <div className="text-sm text-muted-foreground">
+              <p className="mb-1 text-xs font-medium text-foreground">En bref</p>
+              <div className="line-clamp-4">
+                <MarkdownText>{summary}</MarkdownText>
+              </div>
             </div>
           )}
 
@@ -137,14 +150,15 @@ export function DossierCard({
               {amendmentCount > 0 && (
                 <span className="flex items-center gap-1">
                   <FileText className="h-4 w-4" />
-                  {amendmentCount} amendement{amendmentCount > 1 ? "s" : ""}
+                  {amendmentCount} amendement{amendmentCount > 1 ? "s" : ""} lié
+                  {amendmentCount > 1 ? "s" : ""}
                 </span>
               )}
             </div>
 
             <div className="flex items-center gap-2">
               <Link href={href} prefetch={false} className="text-sm text-primary hover:underline">
-                Détails
+                Comprendre ce dossier
               </Link>
               {sourceUrl && (
                 <a

--- a/src/config/labels.test.ts
+++ b/src/config/labels.test.ts
@@ -12,6 +12,7 @@ import {
   DOSSIER_STATUS_COLORS,
   DOSSIER_STATUS_ICONS,
   DOSSIER_STATUS_DESCRIPTIONS,
+  DOSSIER_STATUS_SITUATIONS,
 } from "./labels";
 
 describe("AFFAIR_STATUS_LABELS", () => {
@@ -201,5 +202,25 @@ describe("DOSSIER_STATUS_LABELS", () => {
     expect(DOSSIER_STATUS_LABELS.EN_COMMISSION).toBe("En commission");
     expect(DOSSIER_STATUS_LABELS.CONSEIL_CONSTITUTIONNEL).toBe("Conseil constitutionnel");
     expect(DOSSIER_STATUS_LABELS.CADUQUE).toBe("Caduc");
+  });
+
+  it("should have a situation sentence for all dossier statuses", () => {
+    Object.keys(DOSSIER_STATUS_LABELS).forEach((status) => {
+      expect(DOSSIER_STATUS_SITUATIONS).toHaveProperty(status);
+      expect(
+        typeof DOSSIER_STATUS_SITUATIONS[status as keyof typeof DOSSIER_STATUS_SITUATIONS]
+      ).toBe("string");
+    });
+  });
+
+  it("should keep EN_COURS situation generic (no séance/navette/CMP sub-step)", () => {
+    const situation = DOSSIER_STATUS_SITUATIONS.EN_COURS.toLowerCase();
+    expect(situation).not.toContain("séance");
+    expect(situation).not.toContain("navette");
+    expect(situation).not.toContain("cmp");
+  });
+
+  it("should not conflate ADOPTE with promulgation", () => {
+    expect(DOSSIER_STATUS_SITUATIONS.ADOPTE.toLowerCase()).not.toContain("promulgu");
   });
 });

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -727,6 +727,21 @@ export const DOSSIER_STATUS_DESCRIPTIONS: Record<DossierStatus, string> = {
   CADUQUE: "Texte devenu caduc à la fin de la législature précédente.",
 };
 
+// Plain-language "where it stands" sentences for dossier cards. Derived solely
+// from DossierStatus: never asserts a sub-step (séance, navette, CMP) or an
+// outcome (promulgation) that the data does not actually carry.
+export const DOSSIER_STATUS_SITUATIONS: Record<DossierStatus, string> = {
+  DEPOSE: "Déposé : le texte est enregistré, mais pas forcément encore examiné.",
+  EN_COMMISSION: "En commission : le texte est préparé ou examiné avant un éventuel débat public.",
+  EN_COURS: "En discussion active : le texte poursuit son parcours parlementaire.",
+  CONSEIL_CONSTITUTIONNEL:
+    "Au Conseil constitutionnel : le texte fait l'objet d'un contrôle avant promulgation éventuelle.",
+  ADOPTE: "Adopté : les données indiquent que le Parlement a terminé l'examen du texte.",
+  REJETE: "Rejeté : le texte n'a pas été adopté.",
+  RETIRE: "Retiré : le texte a été retiré par son auteur ou son initiateur.",
+  CADUQUE: "Caduc : le texte n'est plus poursuivi dans la procédure actuelle.",
+};
+
 export const AMENDMENT_STATUS_LABELS: Record<AmendmentStatus, string> = {
   DEPOSE: "Déposé",
   ADOPTE: "Adopté",


### PR DESCRIPTION
- Adds a reusable public situation label for each dossier status.
- Shows a clear "Où ça en est" line on full dossier cards.
- Keeps EN_COURS intentionally generic to avoid inventing missing sub-steps.
- Avoids conflating ADOPTE with promulgation or entry into force.
- Adds "En bref" before dossier summaries.
- Clarifies amendment counts as "amendements liés".
- Replaces "Détails" with "Comprendre ce dossier".
- Adds tests for status mapping exhaustiveness and wording guardrails.
- No DB/schema changes.
