### PR TITLE
Harden Sentry build config (gate upload, swallow upload errors)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -178,19 +178,39 @@ const nextConfig: NextConfig = {
 };
 
 const sentryEnabled = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN);
+// Attempt source map upload / release creation only when fully configured
+// (token + org + project). A partial or invalid config must never pollute the
+// build log nor risk failing the build; runtime DSN reporting is independent.
+const sentryUploadEnabled = Boolean(
+  process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT
+);
+// Visible-but-short heads-up when Sentry is on (DSN set) but the upload creds
+// are incomplete: not silent, not spammy, never blocking. (Only fires when a DSN
+// is present, so local dev without a DSN stays quiet.)
+if (sentryEnabled && !sentryUploadEnabled) {
+  // eslint-disable-next-line no-console -- intentional build-time diagnostic
+  console.warn(
+    "[sentry] source map upload disabled: set SENTRY_AUTH_TOKEN + SENTRY_ORG + SENTRY_PROJECT."
+  );
+}
 
 export default sentryEnabled
   ? withSentryConfig(nextConfig, {
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
       silent: !process.env.CI,
-      // Upload source maps only when an auth token is provided (build-time secret)
-      sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
+      // Upload source maps only when token + org + project are all set
+      sourcemaps: { disable: !sentryUploadEnabled },
       widenClientFileUpload: true,
       // Route Sentry events through our domain to bypass ad blockers
       tunnelRoute: "/monitoring",
       disableLogger: true,
       // Instruments Vercel Cron jobs defined in vercel.json automatically
       automaticVercelMonitors: true,
+      // A bad/partial upload config must not break or spam the build log
+      errorHandler: (err) => {
+        // eslint-disable-next-line no-console -- intentional build-time diagnostic
+        console.warn("[sentry] source map upload failed (non-blocking):", err.message);
+      },
     })
   : nextConfig;


### PR DESCRIPTION
## Summary

Durcit la config du plugin Sentry au build pour qu'une configuration partielle ou invalide ne casse ni ne pollue le build, tout en restant visible (warning court). **Ne corrige pas des valeurs fausses** : le vrai fix reste côté env Vercel (`SENTRY_ORG=poligraph` + un Organization Auth Token) ; ce PR rend l'échec gracieux.

- Upload des source maps / création de release tenté **uniquement** si `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT` sont tous présents.
- Warning court non bloquant quand le DSN est présent mais les credentials d'upload incomplets (silencieux en dev local sans DSN).
- `errorHandler` : une erreur d'upload (org/token invalide) loggue une ligne courte et ne casse jamais le build.

## Tests

`tsc --noEmit --incremental false` clean ; `eslint` clean (0 warning). Aucun test unitaire ajouté (changement limité à `next.config.ts`). La capture d'erreurs runtime via DSN est indépendante et inchangée.

## Scope / non-goals

`next.config.ts` (Sentry) uniquement. Aucun changement app / SEO / route / data, aucune variable d'env dans le repo, pas de `robots.txt`.
