### PR TITLE
Re-introduce API rate limiting in the active proxy

### DIFF
--- a/src/lib/ratelimit/upstash-credentials.test.ts
+++ b/src/lib/ratelimit/upstash-credentials.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getUpstashCredentials } from "./upstash-credentials";
+
+const KEYS = [
+  "POLIGRAPH_API_KV_REST_API_URL",
+  "POLIGRAPH_API_KV_REST_API_TOKEN",
+  "UPSTASH_REDIS_REST_URL",
+  "UPSTASH_REDIS_REST_TOKEN",
+] as const;
+
+describe("getUpstashCredentials", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("returns null when nothing is configured", () => {
+    expect(getUpstashCredentials()).toBeNull();
+  });
+
+  it("returns null when only the URL is set (token missing)", () => {
+    process.env.POLIGRAPH_API_KV_REST_API_URL = "https://int.example";
+    expect(getUpstashCredentials()).toBeNull();
+  });
+
+  it("uses the manual UPSTASH_* aliases as a fallback", () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://alias.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "alias-token";
+    expect(getUpstashCredentials()).toEqual({
+      url: "https://alias.example",
+      token: "alias-token",
+    });
+  });
+
+  it("prefers the POLIGRAPH_API_KV_* integration vars over the UPSTASH_* aliases", () => {
+    process.env.POLIGRAPH_API_KV_REST_API_URL = "https://int.example";
+    process.env.POLIGRAPH_API_KV_REST_API_TOKEN = "int-token";
+    process.env.UPSTASH_REDIS_REST_URL = "https://alias.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "alias-token";
+    expect(getUpstashCredentials()).toEqual({
+      url: "https://int.example",
+      token: "int-token",
+    });
+  });
+
+  it("resolves url and token independently (per-var fallback)", () => {
+    process.env.POLIGRAPH_API_KV_REST_API_URL = "https://int.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "alias-token";
+    expect(getUpstashCredentials()).toEqual({
+      url: "https://int.example",
+      token: "alias-token",
+    });
+  });
+
+  it("never reads the READ_ONLY token", () => {
+    process.env.POLIGRAPH_API_KV_REST_API_READ_ONLY_TOKEN = "ro-token";
+    process.env.POLIGRAPH_API_KV_REST_API_URL = "https://int.example";
+    // URL present but no write token -> null (read-only must not satisfy it)
+    expect(getUpstashCredentials()).toBeNull();
+  });
+});

--- a/src/lib/ratelimit/upstash-credentials.ts
+++ b/src/lib/ratelimit/upstash-credentials.ts
@@ -1,0 +1,18 @@
+// Resolve the Upstash Redis REST credentials used by the API rate limiter.
+//
+// Priority: the Vercel/Upstash INTEGRATION variables (POLIGRAPH_API_KV_REST_API_*)
+// first, because they are managed by the integration and follow token rotations.
+// Manual UPSTASH_REDIS_REST_* aliases are a fallback (local dev, or a standard
+// environment). The READ_ONLY token is intentionally never used: the sliding
+// window WRITES to Redis.
+//
+// Returns null when neither pair is fully configured, so the caller can run with
+// rate limiting OFF rather than failing closed (a missing config must never break
+// /api/export).
+export function getUpstashCredentials(): { url: string; token: string } | null {
+  const url = process.env.POLIGRAPH_API_KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.POLIGRAPH_API_KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) return null;
+  return { url, token };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,300 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import { NextRequest, NextResponse, type NextFetchEvent } from "next/server";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import * as Sentry from "@sentry/nextjs";
+import {
+  resolveRateLimitMode,
+  degradedActionForTier,
+  isProductionRuntime,
+  shouldEmitDegradedAlert,
+  type RateLimitMode,
+} from "@/lib/ratelimit/degraded-mode";
+import { getUpstashCredentials } from "@/lib/ratelimit/upstash-credentials";
 import { buildVotesListingRedirect } from "@/lib/parlement-votes-redirect";
 
