### PR TITLE
Canonicalize filtered /parlement to the votes listing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,7 @@ import {
   shouldEmitDegradedAlert,
   type RateLimitMode,
 } from "@/lib/ratelimit/degraded-mode";
+import { buildVotesListingRedirect } from "@/lib/parlement-votes-redirect";
 
 // ─── Rate limit tiers ────────────────────────────────────────────
 
@@ -201,6 +202,16 @@ function applySubscribeCors(request: NextRequest, response: NextResponse): void 
 export async function middleware(request: NextRequest, event: NextFetchEvent) {
   const pathname = request.nextUrl.pathname;
 
+  // Canonicalize the legacy /parlement?<filters> listing to /parlement/votes.
+  // Real HTTP 308 issued before any rendering; the bare /parlement hub (no
+  // listing param) falls through to the rate-limit logic below as a passthrough.
+  if (pathname === "/parlement") {
+    const target = buildVotesListingRedirect(request.nextUrl.searchParams);
+    if (target) {
+      return NextResponse.redirect(new URL(target, request.url), 308);
+    }
+  }
+
   // CORS preflight for v1 API
   if (isV1Route(pathname) && request.method === "OPTIONS") {
     return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
@@ -262,5 +273,5 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
 }
 
 export const config = {
-  matcher: "/api/:path*",
+  matcher: ["/api/:path*", "/parlement"],
 };

--- a/src/app/parlement/page.tsx
+++ b/src/app/parlement/page.tsx
@@ -1,56 +1,15 @@
 import { Metadata } from "next";
-import { ParlementHub, ScrutinsListing } from "@/components/parlement";
+import { ParlementHub } from "@/components/parlement";
 import { getHubStats } from "@/lib/data/scrutins";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 
 export const revalidate = 300;
 
-interface PageProps {
-  searchParams: Promise<{
-    page?: string;
-    result?: string;
-    legislature?: string;
-    chamber?: string;
-    theme?: string;
-    type?: string;
-    search?: string;
-  }>;
-}
-
-export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
-  const params = await searchParams;
-  const hasFilters =
-    params.search ||
-    params.result ||
-    params.legislature ||
-    params.chamber ||
-    params.theme ||
-    params.type ||
-    params.page;
-
-  if (hasFilters) {
-    const canonicalParams = new URLSearchParams();
-    if (params.type) canonicalParams.set("type", params.type);
-    if (params.theme) canonicalParams.set("theme", params.theme);
-    if (params.legislature) canonicalParams.set("legislature", params.legislature);
-    if (params.chamber) canonicalParams.set("chamber", params.chamber);
-    if (params.result) canonicalParams.set("result", params.result);
-    const qs = canonicalParams.toString();
-    const chamberTitle =
-      params.chamber === "AN"
-        ? "Votes de l'Assemblée nationale"
-        : params.chamber === "SENAT"
-          ? "Votes du Sénat"
-          : "Votes parlementaires";
-    return {
-      title: chamberTitle,
-      description:
-        "Suivez les votes de l'Assemblée nationale et du Sénat. Consultez les scrutins et découvrez comment votent vos représentants.",
-      alternates: { canonical: `/parlement${qs ? `?${qs}` : ""}` },
-    };
-  }
-
+// /parlement is a pure hub. The legacy /parlement?<filters> listing is
+// canonicalized to /parlement/votes by middleware (HTTP 308), so this page never
+// renders the scrutins listing and no longer reads searchParams.
+export async function generateMetadata(): Promise<Metadata> {
   const stats = await getHubStats();
   return {
     title: "Le Parlement en données : scrutins et lois en construction",
@@ -59,33 +18,8 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   };
 }
 
-export default async function ParlementPage({ searchParams }: PageProps) {
-  const params = await searchParams;
-  const hasFilters =
-    params.search ||
-    params.result ||
-    params.legislature ||
-    params.chamber ||
-    params.theme ||
-    params.type ||
-    params.page;
-
+export default async function ParlementPage() {
   const stats = await getHubStats();
-
-  if (hasFilters) {
-    return (
-      <>
-        <CollectionPageJsonLd
-          name="Travail parlementaire"
-          description="Suivez les scrutins et l'activité de l'Assemblée nationale et du Sénat."
-          url="https://poligraph.fr/parlement"
-          numberOfItems={stats.totalScrutins}
-        />
-        <Breadcrumb items={[{ label: "Parlement" }]} />
-        <ScrutinsListing searchParams={params} />
-      </>
-    );
-  }
 
   return (
     <>

--- a/src/components/parlement/ParlementSearch.tsx
+++ b/src/components/parlement/ParlementSearch.tsx
@@ -11,7 +11,7 @@ export function ParlementSearch() {
       value=""
       onSearch={(v) => {
         if (v.trim()) {
-          router.push(`/parlement?search=${encodeURIComponent(v.trim())}`);
+          router.push(`/parlement/votes?search=${encodeURIComponent(v.trim())}`);
         }
       }}
       placeholder="Rechercher un scrutin, un sujet, un thème..."

--- a/src/lib/parlement-votes-redirect.test.ts
+++ b/src/lib/parlement-votes-redirect.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { buildVotesListingRedirect } from "./parlement-votes-redirect";
+
+const build = (qs: string) => buildVotesListingRedirect(new URLSearchParams(qs));
+
+describe("buildVotesListingRedirect", () => {
+  it("returns null when there is no listing param (the hub must not redirect)", () => {
+    expect(build("")).toBeNull();
+  });
+
+  it("redirects a single theme param", () => {
+    expect(build("theme=sante")).toBe("/parlement/votes?theme=sante");
+  });
+
+  it("preserves multiple params in input order", () => {
+    expect(build("search=retraites&page=2")).toBe("/parlement/votes?search=retraites&page=2");
+    expect(build("chamber=AN&result=adopted")).toBe("/parlement/votes?chamber=AN&result=adopted");
+  });
+
+  it("drops empty params and returns null when only empties are present", () => {
+    expect(build("theme=&chamber=AN")).toBe("/parlement/votes?chamber=AN");
+    expect(build("theme=")).toBeNull();
+  });
+
+  it("returns null when every known param is empty (never redirect with no query)", () => {
+    expect(build("page=&result=&theme=")).toBeNull();
+  });
+
+  it("ignores unknown params", () => {
+    expect(build("foo=bar")).toBeNull();
+    expect(build("foo=bar&theme=sante")).toBe("/parlement/votes?theme=sante");
+  });
+
+  it("keeps the first occurrence of a repeated param", () => {
+    expect(build("theme=sante&theme=economie")).toBe("/parlement/votes?theme=sante");
+  });
+});

--- a/src/lib/parlement-votes-redirect.ts
+++ b/src/lib/parlement-votes-redirect.ts
@@ -1,0 +1,31 @@
+// Listing params that belong to the scrutins listing (/parlement/votes).
+// Kept in sync with the searchParams accepted by ScrutinsListing.
+export const VOTES_LISTING_PARAMS = [
+  "page",
+  "result",
+  "legislature",
+  "chamber",
+  "theme",
+  "type",
+  "search",
+] as const;
+
+const VOTES_LISTING_PARAM_SET: ReadonlySet<string> = new Set(VOTES_LISTING_PARAMS);
+
+/**
+ * Build the canonical /parlement/votes listing target from a /parlement request's
+ * query string. Returns null when no non-empty listing param is present, so the
+ * bare /parlement hub is never redirected. Input order is preserved, unknown and
+ * empty params are dropped, the first occurrence of a repeated param wins, and
+ * values are passed through unchanged. Pure + edge-safe (used from middleware).
+ */
+export function buildVotesListingRedirect(searchParams: URLSearchParams): string | null {
+  const out = new URLSearchParams();
+  for (const [key, value] of searchParams) {
+    if (VOTES_LISTING_PARAM_SET.has(key) && value && !out.has(key)) {
+      out.set(key, value);
+    }
+  }
+  const query = out.toString();
+  return query ? `/parlement/votes?${query}` : null;
+}


### PR DESCRIPTION
- Makes /parlement a hub-only route.
- Redirects filtered /parlement URLs to /parlement/votes with a real middleware 308.
- Preserves valid listing query parameters while ignoring empty values.
- Removes the filtered metadata/canonical branch from /parlement.
- Leaves /parlement/votes as the canonical votes listing route.
- Updates the remaining legacy search producer to target /parlement/votes.
- Adds tests for redirect URL construction and guard cases.
- Preserves existing data fetching and listing behavior.
- No DB/schema changes.
- No production verification while Vercel deployment is intentionally blocked.
