### PR TITLE
Fix /comparer/votes canonical pointing to a 404

### DIFF
--- a/src/app/comparer/votes/page.tsx
+++ b/src/app/comparer/votes/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { VOTE_POSITION_LABELS, VOTE_POSITION_DOT_COLORS } from "@/config/labels";
 import { VoteComparisonFilters } from "@/components/compare/VoteComparisonFilters";
 import { COMPARE_CATEGORIES, COMPARE_CATEGORY_LABELS, type CompareCategory } from "@/types/compare";
+import { buildComparerVotesCanonical } from "@/lib/seo/comparer-votes-metadata";
 import type { VotePosition } from "@/types";
 
 interface PageProps {
@@ -33,11 +34,12 @@ export async function generateMetadata({ searchParams }: PageProps) {
   const params = await searchParams;
   const cat = parseCategory(params.cat);
   const label = COMPARE_CATEGORY_LABELS[cat];
+  const canonical = buildComparerVotesCanonical(cat, params.a, params.b);
 
   return {
     title: `Concordance des votes — ${label}`,
     description: `Détail de la concordance des votes entre deux ${label.toLowerCase()}.`,
-    alternates: { canonical: "/comparer/votes" },
+    ...(canonical ? { alternates: { canonical } } : {}),
   };
 }
 

--- a/src/lib/seo/__tests__/comparer-votes-metadata.test.ts
+++ b/src/lib/seo/__tests__/comparer-votes-metadata.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { buildComparerVotesCanonical } from "../comparer-votes-metadata";
+
+describe("buildComparerVotesCanonical", () => {
+  it("returns null when `a` is missing", () => {
+    expect(buildComparerVotesCanonical("deputes", undefined, "marine-le-pen")).toBeNull();
+  });
+
+  it("returns null when `b` is missing", () => {
+    expect(buildComparerVotesCanonical("deputes", "marine-le-pen", undefined)).toBeNull();
+  });
+
+  it("returns null when both are missing", () => {
+    expect(buildComparerVotesCanonical("deputes")).toBeNull();
+  });
+
+  it("builds a self-canonical from cat/a/b when both are present", () => {
+    expect(buildComparerVotesCanonical("deputes", "marine-le-pen", "jean-luc-melenchon")).toBe(
+      "/comparer/votes?cat=deputes&a=marine-le-pen&b=jean-luc-melenchon"
+    );
+  });
+
+  it("excludes search/filter/page (only cat/a/b are inputs)", () => {
+    const canonical = buildComparerVotesCanonical("partis", "rn", "lfi");
+    expect(canonical).toBe("/comparer/votes?cat=partis&a=rn&b=lfi");
+    expect(canonical).not.toContain("search");
+    expect(canonical).not.toContain("filter");
+    expect(canonical).not.toContain("page");
+  });
+});

--- a/src/lib/seo/comparer-votes-metadata.ts
+++ b/src/lib/seo/comparer-votes-metadata.ts
@@ -1,0 +1,15 @@
+/**
+ * Canonical de la page de concordance des votes (/comparer/votes).
+ *
+ * Une comparaison n'existe que si `a` ET `b` sont présents : sans eux la page
+ * renvoie 404 (page.tsx, notFound() quand slugA/slugB manquent), donc on
+ * n'émet PAS de canonical pointant vers cette 404 (retour null).
+ *
+ * `search`, `filter` et `page` sont volontairement exclus : les variantes
+ * filtrées/paginées d'une même paire se consolident sur l'URL propre de la paire.
+ */
+export function buildComparerVotesCanonical(cat: string, a?: string, b?: string): string | null {
+  if (!a || !b) return null;
+  const qs = new URLSearchParams({ cat, a, b });
+  return `/comparer/votes?${qs.toString()}`;
+}


### PR DESCRIPTION
## Summary

The `/comparer/votes` canonical was hardcoded to `/comparer/votes`, but that bare URL calls `notFound()` (404) when `a` or `b` is missing. Every comparison therefore declared a canonical pointing to a 404, which Google ignores.

The canonical is now built from `cat`/`a`/`b` via a pure helper and emitted **only when a real pair exists** (`a` and `b` both present). `search`/`filter`/`page` are excluded so filtered/paginated variants of a pair consolidate to the clean pair URL.

## Tests

- New unit test `comparer-votes-metadata.test.ts` (5 cases): `null` when `a` and/or `b` missing, self-canonical for a real pair, exclusion of `search`/`filter`/`page`. `vitest run` → **5/5 passed**.
- `tsc --noEmit --incremental false` → **clean**.
- `eslint` on the 3 touched files → **clean**.

## Scope / non-goals

**3 fichiers touchés :**

- `src/lib/seo/comparer-votes-metadata.ts` (nouveau, fonction pure sans dépendance Next/db)
- `src/lib/seo/__tests__/comparer-votes-metadata.test.ts` (nouveau)
- `src/app/comparer/votes/page.tsx` (`generateMetadata` uniquement : 1 import + 2 lignes)

**Explicitement inchangé :**

- Aucun changement de rendu.
- Aucun changement de logique de comparaison (`getPoliticianVoteComparison`, `getPartyVoteComparisonData`, `notFound()`).
- Aucun changement sur les filtres (`VoteComparisonFilters`, `buildUrl`).
- Canonical émis uniquement quand `a` et `b` sont présents.
