### PR TITLE
Rework /affaires filter panel (chips, hierarchy, manual search)

### DIFF
--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -218,7 +218,7 @@ export default async function AffairesPage({ searchParams }: PageProps) {
         {/* Party quick-links */}
         {partiesWithAffairs.length > 0 && (
           <div className="mb-4">
-            <p className="text-xs font-medium text-muted-foreground mb-2">Par parti</p>
+            <p className="text-xs font-medium text-muted-foreground mb-2">Explorer par parti</p>
             <div className="flex flex-wrap gap-2">
               {partiesWithAffairs
                 .sort((a, b) => b._count.affairsAtTime - a._count.affairsAtTime)
@@ -292,42 +292,6 @@ export default async function AffairesPage({ searchParams }: PageProps) {
               prefetch={false}
             >
               Voir le hub Condamnations →
-            </Link>
-          </div>
-        )}
-
-        {/* Active filters summary */}
-        {(searchFilter || superCatFilter || certaintyFilter || categoryFilter || partiFilter) && (
-          <div className="mb-6 flex items-center gap-2 text-sm flex-wrap">
-            <span className="text-muted-foreground">Filtres actifs :</span>
-            {searchFilter && <Badge variant="outline">Recherche : {searchFilter}</Badge>}
-            {partiFilter && (
-              <Badge variant="outline">
-                Parti :{" "}
-                {partiesWithAffairs.find((p) => p.slug === partiFilter)?.shortName || partiFilter}
-              </Badge>
-            )}
-            {superCatFilter && (
-              <Badge className={AFFAIR_SUPER_CATEGORY_COLORS[superCatFilter]}>
-                {AFFAIR_SUPER_CATEGORY_LABELS[superCatFilter]}
-              </Badge>
-            )}
-            {certaintyFilter && (
-              <Badge className={CERTAINTY_COLORS[certaintyFilter as CertaintyLevel]}>
-                {CERTAINTY_LABELS[certaintyFilter as CertaintyLevel]}
-              </Badge>
-            )}
-            {categoryFilter && (
-              <Badge variant="outline">
-                {AFFAIR_CATEGORY_LABELS[categoryFilter as keyof typeof AFFAIR_CATEGORY_LABELS]}
-              </Badge>
-            )}
-            <Link
-              href={mode === "victime" ? "/affaires?mode=victime" : "/affaires"}
-              scroll={false}
-              className="text-primary hover:underline ml-2"
-            >
-              Effacer les filtres
             </Link>
           </div>
         )}

--- a/src/components/affairs/AffairModeToggle.tsx
+++ b/src/components/affairs/AffairModeToggle.tsx
@@ -1,51 +1,59 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { Shield, Users } from "lucide-react";
 
 type AffairMode = "mise-en-cause" | "victime";
 
 export function AffairModeToggle({ mode }: { mode: AffairMode }) {
-  const router = useRouter();
   const searchParams = useSearchParams();
 
-  const setMode = useCallback(
-    (newMode: AffairMode) => {
-      const params = new URLSearchParams(searchParams.toString());
-      params.delete("page");
-      params.set("mode", newMode);
-      router.push(`/affaires?${params.toString()}`);
-    },
-    [router, searchParams]
-  );
+  // "mode=victime" is a real navigable variant: keep <Link> semantics (crawlable
+  // href, middle-click, open-in-new-tab) but use `replace` so switching perimeter
+  // does not stack browser history. The default perimeter resolves to a clean URL.
+  const buildHref = (target: AffairMode) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("page");
+    if (target === "victime") {
+      params.set("mode", "victime");
+    } else {
+      params.delete("mode");
+    }
+    const qs = params.toString();
+    return qs ? `/affaires?${qs}` : "/affaires";
+  };
 
   return (
-    <div className="flex gap-2" role="group" aria-label="Type d affaires">
-      <button
-        onClick={() => setMode("mise-en-cause")}
+    <div className="flex gap-2" role="group" aria-label="Type d'affaires">
+      <Link
+        href={buildHref("mise-en-cause")}
+        replace
+        scroll={false}
+        aria-current={mode === "mise-en-cause" ? "page" : undefined}
         className={`flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors ${
           mode === "mise-en-cause"
             ? "bg-amber-100 text-amber-900 ring-1 ring-amber-300 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-700"
             : "bg-muted text-muted-foreground hover:bg-accent"
         }`}
-        aria-pressed={mode === "mise-en-cause"}
       >
         <Shield className="h-4 w-4" />
         Mis en cause
-      </button>
-      <button
-        onClick={() => setMode("victime")}
+      </Link>
+      <Link
+        href={buildHref("victime")}
+        replace
+        scroll={false}
+        aria-current={mode === "victime" ? "page" : undefined}
         className={`flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors ${
           mode === "victime"
             ? "bg-blue-100 text-blue-900 ring-1 ring-blue-300 dark:bg-blue-900/30 dark:text-blue-200 dark:ring-blue-700"
             : "bg-muted text-muted-foreground hover:bg-accent"
         }`}
-        aria-pressed={mode === "victime"}
       >
         <Users className="h-4 w-4" />
-        Violences contre les elus
-      </button>
+        Violences contre les élus
+      </Link>
     </div>
   );
 }

--- a/src/components/affairs/AffairesFilterBar.tsx
+++ b/src/components/affairs/AffairesFilterBar.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useFilterParams } from "@/hooks/useFilterParams";
-import { DebouncedSearchInput, SelectFilter } from "@/components/filters";
+import { DebouncedSearchInput, SelectFilter, ActiveFilterChips } from "@/components/filters";
+import type { ActiveFilter } from "@/components/filters";
 import { FilterBarShell } from "@/components/filters/FilterBarShell";
 import {
   AFFAIR_CATEGORY_LABELS,
   AFFAIR_SUPER_CATEGORY_LABELS,
+  CATEGORY_TO_SUPER,
   getCategoriesForSuper,
   type AffairSuperCategory,
 } from "@/config/labels";
@@ -54,6 +56,15 @@ export function AffairesFilterBar({
   superCounts,
 }: AffairesFilterBarProps) {
   const { isPending, updateParams } = useFilterParams();
+  // Utility filters use replace so they do not stack browser history.
+  const set = (updates: Record<string, string>) => updateParams(updates, { mode: "replace" });
+
+  // Category-first: the displayed family is the family of the selected
+  // infraction when one is set. This keeps a legacy ?category= URL (no supercat)
+  // coherent and never hides the active infraction.
+  const effectiveSupercat = ((currentFilters.category
+    ? CATEGORY_TO_SUPER[currentFilters.category as AffairCategory]
+    : currentFilters.supercat) || "") as AffairSuperCategory | "";
 
   const certaintyOptions = [
     { value: "", label: "Toutes les certitudes" },
@@ -71,53 +82,94 @@ export function AffairesFilterBar({
     })),
   ];
 
-  const categoryOptions = [
-    { value: "", label: "Toutes les infractions" },
-    ...SUPER_CATEGORIES.flatMap((superCat) => {
-      const cats = getCategoriesForSuper(superCat);
-      if (cats.length === 0) return [];
-      return [
-        {
-          value: `sep-${superCat}`,
-          label: `── ${AFFAIR_SUPER_CATEGORY_LABELS[superCat]} ──`,
-          disabled: true,
-        },
-        ...cats.map((cat: AffairCategory) => ({
+  // Infraction options are scoped to the effective family (no separators).
+  const categoryOptions = effectiveSupercat
+    ? [
+        { value: "", label: "Toutes les infractions" },
+        ...getCategoriesForSuper(effectiveSupercat).map((cat) => ({
           value: cat,
           label: AFFAIR_CATEGORY_LABELS[cat],
         })),
-      ];
-    }),
-  ];
-
-  const partyOptions = [
-    { value: "", label: "Tous les partis" },
-    ...parties.map((p) => ({
-      value: p.slug,
-      label: `${p.shortName} — ${p.name} (${p.count})`,
-    })),
-  ];
+      ]
+    : [{ value: "", label: "Choisir d'abord une famille" }];
 
   const sortOptions = Object.entries(SORT_OPTIONS).map(([value, label]) => ({ value, label }));
 
+  // Active filter chips. `mode` is a perimeter tab (not a chip); `sort` IS shown
+  // so that "Tout effacer" never resets an invisible state.
+  const activeFilters: ActiveFilter[] = [];
+  if (currentFilters.search) {
+    activeFilters.push({ key: "search", label: `Recherche : ${currentFilters.search}` });
+  }
+  if (currentFilters.parti) {
+    const party = parties.find((p) => p.slug === currentFilters.parti);
+    activeFilters.push({
+      key: "parti",
+      label: `Parti : ${party?.shortName ?? currentFilters.parti}`,
+    });
+  }
+  if (currentFilters.supercat) {
+    // Suppress a stale family chip that would contradict the selected infraction
+    // (incoherent ?supercat=A&category=B URL). Category prevails in the UI.
+    const consistent =
+      !currentFilters.category ||
+      CATEGORY_TO_SUPER[currentFilters.category as AffairCategory] === currentFilters.supercat;
+    if (consistent) {
+      activeFilters.push({
+        key: "supercat",
+        label:
+          AFFAIR_SUPER_CATEGORY_LABELS[currentFilters.supercat as AffairSuperCategory] ??
+          currentFilters.supercat,
+      });
+    }
+  }
+  if (currentFilters.certainty) {
+    activeFilters.push({
+      key: "certainty",
+      label:
+        CERTAINTY_LABELS[currentFilters.certainty as CertaintyLevel] ?? currentFilters.certainty,
+    });
+  }
+  if (currentFilters.category) {
+    activeFilters.push({
+      key: "category",
+      label:
+        AFFAIR_CATEGORY_LABELS[currentFilters.category as AffairCategory] ??
+        currentFilters.category,
+    });
+  }
+  if (currentFilters.sort) {
+    activeFilters.push({
+      key: "sort",
+      label: `Tri : ${SORT_OPTIONS[currentFilters.sort] ?? currentFilters.sort}`,
+    });
+  }
+
+  const removeFilter = (key: string) =>
+    key === "supercat" ? set({ supercat: "", category: "" }) : set({ [key]: "" });
+
+  const clearAll = () =>
+    set({ search: "", supercat: "", category: "", certainty: "", parti: "", sort: "" });
+
   return (
     <FilterBarShell isPending={isPending} className="space-y-3">
-      {/* Search input */}
+      {/* Search input — manual: applies on submit (button/Enter), not while typing */}
       <DebouncedSearchInput
         id="search-affairs"
         value={currentFilters.search}
-        onSearch={(v) => updateParams({ search: v })}
+        onSearch={(v) => set({ search: v })}
+        manual
         placeholder="Rechercher une affaire..."
         label="Recherche"
       />
 
-      {/* Dropdowns grid: 2 cols mobile, 5 cols desktop */}
-      <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
+      {/* Dropdowns grid: 2 cols mobile, 4 cols desktop */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <SelectFilter
           id="supercat-affairs"
           label="Famille"
-          value={currentFilters.supercat}
-          onChange={(v) => updateParams({ supercat: v, category: "" })}
+          value={effectiveSupercat}
+          onChange={(v) => set({ supercat: v, category: "" })}
           options={superCatOptions}
         />
 
@@ -125,34 +177,29 @@ export function AffairesFilterBar({
           id="category-affairs"
           label="Infraction"
           value={currentFilters.category}
-          onChange={(v) => updateParams({ category: v })}
+          onChange={(v) => set({ supercat: effectiveSupercat, category: v })}
           options={categoryOptions}
+          disabled={!effectiveSupercat}
         />
 
         <SelectFilter
           id="certainty-affairs"
           label="Certitude"
           value={currentFilters.certainty}
-          onChange={(v) => updateParams({ certainty: v })}
+          onChange={(v) => set({ certainty: v })}
           options={certaintyOptions}
-        />
-
-        <SelectFilter
-          id="parti-affairs"
-          label="Parti"
-          value={currentFilters.parti}
-          onChange={(v) => updateParams({ parti: v })}
-          options={partyOptions}
         />
 
         <SelectFilter
           id="sort-affairs"
           label="Trier par"
           value={currentFilters.sort}
-          onChange={(v) => updateParams({ sort: v })}
+          onChange={(v) => set({ sort: v })}
           options={sortOptions}
         />
       </div>
+
+      <ActiveFilterChips filters={activeFilters} onRemove={removeFilter} onClearAll={clearAll} />
     </FilterBarShell>
   );
 }

--- a/src/components/affairs/__tests__/AffairModeToggle.test.tsx
+++ b/src/components/affairs/__tests__/AffairModeToggle.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AffairModeToggle } from "@/components/affairs/AffairModeToggle";
+
+// next/navigation is globally mocked in src/test/setup.tsx (useSearchParams -> empty).
+
+describe("AffairModeToggle", () => {
+  it("renders both perimeter tabs as links with clean hrefs", () => {
+    render(<AffairModeToggle mode="mise-en-cause" />);
+    expect(screen.getByRole("link", { name: /Mis en cause/ })).toHaveAttribute("href", "/affaires");
+    expect(screen.getByRole("link", { name: /Violences contre les élus/ })).toHaveAttribute(
+      "href",
+      "/affaires?mode=victime"
+    );
+  });
+
+  it("marks the active perimeter with aria-current", () => {
+    render(<AffairModeToggle mode="victime" />);
+    expect(screen.getByRole("link", { name: /Violences contre les élus/ })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByRole("link", { name: /Mis en cause/ })).not.toHaveAttribute("aria-current");
+  });
+
+  it("uses the correct accents in the group label and tab text", () => {
+    render(<AffairModeToggle mode="mise-en-cause" />);
+    expect(screen.getByRole("group", { name: "Type d'affaires" })).toBeInTheDocument();
+    expect(screen.getByText("Violences contre les élus")).toBeInTheDocument();
+  });
+});

--- a/src/components/affairs/__tests__/AffairesFilterBar.test.tsx
+++ b/src/components/affairs/__tests__/AffairesFilterBar.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const { updateParams } = vi.hoisted(() => ({ updateParams: vi.fn() }));
+
+vi.mock("@/hooks/useFilterParams", () => ({
+  useFilterParams: () => ({
+    updateParams,
+    searchParams: new URLSearchParams(),
+    isPending: false,
+  }),
+}));
+
+import { AffairesFilterBar } from "@/components/affairs/AffairesFilterBar";
+
+const parties = [{ slug: "rn", shortName: "RN", name: "Rassemblement National", count: 5 }];
+const emptyFilters = {
+  search: "",
+  sort: "",
+  certainty: "",
+  parti: "",
+  category: "",
+  supercat: "",
+};
+const baseProps = {
+  currentFilters: emptyFilters,
+  parties,
+  certaintyCounts: {},
+  superCounts: {},
+};
+
+describe("AffairesFilterBar", () => {
+  beforeEach(() => updateParams.mockClear());
+
+  it("does not render a Parti select in the panel", () => {
+    render(<AffairesFilterBar {...baseProps} />);
+    expect(screen.queryByLabelText("Parti")).toBeNull();
+    // The editorial axes remain
+    expect(screen.getByLabelText("Famille")).toBeInTheDocument();
+    expect(screen.getByLabelText("Infraction")).toBeInTheDocument();
+  });
+
+  it("disables the Infraction select until a Famille is chosen", () => {
+    render(<AffairesFilterBar {...baseProps} />);
+    expect(screen.getByLabelText("Infraction")).toBeDisabled();
+  });
+
+  it("enables the Infraction select when a Famille is selected", () => {
+    render(
+      <AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, supercat: "PROBITE" }} />
+    );
+    expect(screen.getByLabelText("Infraction")).toBeEnabled();
+  });
+
+  it("keeps a legacy ?category= (no supercat) infraction visible and removable", () => {
+    render(
+      <AffairesFilterBar
+        {...baseProps}
+        currentFilters={{ ...emptyFilters, category: "CORRUPTION" }}
+      />
+    );
+    // Family inferred from the category -> infraction select is usable
+    expect(screen.getByLabelText("Infraction")).toBeEnabled();
+    // The infraction chip is present and removable
+    fireEvent.click(screen.getByRole("button", { name: /^Retirer le filtre/ }));
+    expect(updateParams).toHaveBeenCalledWith({ category: "" }, { mode: "replace" });
+  });
+
+  it("applies the manual search only on submit, never while typing", () => {
+    render(<AffairesFilterBar {...baseProps} />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "dupont" } });
+    expect(updateParams).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Rechercher" }));
+    expect(updateParams).toHaveBeenCalledWith({ search: "dupont" }, { mode: "replace" });
+  });
+
+  it("removing the Famille chip also clears the category", () => {
+    render(
+      <AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, supercat: "PROBITE" }} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Retirer le filtre/ }));
+    expect(updateParams).toHaveBeenCalledWith({ supercat: "", category: "" }, { mode: "replace" });
+  });
+
+  it("renders a removable Parti chip for a legacy ?parti= URL", () => {
+    render(<AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, parti: "rn" }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Retirer le filtre Parti : RN" }));
+    expect(updateParams).toHaveBeenCalledWith({ parti: "" }, { mode: "replace" });
+  });
+
+  it("'Tout effacer' clears every filter but leaves mode untouched", () => {
+    render(<AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, parti: "rn" }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Tout effacer" }));
+    expect(updateParams).toHaveBeenCalledWith(
+      { search: "", supercat: "", category: "", certainty: "", parti: "", sort: "" },
+      { mode: "replace" }
+    );
+  });
+
+  it("shows a Tri chip when a non-default sort is active", () => {
+    render(
+      <AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, sort: "certainty" }} />
+    );
+    expect(screen.getByText("Tri : Par certitude")).toBeInTheDocument();
+  });
+
+  it("does not show a stale Famille chip when supercat contradicts the category", () => {
+    // category CORRUPTION belongs to PROBITE; supercat=FINANCES is incoherent
+    render(
+      <AffairesFilterBar
+        {...baseProps}
+        currentFilters={{ ...emptyFilters, supercat: "FINANCES", category: "CORRUPTION" }}
+      />
+    );
+    expect(screen.queryByText("Infractions financières")).toBeNull();
+  });
+});

