### PR TITLE
Disable Vercel git auto-deploy (deploy on demand only)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## Summary

Ajoute un `vercel.json` versionné qui désactive l'auto-deploy git de Vercel (`git.deploymentEnabled: false`). Les déploiements ne se font désormais **que sur demande** (CLI ou dashboard) ; un push ne déclenche plus de déploiement. Les déploiements **manuels ne sont pas affectés** (le flag ne gate que les déploiements déclenchés par git).

Objectif : une **source de vérité versionnée** dans le repo, à la place du réglage dashboard « Ignored Build Step » (invisible, non versionné).

## Tests

Aucun test (changement de config uniquement). `vercel.json` validé comme JSON (`python -m json.tool`, exit 0). Aucun changement app / SEO / env / route / CI.

## Scope / non-goals

Nouveau `vercel.json` uniquement. Le réglage dashboard « Ignored Build Step » (« Don't build anything ») est **laissé tel quel pour l'instant** ; le basculer vers « Automatic » (pour que `vercel.json` soit la seule source de vérité) est un suivi, après confirmation du comportement post-merge :

1. `main` clean ;
2. `vercel.json` présent sur `main` ;
3. un push git ne déclenche pas de déploiement auto ;
4. un déploiement manuel dashboard fonctionne toujours.
