### PR TITLE
Noindex filtered /politiques variants (Lot 3c-1)

### DIFF
--- a/src/app/politiques/page.tsx
+++ b/src/app/politiques/page.tsx
@@ -9,6 +9,7 @@ import { PoliticiansGrid } from "@/components/politicians/PoliticiansGrid";
 
 import { SeoIntro } from "@/components/seo/SeoIntro";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
+import { hasActiveListingFilter, listingRobotsMetadata } from "@/lib/seo/listing-robots";
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 
@@ -38,9 +39,17 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   if (params.sort && params.sort !== "prominence") cp.set("sort", params.sort);
   const qs = cp.toString();
 
+  const hasNonDefaultSort = params.sort !== undefined && params.sort !== "prominence";
+  const hasConvictionFilter = params.conviction === "true";
+  const noindex =
+    hasActiveListingFilter(params, ["search", "party", "mandate", "status"]) ||
+    hasConvictionFilter ||
+    hasNonDefaultSort;
+
   return {
     title: "Représentants politiques",
     description: "Liste des représentants politiques français - députés, sénateurs, ministres",
+    ...listingRobotsMetadata(noindex),
     alternates: { canonical: `/politiques${qs ? `?${qs}` : ""}` },
   };
 }


### PR DESCRIPTION
## Summary

Lot 3c-1 de la doctrine SEO listings.

Les variantes filtrées/search/paginées de `/politiques` passent en `noindex,follow`, tandis que la page nue `/politiques` reste indexable.

Déclencheurs noindex :

- search ;
- party ;
- mandate ;
- status ;
- conviction=true ;
- sort non défaut ;
- page > 1 via `hasActiveListingFilter`.

Cas préservés indexables :

- `/politiques` ;
- `/politiques?page=1` ;
- `/politiques?sort=prominence`.

## Tests

- `tsc --noEmit --incremental false`
- `eslint src/app/politiques/page.tsx`
- `vitest run src/lib/seo`

## Scope / non-goals

- Fichier unique : `src/app/politiques/page.tsx`
- `generateMetadata` uniquement
- Réutilise `listing-robots.ts`
- Canonical inchangé
- Pas de robots.txt
- Pas d'UI
- Pas de data
- Pas de Vercel
- Pas de Sentry
- Pas de `/factchecks`
- Pas de `/parlement/votes/themes`
- Pas de `/elections/municipales-2026/resultats`
