### PR TITLE
Add shared filter contract (chips, URL search, push/replace opt-in)

### DIFF
--- a/src/components/filters/ActiveFilterChips.tsx
+++ b/src/components/filters/ActiveFilterChips.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface ActiveFilter {
+  /** Param key, used for removal */
+  key: string;
+  /** Human-readable label shown in the chip */
+  label: string;
+  /** Optional raw value, kept for future needs (not required for removal) */
+  value?: string;
+}
+
+interface ActiveFilterChipsProps {
+  filters: ActiveFilter[];
+  onRemove: (key: string) => void;
+  onClearAll: () => void;
+  className?: string;
+  /** Leading label (default: "Filtres actifs :") */
+  label?: string;
+}
+
+export function ActiveFilterChips({
+  filters,
+  onRemove,
+  onClearAll,
+  className,
+  label = "Filtres actifs :",
+}: ActiveFilterChipsProps) {
+  if (filters.length === 0) return null;
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2 text-sm", className)}>
+      <span className="text-muted-foreground">{label}</span>
+      {filters.map((f) => (
+        <span
+          key={f.key}
+          className="inline-flex items-center gap-1 rounded-full border bg-muted/40 pl-3 pr-1 py-0.5"
+        >
+          {f.label}
+          <button
+            type="button"
+            onClick={() => onRemove(f.key)}
+            className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={`Retirer le filtre ${f.label}`}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </span>
+      ))}
+      <button type="button" onClick={onClearAll} className="ml-1 text-primary hover:underline">
+        Tout effacer
+      </button>
+    </div>
+  );
+}

--- a/src/components/filters/DebouncedSearchInput.tsx
+++ b/src/components/filters/DebouncedSearchInput.tsx
@@ -7,10 +7,17 @@ import { cn } from "@/lib/utils";
 interface DebouncedSearchInputProps {
   /** Current value from URL */
   value: string;
-  /** Called with trimmed value after debounce */
+  /** Called with the trimmed value after debounce (or on submit in manual mode) */
   onSearch: (value: string) => void;
-  /** Debounce delay in ms (default: 300) */
+  /** Debounce delay in ms (default: 800). Ignored in manual mode. */
   delay?: number;
+  /**
+   * Manual mode: render a real <form>; onSearch fires only on submit
+   * (button click or Enter), never while typing. Default: false (debounced).
+   */
+  manual?: boolean;
+  /** Submit button label in manual mode (default: "Rechercher") */
+  submitLabel?: string;
   placeholder?: string;
   className?: string;
   id?: string;
@@ -21,6 +28,8 @@ export function DebouncedSearchInput({
   value,
   onSearch,
   delay = 800,
+  manual = false,
+  submitLabel = "Rechercher",
   placeholder = "Rechercher...",
   className,
   id,
@@ -43,26 +52,92 @@ export function DebouncedSearchInput({
     };
   }, []);
 
+  // Debounced mode only: notify after the debounce window. No-op in manual mode
+  // so typing never triggers a search.
   const handleChange = (inputValue: string) => {
+    if (manual) return;
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       onSearch(inputValue.trim());
     }, delay);
   };
 
+  // Single submit path shared by Enter (debounced) and the <form> (manual).
+  const submit = () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    onSearch(inputRef.current?.value.trim() ?? "");
+  };
+
+  // Debounced mode: Enter submits immediately. Manual mode: the native <form>
+  // submit handles Enter, so we don't intercept it here.
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (!manual && e.key === "Enter") {
       e.preventDefault();
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      onSearch(inputRef.current?.value.trim() ?? "");
+      submit();
     }
   };
 
+  // Removes the currently applied search. The clear (X) button below only
+  // renders when `value` is non-empty (a search is applied), so in manual mode
+  // an unsubmitted local entry shows no X and never touches the URL.
   const handleClear = () => {
     if (inputRef.current) inputRef.current.value = "";
     if (debounceRef.current) clearTimeout(debounceRef.current);
     onSearch("");
   };
