### PR TITLE
Single-source the legislative journey pedagogy

### DIFF
--- a/src/components/legislation/LegislativeJourney.tsx
+++ b/src/components/legislation/LegislativeJourney.tsx
@@ -1,36 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
+import { LEGISLATIVE_JOURNEY_STEPS } from "@/config/legislative-journey";
 import { Route } from "lucide-react";
-
-// Plain-language steps of the French legislative procedure. Copy lives in a data
-// array (not JSX) so apostrophes stay unescaped and the markup stays compact.
-const JOURNEY_STEPS: { label: string; description: string }[] = [
-  {
-    label: "Dépôt",
-    description: "Le texte est enregistré au Parlement, mais pas forcément examiné.",
-  },
-  {
-    label: "Commission",
-    description: "Les députés ou sénateurs étudient et amendent le texte avant le débat.",
-  },
-  {
-    label: "Séance publique",
-    description: "Le texte est débattu puis voté en public dans l'hémicycle.",
-  },
-  {
-    label: "Navette",
-    description: "L'Assemblée et le Sénat s'échangent le texte pour aboutir à une version commune.",
-  },
-  {
-    label: "Adoption définitive",
-    description:
-      "Le Parlement a terminé l'examen, parfois après une commission mixte paritaire (CMP).",
-  },
-  {
-    label: "Conseil constitutionnel & promulgation",
-    description:
-      "Contrôle éventuel, puis publication au Journal officiel : le texte entre en vigueur.",
-  },
-];
 
 export function LegislativeJourney() {
   return (
@@ -45,7 +15,7 @@ export function LegislativeJourney() {
           peut être rejeté, retiré ou rester sans suite à n&apos;importe quel moment.
         </p>
         <ol className="grid gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
-          {JOURNEY_STEPS.map((step, i) => (
+          {LEGISLATIVE_JOURNEY_STEPS.map((step, i) => (
             <li key={step.label} className="flex gap-3">
               <span
                 className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold tabular-nums"

--- a/src/components/parlement/ParlementHub.tsx
+++ b/src/components/parlement/ParlementHub.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/data/scrutins";
 import { getLatestDossiers } from "@/lib/data/legislation";
 import { getGroupesListing } from "@/lib/data/groupes";
+import { LEGISLATIVE_JOURNEY_STEPS } from "@/config/legislative-journey";
 import { Info, ArrowRight, Building2, AlertTriangle, Calendar } from "lucide-react";
 import {
   resolveParliamentaryPeriod,
@@ -163,24 +164,16 @@ export async function ParlementHub() {
           </p>
           <p className="font-medium">Parcours d{"'"}un texte de loi :</p>
           <ol className="list-decimal list-inside space-y-1 ml-2">
-            <li>
-              <strong>Dépôt</strong> : un projet (gouvernement) ou une proposition (parlementaire)
-              est déposé
-            </li>
-            <li>
-              <strong>Commission</strong> : examen en commission spécialisée, amendements
-            </li>
-            <li>
-              <strong>Hémicycle</strong> : débat et vote en séance publique
-            </li>
-            <li>
-              <strong>Navette</strong> : le texte fait la navette entre les deux chambres jusqu{"'"}
-              à accord
-            </li>
-            <li>
-              <strong>Promulgation</strong> : le Président de la République promulgue la loi
-            </li>
+            {LEGISLATIVE_JOURNEY_STEPS.map((step) => (
+              <li key={step.label}>
+                <strong>{step.label}</strong> : {step.description}
+              </li>
+            ))}
           </ol>
+          <p>
+            Tous les textes ne franchissent pas toutes ces étapes : ils peuvent être rejetés,
+            retirés ou rester sans suite.
+          </p>
         </div>
       </details>
 

--- a/src/config/legislative-journey.test.ts
+++ b/src/config/legislative-journey.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { LEGISLATIVE_JOURNEY_STEPS } from "./legislative-journey";
+
+describe("LEGISLATIVE_JOURNEY_STEPS", () => {
+  it("exposes the 6 ordered steps starting at Dépôt", () => {
+    expect(LEGISLATIVE_JOURNEY_STEPS).toHaveLength(6);
+    expect(LEGISLATIVE_JOURNEY_STEPS[0]?.label).toBe("Dépôt");
+    LEGISLATIVE_JOURNEY_STEPS.forEach((step) => {
+      expect(typeof step.label).toBe("string");
+      expect(step.label.length).toBeGreaterThan(0);
+      expect(typeof step.description).toBe("string");
+      expect(step.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("keeps adoption and promulgation as distinct steps (no conflation)", () => {
+    const adoption = LEGISLATIVE_JOURNEY_STEPS.find((s) => /adoption/i.test(s.label));
+    const promulgation = LEGISLATIVE_JOURNEY_STEPS.find((s) =>
+      /promulgation|constitutionnel/i.test(s.label)
+    );
+    expect(adoption).toBeDefined();
+    expect(promulgation).toBeDefined();
+    expect(adoption).not.toBe(promulgation);
+
+    // The adoption step must not claim promulgation or entry into force.
+    const adoptionText = `${adoption!.label} ${adoption!.description}`.toLowerCase();
+    expect(adoptionText).not.toContain("promulg");
+    expect(adoptionText).not.toContain("en vigueur");
+  });
+
+  it("does not reduce the journey to 'le Président promulgue la loi' as an isolated step", () => {
+    const hasReductiveStep = LEGISLATIVE_JOURNEY_STEPS.some((s) =>
+      /le président de la république promulgue la loi/i.test(`${s.label} ${s.description}`)
+    );
+    expect(hasReductiveStep).toBe(false);
+  });
+});

--- a/src/config/legislative-journey.ts
+++ b/src/config/legislative-journey.ts
@@ -1,0 +1,40 @@
+// Single source of truth for the plain-language steps of the French legislative
+// procedure. Consumed by the <LegislativeJourney> card (/parlement/dossiers) and
+// the pedagogy <details> on the /parlement hub.
+//
+// Adoption and promulgation are intentionally kept as DISTINCT steps: a text
+// adopted by Parliament is not automatically promulgated nor in force. Do not
+// merge them back into a single "the President promulgates the law" step.
+export interface LegislativeJourneyStep {
+  label: string;
+  description: string;
+}
+
+export const LEGISLATIVE_JOURNEY_STEPS: LegislativeJourneyStep[] = [
+  {
+    label: "Dépôt",
+    description: "Le texte est enregistré au Parlement, mais pas forcément examiné.",
+  },
+  {
+    label: "Commission",
+    description: "Les députés ou sénateurs étudient et amendent le texte avant le débat.",
+  },
+  {
+    label: "Séance publique",
+    description: "Le texte est débattu puis voté en public dans l'hémicycle.",
+  },
+  {
+    label: "Navette",
+    description: "L'Assemblée et le Sénat s'échangent le texte pour aboutir à une version commune.",
+  },
+  {
+    label: "Adoption définitive",
+    description:
+      "Le Parlement a terminé l'examen, parfois après une commission mixte paritaire (CMP).",
+  },
+  {
+    label: "Conseil constitutionnel & promulgation",
+    description:
+      "Contrôle éventuel, puis publication au Journal officiel : le texte entre en vigueur.",
+  },
+];


### PR DESCRIPTION
- Adds a shared typed source for the legislative journey steps.
- Reuses the same journey steps in /parlement and /parlement/dossiers.
- Keeps the /parlement hub pedagogy compact inside the existing details block.
- Preserves the existing /parlement/dossiers journey copy and layout.
- Removes the reductive standalone promulgation step from the hub.
- Adds tests to guard against conflating adoption and promulgation.
- Preserves /parlement filter behavior.
- No DB/schema changes.
- No production verification while Vercel deployment is intentionally blocked.
