### PR TITLE
Clarify /affaires category filter labels

### DIFF
--- a/src/components/affairs/AffairesFilterBar.tsx
+++ b/src/components/affairs/AffairesFilterBar.tsx
@@ -75,7 +75,7 @@ export function AffairesFilterBar({
   ];
 
   const superCatOptions = [
-    { value: "", label: "Toutes les familles" },
+    { value: "", label: "Toutes les catégories" },
     ...SUPER_CATEGORIES.map((superCat) => ({
       value: superCat,
       label: `${AFFAIR_SUPER_CATEGORY_LABELS[superCat]} (${superCounts[superCat] || 0})`,
@@ -91,7 +91,7 @@ export function AffairesFilterBar({
           label: AFFAIR_CATEGORY_LABELS[cat],
         })),
       ]
-    : [{ value: "", label: "Choisir d'abord une famille" }];
+    : [{ value: "", label: "Choisir d'abord une catégorie" }];
 
   const sortOptions = Object.entries(SORT_OPTIONS).map(([value, label]) => ({ value, label }));
 
@@ -167,7 +167,7 @@ export function AffairesFilterBar({
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <SelectFilter
           id="supercat-affairs"
-          label="Famille"
+          label="Catégorie d'infraction"
           value={effectiveSupercat}
           onChange={(v) => set({ supercat: v, category: "" })}
           options={superCatOptions}
@@ -175,7 +175,7 @@ export function AffairesFilterBar({
 
         <SelectFilter
           id="category-affairs"
-          label="Infraction"
+          label="Infraction précise"
           value={currentFilters.category}
           onChange={(v) => set({ supercat: effectiveSupercat, category: v })}
           options={categoryOptions}

--- a/src/components/affairs/__tests__/AffairesFilterBar.test.tsx
+++ b/src/components/affairs/__tests__/AffairesFilterBar.test.tsx
@@ -36,20 +36,20 @@ describe("AffairesFilterBar", () => {
     render(<AffairesFilterBar {...baseProps} />);
     expect(screen.queryByLabelText("Parti")).toBeNull();
     // The editorial axes remain
-    expect(screen.getByLabelText("Famille")).toBeInTheDocument();
-    expect(screen.getByLabelText("Infraction")).toBeInTheDocument();
+    expect(screen.getByLabelText("Catégorie d'infraction")).toBeInTheDocument();
+    expect(screen.getByLabelText("Infraction précise")).toBeInTheDocument();
   });
 
   it("disables the Infraction select until a Famille is chosen", () => {
     render(<AffairesFilterBar {...baseProps} />);
-    expect(screen.getByLabelText("Infraction")).toBeDisabled();
+    expect(screen.getByLabelText("Infraction précise")).toBeDisabled();
   });
 
   it("enables the Infraction select when a Famille is selected", () => {
     render(
       <AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, supercat: "PROBITE" }} />
     );
-    expect(screen.getByLabelText("Infraction")).toBeEnabled();
+    expect(screen.getByLabelText("Infraction précise")).toBeEnabled();
   });
 
   it("keeps a legacy ?category= (no supercat) infraction visible and removable", () => {
@@ -60,7 +60,7 @@ describe("AffairesFilterBar", () => {
       />
     );
     // Family inferred from the category -> infraction select is usable
-    expect(screen.getByLabelText("Infraction")).toBeEnabled();
+    expect(screen.getByLabelText("Infraction précise")).toBeEnabled();
     // The infraction chip is present and removable
     fireEvent.click(screen.getByRole("button", { name: /^Retirer le filtre/ }));
     expect(updateParams).toHaveBeenCalledWith({ category: "" }, { mode: "replace" });


### PR DESCRIPTION
## Summary

Clarté UX du filtre à deux niveaux de `/affaires`. Les labels « Famille / Infraction » ne disaient pas la hiérarchie ; renommés pour qu'elle soit immédiate :

- « Famille » → **« Catégorie d'infraction »** (niveau 1)
- « Infraction » → **« Infraction précise »** (niveau 2, désactivé tant qu'aucune catégorie n'est choisie)
- placeholders : « Toutes les familles » → « Toutes les catégories », « Choisir d'abord une famille » → « Choisir d'abord une catégorie »

Le placeholder du 2e select reste « Toutes les infractions » (plus naturel que « Toutes les infractions précises »).

## Tests

`AffairesFilterBar.test.tsx` : assertions `getByLabelText` mises à jour vers les nouveaux labels. `vitest` 10/10, `tsc --noEmit --incremental false` clean, `eslint` clean.

## Scope / non-goals

Wording + adaptation de test **uniquement**. Aucun changement de logique, de SEO (canonical/robots), de route, ni de données. 2 fichiers touchés (`AffairesFilterBar.tsx` + son test).