+
+  const field = (
+    <div className="relative">
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+      <input
+        ref={inputRef}
+        id={id}
+        type="search"
+        defaultValue={value}
+        placeholder={placeholder}
+        onChange={(e) => handleChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className="h-9 w-full rounded-md border border-input bg-background pl-9 pr-8 py-1 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 placeholder:text-muted-foreground"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={handleClear}
+          className="absolute right-1 top-1/2 -translate-y-1/2 size-8 flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+          aria-label="Effacer la recherche"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+
+  if (manual) {
+    return (
+      <form
+        className={cn(className)}
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        {label && (
+          <label htmlFor={id} className="text-xs font-medium text-muted-foreground mb-1 block">
+            {label}
+          </label>
+        )}
+        <div className="flex gap-2">
+          <div className="flex-1">{field}</div>
+          <button
+            type="submit"
+            className="h-9 shrink-0 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </form>
+    );
+  }
 
   return (
     <div className={cn(className)}>
@@ -71,29 +146,7 @@ export function DebouncedSearchInput({
           {label}
         </label>
       )}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-        <input
-          ref={inputRef}
-          id={id}
-          type="search"
-          defaultValue={value}
-          placeholder={placeholder}
-          onChange={(e) => handleChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          className="h-9 w-full rounded-md border border-input bg-background pl-9 pr-8 py-1 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 placeholder:text-muted-foreground"
-        />
-        {value && (
-          <button
-            type="button"
-            onClick={handleClear}
-            className="absolute right-1 top-1/2 -translate-y-1/2 size-8 flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
-            aria-label="Effacer la recherche"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        )}
-      </div>
+      {field}
     </div>
   );
 }

--- a/src/components/filters/UrlSearchInput.tsx
+++ b/src/components/filters/UrlSearchInput.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { DebouncedSearchInput } from "@/components/filters/DebouncedSearchInput";
+import { useFilterParams } from "@/hooks/useFilterParams";
+
+interface UrlSearchInputProps {
+  /** Current applied value, read from the URL on the server */
+  value: string;
+  /** URL param to write (default: "search") */
+  param?: string;
+  /** Navigation mode for the param update (default: "push") */
+  mode?: "push" | "replace";
+  /** Manual mode: search applies only on submit (default: false) */
+  manual?: boolean;
+  placeholder?: string;
+  className?: string;
+  id?: string;
+  label?: string;
+  submitLabel?: string;
+}
+
+export function UrlSearchInput({
+  value,
+  param = "search",
+  mode = "push",
+  manual = false,
+  placeholder,
+  className,
+  id,
+  label,
+  submitLabel,
+}: UrlSearchInputProps) {
+  const { updateParams } = useFilterParams();
+  return (
+    <DebouncedSearchInput
+      value={value}
+      onSearch={(v) => updateParams({ [param]: v }, { mode })}
+      manual={manual}
+      placeholder={placeholder}
+      className={className}
+      id={id}
+      label={label}
+      submitLabel={submitLabel}
+    />
+  );
+}

--- a/src/components/filters/__tests__/ActiveFilterChips.test.tsx
+++ b/src/components/filters/__tests__/ActiveFilterChips.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ActiveFilterChips } from "@/components/filters/ActiveFilterChips";
+
+describe("ActiveFilterChips", () => {
+  it("renders nothing when there are no filters", () => {
+    const { container } = render(
+      <ActiveFilterChips filters={[]} onRemove={() => {}} onClearAll={() => {}} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("calls onRemove with the filter key when the × is clicked", () => {
+    const onRemove = vi.fn();
+    render(
+      <ActiveFilterChips
+        filters={[{ key: "parti", label: "RN" }]}
+        onRemove={onRemove}
+        onClearAll={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Retirer le filtre RN" }));
+    expect(onRemove).toHaveBeenCalledWith("parti");
+  });
+
+  it("calls onClearAll when 'Tout effacer' is clicked", () => {
+    const onClearAll = vi.fn();
+    render(
+      <ActiveFilterChips
+        filters={[{ key: "parti", label: "RN" }]}
+        onRemove={() => {}}
+        onClearAll={onClearAll}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Tout effacer" }));
+    expect(onClearAll).toHaveBeenCalled();
+  });
+
+  it("exposes an explicit aria-label on each remove button", () => {
+    render(
+      <ActiveFilterChips
+        filters={[{ key: "certainty", label: "Établi" }]}
+        onRemove={() => {}}
+        onClearAll={() => {}}
+      />
+    );
+    expect(screen.getByLabelText("Retirer le filtre Établi")).toBeInTheDocument();
+  });
+});

--- a/src/components/filters/__tests__/DebouncedSearchInput.test.tsx
+++ b/src/components/filters/__tests__/DebouncedSearchInput.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DebouncedSearchInput } from "@/components/filters/DebouncedSearchInput";
+
+describe("DebouncedSearchInput (manual mode)", () => {
+  it("does not call onSearch while typing", () => {
+    const onSearch = vi.fn();
+    render(<DebouncedSearchInput value="" onSearch={onSearch} manual />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "macron" } });
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it("calls onSearch with the trimmed value when the submit button is clicked", () => {
+    const onSearch = vi.fn();
+    render(<DebouncedSearchInput value="" onSearch={onSearch} manual submitLabel="Rechercher" />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "  macron  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Rechercher" }));
+    expect(onSearch).toHaveBeenCalledWith("macron");
+  });
+
+  it("submits via the form submit path", () => {
+    const onSearch = vi.fn();
+    render(<DebouncedSearchInput value="" onSearch={onSearch} manual />);
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "borne" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(onSearch).toHaveBeenCalledWith("borne");
+  });
+
+  it("renders no clear (X) button when no search is applied (value empty)", () => {
+    const onSearch = vi.fn();
+    render(<DebouncedSearchInput value="" onSearch={onSearch} manual />);
+    expect(screen.queryByRole("button", { name: "Effacer la recherche" })).toBeNull();
+  });
+
+  it("shows the clear (X) button when a search is applied and removes it", () => {
+    const onSearch = vi.fn();
+    render(<DebouncedSearchInput value="macron" onSearch={onSearch} manual />);
+    fireEvent.click(screen.getByRole("button", { name: "Effacer la recherche" }));
+    expect(onSearch).toHaveBeenCalledWith("");
+  });
+});

--- a/src/components/filters/__tests__/UrlSearchInput.test.tsx
+++ b/src/components/filters/__tests__/UrlSearchInput.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// Capture updateParams calls instead of touching the router.
+const { updateParams } = vi.hoisted(() => ({ updateParams: vi.fn() }));
+
+vi.mock("@/hooks/useFilterParams", () => ({
+  useFilterParams: () => ({
+    updateParams,
+    searchParams: new URLSearchParams(),
+    isPending: false,
+  }),
+}));
+
+import { UrlSearchInput } from "@/components/filters/UrlSearchInput";
+
+describe("UrlSearchInput", () => {
+  beforeEach(() => updateParams.mockClear());
+
+  it("updates the default 'search' param in push mode by default", () => {
+    render(<UrlSearchInput value="" manual />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "macron" } });
+    fireEvent.click(screen.getByRole("button", { name: "Rechercher" }));
+    expect(updateParams).toHaveBeenCalledWith({ search: "macron" }, { mode: "push" });
+  });
+
+  it("writes a custom param in replace mode", () => {
+    render(<UrlSearchInput value="" param="q" mode="replace" manual />);
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "borne" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(updateParams).toHaveBeenCalledWith({ q: "borne" }, { mode: "replace" });
+  });
+});

--- a/src/components/filters/index.ts
+++ b/src/components/filters/index.ts
@@ -4,3 +4,6 @@ export type { ComboboxOption } from "./ComboboxFilter";
 export { SelectFilter } from "./SelectFilter";
 export type { SelectOption } from "./SelectFilter";
 export { FilterBarShell } from "./FilterBarShell";
+export { ActiveFilterChips } from "./ActiveFilterChips";
+export type { ActiveFilter } from "./ActiveFilterChips";
+export { UrlSearchInput } from "./UrlSearchInput";

--- a/src/components/presse/PresseSearchInput.tsx
+++ b/src/components/presse/PresseSearchInput.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { DebouncedSearchInput } from "@/components/filters";
-import { useFilterParams } from "@/hooks/useFilterParams";
+import { UrlSearchInput } from "@/components/filters";
 
 export function PresseSearchInput({ value }: { value: string }) {
-  const { updateParams } = useFilterParams();
   return (
-    <DebouncedSearchInput
+    <UrlSearchInput
       value={value}
-      onSearch={(v) => updateParams({ search: v })}
       placeholder="Rechercher un article..."
       className="flex-1 min-w-[200px]"
     />

--- a/src/components/votes/VotesSearchInput.tsx
+++ b/src/components/votes/VotesSearchInput.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { DebouncedSearchInput } from "@/components/filters";
-import { useFilterParams } from "@/hooks/useFilterParams";
+import { UrlSearchInput } from "@/components/filters";
 
 export function VotesSearchInput({ value }: { value: string }) {
-  const { updateParams } = useFilterParams();
   return (
-    <DebouncedSearchInput
+    <UrlSearchInput
       value={value}
-      onSearch={(v) => updateParams({ search: v })}
       placeholder="Rechercher un scrutin..."
       className="flex-1 min-w-[200px]"
     />

--- a/src/hooks/__tests__/useFilterParams.test.ts
+++ b/src/hooks/__tests__/useFilterParams.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Stable router spies + controllable search string, shared with the mock below.
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  search: "",
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.push,
+    replace: mocks.replace,
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+  usePathname: () => "/affaires",
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+import { useFilterParams } from "@/hooks/useFilterParams";
+
+describe("useFilterParams", () => {
+  beforeEach(() => {
+    mocks.push.mockClear();
+    mocks.replace.mockClear();
+    mocks.search = "";
+  });
+
+  it("uses router.push by default", () => {
+    const { result } = renderHook(() => useFilterParams());
+    act(() => result.current.updateParams({ parti: "rn" }));
+    expect(mocks.push).toHaveBeenCalledWith("/affaires?parti=rn", { scroll: false });
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
+  it("uses router.replace when mode is 'replace'", () => {
+    const { result } = renderHook(() => useFilterParams());
+    act(() => result.current.updateParams({ parti: "rn" }, { mode: "replace" }));
+    expect(mocks.replace).toHaveBeenCalledWith("/affaires?parti=rn", { scroll: false });
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("always drops the page param on update", () => {
+    mocks.search = "page=3&parti=rn";
+    const { result } = renderHook(() => useFilterParams());
+    act(() => result.current.updateParams({ sort: "date-asc" }));
+    expect(mocks.push).toHaveBeenCalledTimes(1);
+    const url = mocks.push.mock.calls[0]![0] as string;
+    expect(url).not.toContain("page=");
+    expect(url).toContain("sort=date-asc");
+    expect(url).toContain("parti=rn");
+  });
+
+  it("navigates to the bare pathname when no params remain", () => {
+    mocks.search = "parti=rn";
+    const { result } = renderHook(() => useFilterParams());
+    act(() => result.current.updateParams({ parti: "" }));
+    expect(mocks.push).toHaveBeenCalledWith("/affaires", { scroll: false });
+  });
+});

--- a/src/hooks/useFilterParams.ts
+++ b/src/hooks/useFilterParams.ts
@@ -10,7 +10,7 @@ export function useFilterParams() {
   const [isPending, startTransition] = useTransition();
 
   const updateParams = useCallback(
-    (updates: Record<string, string>) => {
+    (updates: Record<string, string>, options?: { mode?: "push" | "replace" }) => {
       const params = new URLSearchParams(searchParams.toString());
       for (const [key, value] of Object.entries(updates)) {
         if (value) {
@@ -22,7 +22,14 @@ export function useFilterParams() {
       params.delete("page");
       startTransition(() => {
         const qs = params.toString();
-        router.push(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+        const url = qs ? `${pathname}?${qs}` : pathname;
+        // Default "push" preserves existing behavior for every current caller.
+        // Opt into "replace" for utility filters that should not stack history.
+        if (options?.mode === "replace") {
+          router.replace(url, { scroll: false });
+        } else {
+          router.push(url, { scroll: false });
+        }
       });
     },
     [router, pathname, searchParams, startTransition]


### PR DESCRIPTION
## Summary

Lot 1 of the listing-filter refonte: shared, **additive** primitives that the per-page work (starting with `/affaires`) will build on. Defaults preserve current behavior, so no existing page changes behavior.

- `useFilterParams`: new opt-in `mode: "push" | "replace"` option on `updateParams`. **Default stays `push`** — every current caller is unchanged. `replace` lets utility filters avoid stacking browser history.
- `DebouncedSearchInput`: new additive `manual` mode (real `<form>`; `onSearch` fires only on submit via button or Enter, never while typing). Debounced mode is byte-identical to before. JSDoc fixed (`delay` default is 800, not 300).
- `ActiveFilterChips` (new): chips with individual removal (`aria-label` per `×`, 32px touch target) and a "Tout effacer" `<button>`. `ActiveFilter` type is exported and extensible.
- `UrlSearchInput` (new): generic wrapper over `useFilterParams` + `DebouncedSearchInput`. `param?: string` (default `"search"`), `mode?`, `manual?`.
- `PresseSearchInput` / `VotesSearchInput`: adopt `UrlSearchInput`. Behavior strictly identical (`search` param, `push`, debounced 800ms).

## Tests

4 new test files, **15 tests**, all green:

- `useFilterParams`: default → `router.push`, `mode:"replace"` → `router.replace`, `page` always dropped, bare pathname when empty.
- `DebouncedSearchInput` (manual): typing never calls `onSearch`; submit (button) and the form submit path call `onSearch(trimmed)`; no `×` when `value` empty; `×` removes the applied search.
- `ActiveFilterChips`: renders nothing when empty, `onRemove(key)`, `onClearAll`, explicit `aria-label`.
- `UrlSearchInput`: calls `updateParams` with the right `param` and `mode`.

Local: `vitest` 15/15, `tsc --noEmit --incremental false` clean, `eslint` clean on all touched files.

## Scope / non-goals

**11 fichiers** (3 modifiés, 2 nouveaux composants, 6 nouveaux/adoptés). Ce PR est **purement additif**.

Explicitement hors périmètre :

- Pas de bascule globale `push` → `replace` (opt-in uniquement).
- Pas de changement de la valeur de debounce (800ms conservé, seul le JSDoc est corrigé).
- Pas d'unification des 3 implémentations de "pending" UI, pas de fusion `ComboboxFilter` / `PoliticianFilterAutocomplete`.
- Aucune page produit migrée hors `Presse` / `Votes` (et celles-ci restent strictement équivalentes).
- Aucun changement SEO (robots / canonical).