-export function proxy(request: NextRequest) {
+// ─── Rate limit tiers ────────────────────────────────────────────
+
+type RateLimitTier = "general" | "search" | "export" | "admin" | "subscribe";
+
+const TIER_CONFIG: Record<RateLimitTier, { tokens: number; window: string }> = {
+  general: { tokens: 60, window: "1m" },
+  search: { tokens: 30, window: "1m" },
+  export: { tokens: 5, window: "1m" },
+  admin: { tokens: 30, window: "1m" },
+  subscribe: { tokens: 8, window: "1m" },
+};
+
+// ─── Lazy-init rate limiters ─────────────────────────────────────
+
+let redis: Redis | null = null;
+const limiters = new Map<RateLimitTier, Ratelimit>();
+
+function getRedis(): Redis | null {
+  if (redis) return redis;
+
+  // Integration vars (POLIGRAPH_API_KV_*) first, then manual UPSTASH_* aliases.
+  const creds = getUpstashCredentials();
+  if (!creds) return null;
+
+  redis = new Redis({ url: creds.url, token: creds.token });
+  return redis;
+}
+
+function getLimiter(tier: RateLimitTier): Ratelimit | null {
+  if (limiters.has(tier)) return limiters.get(tier)!;
+
+  const client = getRedis();
+  if (!client) return null;
+
+  const config = TIER_CONFIG[tier];
+  const limiter = new Ratelimit({
+    redis: client,
+    limiter: Ratelimit.slidingWindow(config.tokens, config.window as `${number}${"s" | "m" | "h"}`),
+    prefix: `rl:${tier}`,
+  });
+
+  limiters.set(tier, limiter);
+  return limiter;
+}
+
+// ─── Degraded-mode alerting (Lot 3A) ─────────────────────────────
+
+const DEGRADED_ALERT_THROTTLE_MS = 5 * 60 * 1000; // 5 min
+let lastDegradedAlertAt: number | null = null;
+let lastUnconfiguredWarnAt: number | null = null;
+
+/**
+ * Surface that rate limiting is degraded by a RUNTIME outage (Upstash configured
+ * but unreachable). Throttled so it fires at most once per window per instance.
+ * In production: console error (Vercel logs) + Sentry warning, flushed via
+ * `event.waitUntil`. Outside production: a single light log.
+ */
+function reportDegradedMode(
+  mode: RateLimitMode,
+  tier: RateLimitTier,
+  pathname: string,
+  event: NextFetchEvent
+): void {
+  if (mode === "enforced") return;
+  const now = Date.now();
+  if (!shouldEmitDegradedAlert(lastDegradedAlertAt, now, DEGRADED_ALERT_THROTTLE_MS)) {
+    return;
+  }
+  lastDegradedAlertAt = now;
+
+  const detail = `Upstash injoignable, limitation de débit dégradée (tier=${tier}, route=${pathname})`;
+  if (mode === "degraded-prod") {
+    // eslint-disable-next-line no-console -- deliberate ops signal (Vercel logs)
+    console.error(`[ratelimit] PRODUCTION ${detail}`);
+    Sentry.captureMessage(`Rate limiting dégradé : ${detail}`, "warning");
+    event.waitUntil(Sentry.flush(2000));
+  } else {
+    // eslint-disable-next-line no-console -- deliberate ops signal (dev)
+    console.warn(`[ratelimit] ${detail} (hors production, fallback autorisé)`);
+  }
+}
+
+/**
+ * Surface that Upstash is NOT configured at all (no credentials) — distinct from
+ * a runtime outage. Rate limiting runs OFF in this case (open passthrough, never
+ * fail-closed), so this throttled warn is the only signal. Static message (no
+ * request data) to avoid any log injection.
+ */
+function reportUnconfigured(): void {
+  const now = Date.now();
+  if (!shouldEmitDegradedAlert(lastUnconfiguredWarnAt, now, DEGRADED_ALERT_THROTTLE_MS)) return;
+  lastUnconfiguredWarnAt = now;
+  // eslint-disable-next-line no-console -- deliberate ops signal
+  console.warn("[ratelimit] Upstash non configuré — limitation de débit désactivée");
+}
+
+/**
+ * Build the response for a RUNTIME outage (Upstash configured but unreachable):
+ * throttled alert, then fail the export tier closed (503) in production while
+ * letting everything else through. Only reached when a limiter exists but throws.
+ */
+function degradedResponse(
+  tier: RateLimitTier,
+  pathname: string,
+  request: NextRequest,
+  event: NextFetchEvent
+): NextResponse {
+  const mode = resolveRateLimitMode(false, isProductionRuntime(process.env));
+  reportDegradedMode(mode, tier, pathname, event);
+
+  if (degradedActionForTier(mode, tier) === "block") {
+    const blocked = NextResponse.json(
+      { error: "Limitation de débit indisponible. Réessayez plus tard." },
+      {
+        status: 503,
+        headers: {
+          "Retry-After": "60",
+          ...(isV1Route(pathname) ? CORS_HEADERS : {}),
+        },
+      }
+    );
+    applySubscribeCors(request, blocked);
+    return blocked;
+  }
+
+  return openPassthrough(request, pathname);
+}
+
+// ─── Route → tier mapping ────────────────────────────────────────
+
+function getTier(pathname: string): RateLimitTier | null {
+  // Excluded routes — handled by their own rate limiting or internal
+  if (pathname.startsWith("/api/chat")) return null;
+  if (pathname.startsWith("/api/cron")) return null;
+  // Mailjet webhook is signed with HMAC; rate limit per-IP would punish bursty
+  // legitimate batches from a small set of Mailjet IPs.
+  if (pathname.startsWith("/api/newsletter/webhook")) return null;
+
+  // Admin routes — separate tier (auth endpoint has its own stricter limiter too)
+  if (pathname.startsWith("/api/admin")) return "admin";
+
+  if (
+    pathname.startsWith("/api/newsletter/subscribe") ||
+    pathname.startsWith("/api/newsletter/forget")
+  ) {
+    return "subscribe";
+  }
+  if (pathname.startsWith("/api/export")) return "export";
+  if (pathname.startsWith("/api/search")) return "search";
+  if (pathname.startsWith("/api/")) return "general";
+
+  return null;
+}
+
+// ─── Client IP extraction ────────────────────────────────────────
+
+function getClientIp(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]!.trim() ||
+    request.headers.get("x-real-ip") ||
+    "127.0.0.1"
+  );
+}
+
+// ─── CORS for public v1 API ──────────────────────────────────────
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Max-Age": "86400",
+};
+
+function isV1Route(pathname: string): boolean {
+  return pathname.startsWith("/api/v1/");
+}
+
+// ─── CORS for newsletter subscribe (boussole) ────────────────────
+
+const SUBSCRIBE_CORS_ORIGINS = ["https://boussole.poligraph.fr", "http://localhost:8081"];
+
+function applySubscribeCors(request: NextRequest, response: NextResponse): void {
+  if (request.nextUrl.pathname !== "/api/newsletter/subscribe") return;
+  const origin = request.headers.get("origin");
+  if (!origin || !SUBSCRIBE_CORS_ORIGINS.includes(origin)) return;
+  response.headers.set("Access-Control-Allow-Origin", origin);
+  response.headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+  response.headers.set("Access-Control-Allow-Headers", "Content-Type");
+  response.headers.set("Vary", "Origin");
+}
+
+/** Pass the request through while preserving the API CORS headers. */
+function openPassthrough(request: NextRequest, pathname: string): NextResponse {
+  const response = NextResponse.next();
+  if (isV1Route(pathname)) {
+    Object.entries(CORS_HEADERS).forEach(([k, v]) => response.headers.set(k, v));
+  }
+  applySubscribeCors(request, response);
+  return response;
+}
+
+// ─── API rate limiting ───────────────────────────────────────────
+
+/**
+ * Per-IP rate limiting for /api routes (Upstash sliding window). Returns the
+ * response to send (CORS preflight 204 / 429 / 503-on-outage / passthrough with
+ * headers), or null when the path is not subject to limiting so the proxy
+ * continues.
+ *
+ * Two non-enforced cases are kept deliberately distinct:
+ * - Upstash NOT configured (no credentials): rate limiting is OFF — open
+ *   passthrough for every tier, never 503 (so /api/export keeps working).
+ * - Runtime outage (limiter exists but throws): prudent degraded policy, which
+ *   fails the export tier closed (503) in production only.
+ */
+async function applyApiRateLimit(
+  request: NextRequest,
+  event: NextFetchEvent
+): Promise<NextResponse | null> {
+  const pathname = request.nextUrl.pathname;
+
+  // CORS preflight for v1 API
+  if (isV1Route(pathname) && request.method === "OPTIONS") {
+    return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  const tier = getTier(pathname);
+  if (!tier) return null;
+
+  const limiter = getLimiter(tier);
+  if (!limiter) {
+    // Upstash not configured at all → rate limiting OFF (open, never fail-closed).
+    reportUnconfigured();
+    return openPassthrough(request, pathname);
+  }
+
+  const ip = getClientIp(request);
+  let success: boolean;
+  let limit: number;
+  let remaining: number;
+  let reset: number;
+  try {
+    ({ success, limit, remaining, reset } = await limiter.limit(ip));
+  } catch {
+    // Upstash configured but unreachable at runtime: prudent degraded policy.
+    return degradedResponse(tier, pathname, request, event);
+  }
+
+  if (!success) {
+    const retryAfter = Math.ceil((reset - Date.now()) / 1000);
+    const headers: Record<string, string> = {
+      "Retry-After": String(retryAfter),
+      "X-RateLimit-Limit": String(limit),
+      "X-RateLimit-Remaining": "0",
+      "X-RateLimit-Reset": String(reset),
+      ...(isV1Route(pathname) ? CORS_HEADERS : {}),
+    };
+    const limited = NextResponse.json(
+      { error: "Trop de requêtes. Réessayez plus tard." },
+      { status: 429, headers }
+    );
+    applySubscribeCors(request, limited);
+    return limited;
+  }
+
+  const response = NextResponse.next();
+  response.headers.set("X-RateLimit-Limit", String(limit));
+  response.headers.set("X-RateLimit-Remaining", String(remaining));
+  response.headers.set("X-RateLimit-Reset", String(reset));
+  if (isV1Route(pathname)) {
+    Object.entries(CORS_HEADERS).forEach(([k, v]) => response.headers.set(k, v));
+  }
+  applySubscribeCors(request, response);
+  return response;
+}
+
+// ─── Proxy (Next 16 convention; the active middleware-like layer) ──
+
+export async function proxy(request: NextRequest, event: NextFetchEvent) {
+  const pathname = request.nextUrl.pathname;
+
   // Canonicalize the legacy /parlement?<filters> listing to /parlement/votes (HTTP 308).
-  // This must live in the active proxy (src/proxy.ts): in this src/ project, Next 16
-  // ignores the deprecated root middleware.ts where the redirect was first added.
-  if (request.nextUrl.pathname === "/parlement") {
+  if (pathname === "/parlement") {
     const target = buildVotesListingRedirect(request.nextUrl.searchParams);
     if (target) {
       return NextResponse.redirect(new URL(target, request.url), 308);
@@ -18,7 +306,7 @@ export function proxy(request: NextRequest) {
   // Protect non-production environments (preview, staging) with Basic Auth
   if (vercelEnv && vercelEnv !== "production") {
     // Allow API routes (for MCP, webhooks, etc.)
-    if (!request.nextUrl.pathname.startsWith("/api/")) {
+    if (!pathname.startsWith("/api/")) {
       const auth = request.headers.get("authorization");
 
       if (auth) {
@@ -44,10 +332,7 @@ export function proxy(request: NextRequest) {
   }
 
   // Protect admin API routes (except auth endpoint)
-  if (
-    request.nextUrl.pathname.startsWith("/api/admin") &&
-    !request.nextUrl.pathname.startsWith("/api/admin/auth")
-  ) {
+  if (pathname.startsWith("/api/admin") && !pathname.startsWith("/api/admin/auth")) {
     const session = request.cookies.get("admin_session");
     if (!session?.value) {
       return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
@@ -55,15 +340,16 @@ export function proxy(request: NextRequest) {
   }
 
   // Protect admin pages - check session cookie
-  if (
-    request.nextUrl.pathname.startsWith("/admin") &&
-    !request.nextUrl.pathname.startsWith("/admin/login")
-  ) {
+  if (pathname.startsWith("/admin") && !pathname.startsWith("/admin/login")) {
     const session = request.cookies.get("admin_session");
     if (!session?.value) {
       return NextResponse.redirect(new URL("/admin/login", request.url));
     }
   }
+
+  // Per-IP rate limiting for /api routes.
+  const rateLimited = await applyApiRateLimit(request, event);
+  if (rateLimited) return rateLimited;
 
   return NextResponse.next();
 }


### PR DESCRIPTION
## Re-introduce API rate limiting (clean re-land after the #418 incident)

### Context
Rate limiting historically lived in a dead root `middleware.ts` (never ran). #418 moved it into the active `src/proxy.ts`, but Upstash was unconfigured in prod, so the `export` tier failed **closed** → 503 on `/api/export` (incident). #419 reverted. Upstash is now provisioned in Vercel (Production + Preview).

### What this does
- New `src/lib/ratelimit/upstash-credentials.ts`: `getUpstashCredentials()` reads the Vercel/Upstash **integration** vars `POLIGRAPH_API_KV_REST_API_URL/TOKEN` first, then the manual `UPSTASH_REDIS_REST_URL/TOKEN` aliases. The `READ_ONLY` token is never used (the sliding window writes). Returns null unless both URL and token resolve.
- `src/proxy.ts`: restores the rate limiter (from #418) with two anti-re-incident changes:
  - **Upstash unconfigured** (no credentials) → rate limiting is **OFF**: open passthrough for every tier, **never 503** (so `/api/export` keeps working), plus a throttled static warn.
  - **Runtime outage** (limiter exists but throws) → prudent degraded policy (export fails closed in prod only) — unchanged `degraded-mode.ts`.

### Verification
- Adversarial review (3 lenses) — pass, 0 blocking.
- Local `next dev` (no Upstash): `/api/export/*` → **200** (not 503); `/api/v1/elus` → 200 + CORS; `OPTIONS` → 204; `/parlement?theme=sante` → 308; `/admin` → 307; `/api/chat` → 200 (excluded); dev log: "Upstash non configuré — limitation de débit désactivée".
- `tsc --noEmit --incremental false` OK, `eslint` OK, rate-limit tests **19/19** (new credentials suite + degraded-mode).
- Real enforcement (429 + `X-RateLimit-*`) verifiable in prod post-deploy (Upstash configured there).

### Out of scope (follow-ups)
- `degraded-mode.ts` module doc now slightly stale (the unconfigured case no longer reaches it) — doc-only.
- Pre-existing: log-injection via `pathname` in `reportDegradedMode`; staging Basic Auth fall-through on non-`Basic` scheme.

No DB/schema changes. No Sentry refactor.
