### PR TITLE
Noindex filtered /parlement/votes variants (Lot 3a)

### DIFF
--- a/src/app/parlement/votes/page.tsx
+++ b/src/app/parlement/votes/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { ScrutinsListing } from "@/components/parlement";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { hasActiveListingFilter, listingRobotsMetadata } from "@/lib/seo/listing-robots";
 
 export const revalidate = 300;
 
@@ -26,6 +27,17 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   if (params.result) canonicalParams.set("result", params.result);
   const qs = canonicalParams.toString();
 
+  // Lot 3a: de-index utility-filtered/paginated variants (noindex,follow); the
+  // bare /parlement/votes stays indexable. GSC: these facet URLs get 0 clicks.
+  const noindex = hasActiveListingFilter(params, [
+    "search",
+    "result",
+    "legislature",
+    "chamber",
+    "theme",
+    "type",
+  ]);
+
   const chamberTitle =
     params.chamber === "AN"
       ? "Votes de l'Assemblée nationale"
@@ -36,6 +48,7 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
     title: chamberTitle,
     description:
       "Suivez les votes de l'Assemblée nationale et du Sénat. Consultez les scrutins et découvrez comment votent vos représentants.",
+    ...listingRobotsMetadata(noindex),
     alternates: { canonical: `/parlement/votes${qs ? `?${qs}` : ""}` },
   };
 }

--- a/src/lib/seo/__tests__/listing-robots.test.ts
+++ b/src/lib/seo/__tests__/listing-robots.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { hasActiveListingFilter, listingRobotsMetadata } from "../listing-robots";
+
+// /parlement/votes filter keys (Lot 3a)
+const KEYS = ["search", "result", "legislature", "chamber", "theme", "type"] as const;
+
+describe("listingRobotsMetadata", () => {
+  it("returns no robots fragment for the bare listing (inherits index:true)", () => {
+    expect(listingRobotsMetadata(false)).toEqual({});
+  });
+
+  it("returns noindex,follow for a filtered variant", () => {
+    expect(listingRobotsMetadata(true)).toEqual({ robots: { index: false, follow: true } });
+  });
+});
+
+describe("hasActiveListingFilter", () => {
+  it("bare listing (no params) -> false (indexable)", () => {
+    expect(hasActiveListingFilter({}, KEYS)).toBe(false);
+  });
+
+  it.each([...KEYS])("filter '%s' present -> true (noindex)", (key) => {
+    expect(hasActiveListingFilter({ [key]: "x" }, KEYS)).toBe(true);
+  });
+
+  it("empty filter value -> false", () => {
+    expect(hasActiveListingFilter({ search: "" }, KEYS)).toBe(false);
+  });
+
+  it("page=2 -> true", () => {
+    expect(hasActiveListingFilter({ page: "2" }, KEYS)).toBe(true);
+  });
+
+  it("page=1 -> false (page 1 == bare listing)", () => {
+    expect(hasActiveListingFilter({ page: "1" }, KEYS)).toBe(false);
+  });
+
+  it("page=0 -> false", () => {
+    expect(hasActiveListingFilter({ page: "0" }, KEYS)).toBe(false);
+  });
+
+  it("page=abc -> false", () => {
+    expect(hasActiveListingFilter({ page: "abc" }, KEYS)).toBe(false);
+  });
+
+  it("page=2abc -> false (Number(), not parseInt)", () => {
+    expect(hasActiveListingFilter({ page: "2abc" }, KEYS)).toBe(false);
+  });
+
+  it("page='' -> false", () => {
+    expect(hasActiveListingFilter({ page: "" }, KEYS)).toBe(false);
+  });
+});

--- a/src/lib/seo/listing-robots.ts
+++ b/src/lib/seo/listing-robots.ts
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+
+const NOINDEX_FOLLOW = { index: false, follow: true } as const;
+
+/**
+ * `robots` metadata fragment for a utility-filtered listing variant:
+ * noindex,follow (Google can crawl and follow links, but won't index the
+ * filtered/paginated URL). Returns {} for the bare listing so it inherits the
+ * site default (index:true). Spread into the page's generateMetadata return.
+ */
+export function listingRobotsMetadata(hasActiveFilter: boolean): Pick<Metadata, "robots"> {
+  return hasActiveFilter ? { robots: NOINDEX_FOLLOW } : {};
+}
+
+/**
+ * True when a listing URL carries any utility filter/search param, or is
+ * paginated beyond page 1. Pure and route-agnostic: pass the route's filter
+ * keys. Pagination uses Number() (stricter than parseInt: "2abc" -> NaN -> false).
+ */
+export function hasActiveListingFilter(
+  params: Record<string, string | undefined>,
+  filterKeys: readonly string[],
+  paginationKey = "page"
+): boolean {
+  if (filterKeys.some((key) => Boolean(params[key]))) return true;
+
+  const rawPage = params[paginationKey];
+  if (!rawPage) return false;
+  const pageNumber = Number(rawPage);
+  return Number.isFinite(pageNumber) && pageNumber > 1;
+}


### PR DESCRIPTION
## Summary

Lot 3a de la doctrine SEO listings (GSC-gated). Les variantes filtrées/paginées de `/parlement/votes` passent en **`noindex,follow`** ; la page nue reste **indexable**. Données GSC : ces URLs à facettes (theme/chamber/legislature/result/type/search/page) sont massivement « Explorée, actuellement non indexée » (gaspillage de crawl) avec **0 clic**.

- Helper pur réutilisable `src/lib/seo/listing-robots.ts` :
  - `listingRobotsMetadata(hasActiveFilter)` → `{ robots: { index:false, follow:true } }` ou `{}` (héritage `index:true`).
  - `hasActiveListingFilter(params, filterKeys, paginationKey?)` → vrai si un filtre/recherche est présent ou `page > 1` (via `Number()` + `Number.isFinite`, pas `parseInt`).
- `generateMetadata` de `/parlement/votes` : `noindex,follow` si `search/result/legislature/chamber/theme/type` actif ou `page>1`. **Canonical inchangé.**

| URL                                                        | robots                   |
| ---------------------------------------------------------- | ------------------------ |
| `/parlement/votes`                                         | indexable (héritage)     |
| `?page=2` / `?search=` / `?theme=` / `?type=` / `?result=` | noindex,follow           |
| `?page=1`                                                  | indexable (page 1 == nu) |

## Tests

`src/lib/seo/__tests__/listing-robots.test.ts` (**16 tests**) : fragment robots vide vs noindex,follow ; chaque clé de filtre ; `search=""` → false ; `page=1/0/abc/2abc/""` → false ; `page=2` → true. `vitest` 16/16, `tsc --noEmit --incremental false` clean, `eslint` clean.

## Scope / non-goals

`/parlement/votes` uniquement (helper + tests + `generateMetadata`). Pas de `/affaires`, `/factchecks`, `/politiques` (Lot 3b/3c). Pas de `robots.txt`/`Disallow`. Pas de refonte canonical. Pas de changement UI ni de `ScrutinsListing`. Pas de migration Lot 4.
