### PR TITLE
Noindex filtered /affaires variants (Lot 3b)

### DIFF
--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -39,6 +39,7 @@ import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import type { AffairStatus, Involvement } from "@/types";
+import { hasActiveListingFilter, listingRobotsMetadata } from "@/lib/seo/listing-robots";
 
 export const revalidate = 300; // 5 minutes — CDN edge cache with ISR
 
@@ -96,6 +97,22 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
     description = `${AFFAIR_SUPER_CATEGORY_DESCRIPTIONS[superCatKey]}. Liste des responsables politiques concernés.`;
   }
 
+  // Lot 3b: de-index utility-filtered/paginated/perimeter variants (noindex,follow);
+  // bare /affaires (default "mise-en-cause" perimeter) stays indexable. GSC: these
+  // /affaires facet URLs get ~0 clicks (the condamnations hub captures the intent).
+  const hasNonDefaultMode = params.mode !== undefined && params.mode !== "mise-en-cause";
+
+  const noindex =
+    hasActiveListingFilter(params, [
+      "search",
+      "sort",
+      "status",
+      "supercat",
+      "category",
+      "certainty",
+      "parti",
+    ]) || hasNonDefaultMode;
+
   return {
     title,
     description,
@@ -103,6 +120,7 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
       title: `${title} | Poligraph`,
       description,
     },
+    ...listingRobotsMetadata(noindex),
     alternates: {
       canonical: (() => {
         const cp = new URLSearchParams();


### PR DESCRIPTION
## Summary

Lot 3b de la doctrine SEO listings (GSC-gated). Les variantes filtrées/paginées/de-périmètre de `/affaires` passent en **`noindex,follow`** ; la page nue (périmètre par défaut `mise-en-cause`) reste **indexable**. Données GSC : ces facettes `/affaires` ont ~0 clic (l'intention « condamnations » est captée par le hub `/affaires/condamnations`, qui reste indexable).

Condition (dans `generateMetadata`, réutilise le helper de Lot 3a) :

```ts
const hasNonDefaultMode =
  params.mode !== undefined && params.mode !== "mise-en-cause";
const noindex =
  hasActiveListingFilter(params, [
    "search",
    "sort",
    "status",
    "supercat",
    "category",
    "certainty",
    "parti",
  ]) || hasNonDefaultMode;
```

| URL                                                                                          | robots         |
| -------------------------------------------------------------------------------------------- | -------------- |
| `/affaires`                                                                                  | indexable      |
| `?mode=mise-en-cause` (défaut)                                                               | indexable      |
| `?mode=victime` / `?mode=foo` / `?mode=`                                                     | noindex,follow |
| `?parti=` / `?supercat=` / `?category=` / `?certainty=` / `?status=` / `?search=` / `?sort=` | noindex,follow |
| `?page=2`                                                                                    | noindex,follow |

**Canonical inchangé** (le noindex prime pour les variantes).

## Tests

`vitest` SEO 34/34 (le helper `hasActiveListingFilter` est couvert par les tests Lot 3a, dont `page=1/0/abc/2abc/''`). `tsc --noEmit --incremental false` clean, `eslint` clean. La condition `mode` (inline, triviale) sera vérifiée en QA prod.

## Scope / non-goals

`src/app/affaires/page.tsx` (`generateMetadata`) uniquement. Pas de `/factchecks`, `/politiques` (Lot 3c). **`/affaires/condamnations` et `/affaires/parti/[slug]` non touchés** (routes distinctes, restent indexables — `/affaires/condamnations` rapporte ~800 clics/mois). Pas de `robots.txt`, pas de refonte canonical, pas d'UI, pas de data.