--- a/src/components/filters/SelectFilter.tsx
+++ b/src/components/filters/SelectFilter.tsx
@@ -16,6 +16,7 @@ interface SelectFilterProps {
   className?: string;
   id?: string;
   label?: string;
+  disabled?: boolean;
 }
 
 export function SelectFilter({
@@ -26,6 +27,7 @@ export function SelectFilter({
   className,
   id,
   label,
+  disabled,
 }: SelectFilterProps) {
   return (
     <div className={className}>
@@ -38,8 +40,9 @@ export function SelectFilter({
         id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
         className={cn(
-          "h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 cursor-pointer hover:border-primary/50 transition-colors"
+          "h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 cursor-pointer hover:border-primary/50 transition-colors disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-input"
         )}
       >
         {placeholder && <option value="">{placeholder}</option>}


### PR DESCRIPTION
## Summary

Lot 2 of the listing-filter refonte: `/affaires` is the pilot page that adopts the shared contract from Lot 1 (#425). UX/IA only, **no SEO change**.

- **Périmètre en onglets** : `AffairModeToggle` devient deux `<Link replace>` (Mis en cause / Violences contre les élus). `mode=victime` reste une vraie variante navigable (href crawlable, clic-milieu, nouvel onglet), `replace` évite d'empiler l'historique, le périmètre par défaut résout vers une URL propre. Accents corrigés au passage.
- **Pills partis = navigation éditoriale** : le petit titre devient « Explorer par parti », les pills pointent vers `/affaires/parti/[slug]` (inchangé). Le **select Parti est retiré** du panneau (redondant avec les pills + la page dédiée).
- **Famille / Infraction hiérarchiques** : les infractions sont scopées à la famille sélectionnée (plus de séparateurs `──`). Inférence **category-first** : une URL legacy `?category=` sans `supercat` infère sa famille, donc l'infraction active n'est jamais invisible. Un `?supercat=A&category=B` incohérent ne montre pas de chip Famille contradictoire.
- **Recherche manuelle** : bouton « Rechercher » (form submit), plus de filtrage pendant la frappe.
- **`ActiveFilterChips`** dans le panneau : retrait individuel par chip (`×`), `?parti=` legacy visible et retirable, chip `Tri :` quand un tri est actif, « Tout effacer » qui préserve `mode` (non passé à `updateParams`). Filtres en `replace` (pas d'historique pollué).

## Tests

2 nouveaux fichiers, **13 tests**, tous verts :

- `AffairModeToggle` : hrefs propres, `aria-current` sur l'actif, accents.
- `AffairesFilterBar` : select Parti absent ; Infraction désactivée sans famille puis activée ; legacy `?category=` visible/retirable ; recherche manuelle (taper n'écrit rien, submit → `set`) ; retrait chip Famille → `{supercat:"",category:""}` ; chip Parti retirable ; « Tout effacer » sans `mode` ; chip `Tri` ; pas de chip Famille stale.

Local : `vitest` 13/13, `tsc --noEmit --incremental false` clean, `eslint` clean sur les fichiers touchés.

## Scope / non-goals

6 fichiers : `/affaires` (page + `AffairesFilterBar` + `AffairModeToggle`), `SelectFilter` (ajout additif `disabled`), 2 tests.

Explicitement hors périmètre :

- **Aucun changement SEO** : `generateMetadata` non touché, canonical/robots identiques (le `noindex,follow` conditionnel reste pour Lot 3, après vérification GSC).
- Aucune logique data / `getAffairs` modifiée.
- Param orphelin `status` laissé tel quel (follow-up séparé), `/affaires/condamnations` non touché.
- Aucun autre listing migré (Lot 4).
- Aucun texte sensible lié à la présomption d'innocence modifié.

## Checklist post-merge (hors code)

**Communication** (page user-facing) :

- [ ] Post Bluesky
- [ ] Post Twitter/X
- [ ] Note HelloAsso
- [ ] Note Tipeee

**Audit** :

- [ ] Lighthouse (mobile) sur `/affaires`
- [ ] axe (accessibilité) — focus chips, select désactivé, onglets périmètre
- [ ] Rich Results / validation `CollectionPage` JSON-LD
