### PR TITLE
Run filtered /parlement redirects from the active proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,18 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { buildVotesListingRedirect } from "@/lib/parlement-votes-redirect";
 
 export function proxy(request: NextRequest) {
+  // Canonicalize the legacy /parlement?<filters> listing to /parlement/votes (HTTP 308).
+  // This must live in the active proxy (src/proxy.ts): in this src/ project, Next 16
+  // ignores the deprecated root middleware.ts where the redirect was first added.
+  if (request.nextUrl.pathname === "/parlement") {
+    const target = buildVotesListingRedirect(request.nextUrl.searchParams);
+    if (target) {
+      return NextResponse.redirect(new URL(target, request.url), 308);
+    }
+  }
+
   const vercelEnv = process.env.VERCEL_ENV;
 
   // Protect non-production environments (preview, staging) with Basic Auth


### PR DESCRIPTION
## Root cause

Lot E added the `/parlement?<filters>` -> `/parlement/votes` 308 redirect to the root `middleware.ts`. In this `src/` project on Next 16, the active proxy is `src/proxy.ts` (Next 16 convention); the deprecated root `middleware.ts` is **ignored**, so the redirect never ran in production. Confirmed: `/admin` redirects via `src/proxy.ts` while `/parlement?theme=sante` returned 200 instead of 308.

## Fix

- Move the filtered-hub redirect into the active proxy `src/proxy.ts`, at the top of `proxy()`, reusing the existing `buildVotesListingRedirect` helper.
- Existing staging / admin protection in `src/proxy.ts` is unchanged.

## Local verification (next dev)

- `/parlement?theme=sante` -> 308 `/parlement/votes?theme=sante`
- `/parlement?search=retraites&page=2` -> 308 `/parlement/votes?search=retraites&page=2`
- `/parlement` (no param) -> 200 (hub)
- `/parlement/votes?theme=sante` -> 200 (no loop)

## Out of scope (follow-up)

The root `middleware.ts` (kept here, not deleted) also holds the **API rate-limiting**, which is therefore **not running** in production. Restoring it into `src/proxy.ts` + removing `middleware.ts` is a dedicated follow-up PR ("Restore API rate limiting in the active proxy").

No DB/schema changes. Does not touch ScrutinsListing, /parlement/page.tsx, /parlement/votes/page.tsx, or Sentry.
