### PR TITLE
fix(amendments): detect real substance drift during AN sync

### DIFF
--- a/src/services/sync/__tests__/amendments-an/change-detection.test.ts
+++ b/src/services/sync/__tests__/amendments-an/change-detection.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeForChange,
+  textReallyChanged,
+  diffAmendmentRow,
+  type AmendmentComparable,
+} from "@/services/sync/amendments-an/change-detection";
+
+const base = (over: Partial<AmendmentComparable> = {}): AmendmentComparable => ({
+  number: "1",
+  texteRef: null,
+  article: null,
+  content: null,
+  summary: null,
+  status: "DEPOSE",
+  authorType: null,
+  authorName: null,
+  legislature: 17,
+  chamber: "AN",
+  dossierId: null,
+  ...over,
+});
+
+describe("normalizeForChange / textReallyChanged", () => {
+  it("treats identical text as unchanged", () => {
+    expect(textReallyChanged("Article L. 2312-59", "Article L. 2312-59")).toBe(false);
+  });
+
+  it("treats NFC vs NFD accents as unchanged (re-encoding is not a real change)", () => {
+    const nfc = "modalités"; // é precomposed
+    const nfd = "modalités"; // e + combining acute
+    expect(nfc).not.toBe(nfd); // raw strings differ
+    expect(textReallyChanged(nfc, nfd)).toBe(false); // but not a real change
+  });
+
+  it("treats whitespace-only differences as unchanged", () => {
+    expect(textReallyChanged("le  texte\n  officiel", "le texte officiel")).toBe(false);
+  });
+
+  it("treats null vs null as unchanged", () => {
+    expect(textReallyChanged(null, null)).toBe(false);
+    expect(normalizeForChange(null)).toBeNull();
+  });
+
+  it("flags null -> non-null and non-null -> null as changed", () => {
+    expect(textReallyChanged(null, "x")).toBe(true);
+    expect(textReallyChanged("x", null)).toBe(true);
+  });
+
+  it("flags a genuine content change", () => {
+    const before = "droit d'alerte specifique lorsque la situation";
+    const after =
+      "droit d'alerte specifique, nonobstant l'article L. 2312-59, lorsque la situation";
+    expect(textReallyChanged(before, after)).toBe(true);
+  });
+});
+
+describe("diffAmendmentRow", () => {
+  it("identical row -> no content change, no metadata change, empty data", () => {
+    const existing = base({ content: "le dispositif", summary: "l'expose", status: "ADOPTE" });
+    const incoming = base({ content: "le dispositif", summary: "l'expose", status: "ADOPTE" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.contentChanged).toBe(false);
+    expect(diff.summaryChanged).toBe(false);
+    expect(diff.substanceChanged).toBe(false);
+    expect(diff.metadataChanged).toBe(false);
+    expect(diff.data).toEqual({});
+  });
+
+  it("metadata change without substance change -> metadata only, no substance signal", () => {
+    const existing = base({ content: "le dispositif", summary: "l'expose", status: "DEPOSE" });
+    const incoming = base({ content: "le dispositif", summary: "l'expose", status: "ADOPTE" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.contentChanged).toBe(false);
+    expect(diff.summaryChanged).toBe(false);
+    expect(diff.substanceChanged).toBe(false);
+    expect(diff.metadataChanged).toBe(true);
+    expect(diff.data).toEqual({ status: "ADOPTE" });
+  });
+
+  it("real content change (summary unchanged) -> contentChanged + substanceChanged", () => {
+    const existing = base({ content: "ancien dispositif", summary: "expose stable" });
+    const incoming = base({ content: "nouveau dispositif complete", summary: "expose stable" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.contentChanged).toBe(true);
+    expect(diff.summaryChanged).toBe(false);
+    expect(diff.substanceChanged).toBe(true);
+    expect(diff.data.content).toBe("nouveau dispositif complete");
+    expect(diff.data.summary).toBeUndefined();
+  });
+
+  it("content null -> non-null counts as a content change", () => {
+    const existing = base({ content: null });
+    const incoming = base({ content: "le dispositif" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.contentChanged).toBe(true);
+    expect(diff.data.content).toBe("le dispositif");
+  });
+
+  it("content non-null -> null counts as a content change", () => {
+    const existing = base({ content: "le dispositif" });
+    const incoming = base({ content: null });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.contentChanged).toBe(true);
+    expect(diff.data.content).toBeNull();
+  });
+
+  it("NFC-only re-encoding of content is NOT flagged as a change", () => {
+    const existing = base({ content: "modalités de calcul" });
+    const incoming = base({ content: "modalités de calcul" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.contentChanged).toBe(false);
+    expect(diff.substanceChanged).toBe(false);
+    expect(diff.data).toEqual({});
+  });
+
+  it("never nulls an existing dossier link from an unresolved run", () => {
+    const existing = base({ dossierId: "dossier_abc" });
+    const incoming = base({ dossierId: null }); // this run failed to resolve the dossier
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.metadataChanged).toBe(false);
+    expect(diff.data).toEqual({});
+  });
+
+  it("adopts a newly resolved dossier link", () => {
+    const existing = base({ dossierId: null });
+    const incoming = base({ dossierId: "dossier_abc" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.metadataChanged).toBe(true);
+    expect(diff.data).toEqual({ dossierId: "dossier_abc" });
+  });
+});
+
+describe("diffAmendmentRow - summary as substance", () => {
+  it("summary identical with whitespace-only difference -> no change", () => {
+    const existing = base({ summary: "expose  des  motifs\n  detailles" });
+    const incoming = base({ summary: "expose des motifs detailles" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.summaryChanged).toBe(false);
+    expect(diff.substanceChanged).toBe(false);
+    expect(diff.data).toEqual({});
+  });
+
+  it("summary null -> non-null -> summaryChanged + substanceChanged", () => {
+    const existing = base({ summary: null });
+    const incoming = base({ summary: "nouvel expose" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.summaryChanged).toBe(true);
+    expect(diff.substanceChanged).toBe(true);
+    expect(diff.contentChanged).toBe(false);
+    expect(diff.data.summary).toBe("nouvel expose");
+  });
+
+  it("summary non-null -> null -> summaryChanged + substanceChanged", () => {
+    const existing = base({ summary: "ancien expose" });
+    const incoming = base({ summary: null });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.summaryChanged).toBe(true);
+    expect(diff.substanceChanged).toBe(true);
+    expect(diff.data.summary).toBeNull();
+  });
+
+  it("content unchanged but summary changed -> substance signal", () => {
+    const existing = base({ content: "dispositif stable", summary: "ancien expose" });
+    const incoming = base({ content: "dispositif stable", summary: "expose reecrit" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.contentChanged).toBe(false);
+    expect(diff.summaryChanged).toBe(true);
+    expect(diff.substanceChanged).toBe(true);
+    expect(diff.data).toEqual({ summary: "expose reecrit" });
+  });
+
+  it("content and summary both changed -> one substance change, both in data", () => {
+    const existing = base({ content: "ancien dispositif", summary: "ancien expose" });
+    const incoming = base({ content: "nouveau dispositif", summary: "nouvel expose" });
+    const diff = diffAmendmentRow(existing, incoming);
+    expect(diff.contentChanged).toBe(true);
+    expect(diff.summaryChanged).toBe(true);
+    expect(diff.substanceChanged).toBe(true); // single boolean, not double-counted
+    expect(diff.data).toEqual({ content: "nouveau dispositif", summary: "nouvel expose" });
+  });
+});

--- a/src/services/sync/__tests__/amendments-an/writer.test.ts
+++ b/src/services/sync/__tests__/amendments-an/writer.test.ts
@@ -40,7 +40,7 @@ describeIfDb("amendments-an writer", () => {
   });
 
   describe("writeAmendmentBatch", () => {
-    it("upserts idempotently by externalId (2nd run = 0 created)", async () => {
+    it("upserts idempotently by externalId (2nd identical run writes nothing)", async () => {
       const batch = [
         base({ externalId: "TEST_AMW_a", number: "CL8" }),
         base({ externalId: "TEST_AMW_b", number: "I-390" }),
@@ -49,12 +49,112 @@ describeIfDb("amendments-an writer", () => {
       expect(r1.created).toBe(2);
       expect(r1.updated).toBe(0);
 
+      // Identical re-import is now a no-op: classified unchanged, no update issued.
       const r2 = await writeAmendmentBatch(batch);
       expect(r2.created).toBe(0);
-      expect(r2.updated).toBe(2);
+      expect(r2.updated).toBe(0);
+      expect(r2.unchanged).toBe(2);
+      expect(r2.changedSubstanceAmendmentIds).toEqual([]);
 
       const a = await db.amendment.findUnique({ where: { externalId: "TEST_AMW_a" } });
       expect(a?.number).toBe("CL8");
+    });
+
+    it("classifies created / unchanged / metadata-only / content / summary and signals substance once", async () => {
+      // Seed five existing rows.
+      await writeAmendmentBatch([
+        base({
+          externalId: "TEST_AMW_m_same",
+          content: "le dispositif inchange",
+          summary: "expose stable",
+          status: "DEPOSE",
+        }),
+        base({
+          externalId: "TEST_AMW_m_meta",
+          content: "le dispositif stable",
+          summary: "expose stable",
+          status: "DEPOSE",
+        }),
+        base({
+          externalId: "TEST_AMW_m_content",
+          content: "ancien dispositif",
+          summary: "expose stable",
+        }),
+        base({
+          externalId: "TEST_AMW_m_summary",
+          content: "dispositif stable",
+          summary: "ancien expose",
+        }),
+        base({
+          externalId: "TEST_AMW_m_both",
+          content: "ancien dispositif",
+          summary: "ancien expose",
+        }),
+      ]);
+
+      const r = await writeAmendmentBatch([
+        // identical -> unchanged
+        base({
+          externalId: "TEST_AMW_m_same",
+          content: "le dispositif inchange",
+          summary: "expose stable",
+          status: "DEPOSE",
+        }),
+        // only status changed -> metadata only, no substance signal
+        base({
+          externalId: "TEST_AMW_m_meta",
+          content: "le dispositif stable",
+          summary: "expose stable",
+          status: "ADOPTE",
+        }),
+        // content changed, summary same -> substance
+        base({
+          externalId: "TEST_AMW_m_content",
+          content: "nouveau dispositif complete",
+          summary: "expose stable",
+        }),
+        // summary changed, content same -> substance
+        base({
+          externalId: "TEST_AMW_m_summary",
+          content: "dispositif stable",
+          summary: "expose reecrit",
+        }),
+        // both changed -> substance, signalled ONCE
+        base({
+          externalId: "TEST_AMW_m_both",
+          content: "nouveau dispositif",
+          summary: "nouvel expose",
+        }),
+        // brand new -> created
+        base({ externalId: "TEST_AMW_m_new", content: "tout neuf" }),
+      ]);
+
+      expect(r.created).toBe(1);
+      expect(r.unchanged).toBe(1);
+      expect(r.metadataOnly).toBe(1);
+      expect(r.contentChanged).toBe(2); // m_content + m_both
+      expect(r.summaryChanged).toBe(2); // m_summary + m_both
+      expect(r.substanceChanged).toBe(3); // m_content + m_summary + m_both (m_both once)
+      expect(r.updated).toBe(4); // substanceChanged (3) + metadataOnly (1)
+
+      // Signal carries exactly the three substance-changed cuids, m_both only once.
+      const substanceRows = await db.amendment.findMany({
+        where: {
+          externalId: { in: ["TEST_AMW_m_content", "TEST_AMW_m_summary", "TEST_AMW_m_both"] },
+        },
+        select: { id: true },
+      });
+      const expectedIds = substanceRows.map((row) => row.id).sort();
+      expect(r.changedSubstanceAmendmentIds).toHaveLength(3);
+      expect([...r.changedSubstanceAmendmentIds].sort()).toEqual(expectedIds);
+
+      // Metadata-only row got its status updated but kept its substance.
+      const metaRow = await db.amendment.findUnique({
+        where: { externalId: "TEST_AMW_m_meta" },
+      });
+      expect(metaRow?.status).toBe("ADOPTE");
+      expect(metaRow?.content).toBe("le dispositif stable");
+      expect(metaRow?.summary).toBe("expose stable");
     });
 
     it("reports dossier-resolved vs unresolved counts", async () => {

--- a/src/services/sync/amendments-an.ts
+++ b/src/services/sync/amendments-an.ts
@@ -26,6 +26,12 @@ function emptyStats(warnings: SyncWarning[]): SyncAmendmentsANStats {
     amendmentsSeen: 0,
     amendmentsCreated: 0,
     amendmentsUpdated: 0,
+    amendmentsContentChanged: 0,
+    amendmentsSummaryChanged: 0,
+    amendmentsSubstanceChanged: 0,
+    amendmentsMetadataOnly: 0,
+    amendmentsUnchanged: 0,
+    changedSubstanceAmendmentIds: [],
     amendmentsSkipped: 0,
     parentLinksResolved: 0,
     parentLinksDeferred: 0,
@@ -96,6 +102,12 @@ export async function syncAmendmentsAN(
       const r = await writeAmendmentBatch(batch);
       stats.amendmentsCreated += r.created;
       stats.amendmentsUpdated += r.updated;
+      stats.amendmentsContentChanged += r.contentChanged;
+      stats.amendmentsSummaryChanged += r.summaryChanged;
+      stats.amendmentsSubstanceChanged += r.substanceChanged;
+      stats.amendmentsMetadataOnly += r.metadataOnly;
+      stats.amendmentsUnchanged += r.unchanged;
+      stats.changedSubstanceAmendmentIds.push(...r.changedSubstanceAmendmentIds);
       stats.dossiersResolved += r.dossiersResolved;
       stats.dossiersUnresolved += r.dossiersUnresolved;
     }

--- a/src/services/sync/amendments-an/change-detection.ts
+++ b/src/services/sync/amendments-an/change-detection.ts
@@ -1,0 +1,120 @@
+import type { AmendmentStatus, Chamber } from "@/generated/prisma";
+
+/**
+ * The amendment fields the writer compares between the stored row and the
+ * incoming parse to decide what (if anything) to write. Kept db-free so the
+ * change-detection logic is unit-testable without a live database.
+ */
+export interface AmendmentComparable {
+  number: string;
+  texteRef: string | null;
+  article: string | null;
+  content: string | null;
+  summary: string | null;
+  status: AmendmentStatus;
+  authorType: string | null;
+  authorName: string | null;
+  legislature: number;
+  chamber: Chamber;
+  dossierId: string | null;
+}
+
+export interface AmendmentDiff {
+  /** True when `content` (dispositif) really changed (NFC + whitespace-insensitive). */
+  contentChanged: boolean;
+  /** True when `summary` (exposé sommaire) really changed. */
+  summaryChanged: boolean;
+  /** True when either substance field changed: content OR summary. */
+  substanceChanged: boolean;
+  /** True when any non-substance field really changed. */
+  metadataChanged: boolean;
+  /** The minimal Prisma update payload: only the fields that actually changed. */
+  data: Partial<AmendmentComparable>;
+}
+
+/**
+ * NFC + whitespace-collapse normalization used to decide whether a text field
+ * "really changed". Treats precomposed vs. decomposed accents and whitespace-only
+ * differences as equal, so a re-import that merely re-encodes identical text is
+ * NOT counted as a change. This both removes write churn and avoids spurious
+ * evidence drift on policy titles pinned to the earlier encoding.
+ */
+export function normalizeForChange(value: string | null): string | null {
+  if (value == null) return null;
+  return value.normalize("NFC").replace(/\s+/g, " ").trim();
+}
+
+/** True when two text values differ after NFC + whitespace normalization. */
+export function textReallyChanged(a: string | null, b: string | null): boolean {
+  return normalizeForChange(a) !== normalizeForChange(b);
+}
+
+/**
+ * Per-field change detection between the stored amendment and the incoming one.
+ *
+ * Substance is `content` (dispositif) AND `summary` (exposé sommaire): both feed
+ * the policy-title evidence quotes, so either one changing is a substance change.
+ * All long text fields are compared with NFC + whitespace normalization so
+ * encoding-only re-imports are not flagged. `dossierId` is only treated as
+ * changed when the incoming run actually resolved a dossier: a run that fails to
+ * resolve the ref must never null out an existing link.
+ *
+ * Returns the minimal update payload plus the flags the writer uses to classify
+ * the row. `substanceChanged` drives the regeneration signal consumed by a later
+ * stage; `metadataChanged` distinguishes a metadata-only touch from a no-op.
+ */
+export function diffAmendmentRow(
+  existing: AmendmentComparable,
+  incoming: AmendmentComparable
+): AmendmentDiff {
+  const data: Partial<AmendmentComparable> = {};
+
+  const contentChanged = textReallyChanged(existing.content, incoming.content);
+  if (contentChanged) data.content = incoming.content;
+
+  const summaryChanged = textReallyChanged(existing.summary, incoming.summary);
+  if (summaryChanged) data.summary = incoming.summary;
+
+  let metadataChanged = false;
+  if (textReallyChanged(existing.article, incoming.article)) {
+    data.article = incoming.article;
+    metadataChanged = true;
+  }
+  if (textReallyChanged(existing.texteRef, incoming.texteRef)) {
+    data.texteRef = incoming.texteRef;
+    metadataChanged = true;
+  }
+  if (textReallyChanged(existing.number, incoming.number)) {
+    data.number = incoming.number;
+    metadataChanged = true;
+  }
+  if (textReallyChanged(existing.authorName, incoming.authorName)) {
+    data.authorName = incoming.authorName;
+    metadataChanged = true;
+  }
+  if (existing.authorType !== incoming.authorType) {
+    data.authorType = incoming.authorType;
+    metadataChanged = true;
+  }
+  if (existing.status !== incoming.status) {
+    data.status = incoming.status;
+    metadataChanged = true;
+  }
+  if (existing.legislature !== incoming.legislature) {
+    data.legislature = incoming.legislature;
+    metadataChanged = true;
+  }
+  if (existing.chamber !== incoming.chamber) {
+    data.chamber = incoming.chamber;
+    metadataChanged = true;
+  }
+  // Only adopt a resolved dossier; never null an existing link from a run that
+  // failed to resolve the ref this time.
+  if (incoming.dossierId !== null && incoming.dossierId !== existing.dossierId) {
+    data.dossierId = incoming.dossierId;
+    metadataChanged = true;
+  }
+
+  const substanceChanged = contentChanged || summaryChanged;
+  return { contentChanged, summaryChanged, substanceChanged, metadataChanged, data };
+}

--- a/src/services/sync/amendments-an/types.ts
+++ b/src/services/sync/amendments-an/types.ts
@@ -38,7 +38,13 @@ export interface SyncAmendmentsANStats {
   downloadedBytes?: number; // bytes written to disk this run (0 when notModified or zipPath used)
   amendmentsSeen: number;
   amendmentsCreated: number;
-  amendmentsUpdated: number;
+  amendmentsUpdated: number; // amendmentsSubstanceChanged + amendmentsMetadataOnly
+  amendmentsContentChanged: number; // existing rows whose `content` (dispositif) really changed
+  amendmentsSummaryChanged: number; // existing rows whose `summary` (exposé sommaire) really changed
+  amendmentsSubstanceChanged: number; // existing rows where content OR summary changed (once each)
+  amendmentsMetadataOnly: number; // existing rows where only non-substance fields changed
+  amendmentsUnchanged: number; // existing rows identical to the parse (no write)
+  changedSubstanceAmendmentIds: string[]; // signal for PR B: titles to regenerate
   amendmentsSkipped: number;
   parentLinksResolved: number;
   parentLinksDeferred: number;

--- a/src/services/sync/amendments-an/writer.ts
+++ b/src/services/sync/amendments-an/writer.ts
@@ -1,10 +1,28 @@
 import crypto from "crypto";
 import { db } from "@/lib/db";
 import type { NormalizedAmendment } from "./types";
+import { diffAmendmentRow } from "./change-detection";
 
 export interface BatchResult {
   created: number;
+  /** Existing rows actually written this batch (substanceChanged + metadataOnly). */
   updated: number;
+  /** Existing rows whose `content` (dispositif) really changed; may overlap summaryChanged. */
+  contentChanged: number;
+  /** Existing rows whose `summary` (exposé sommaire) really changed; may overlap contentChanged. */
+  summaryChanged: number;
+  /** Existing rows where content OR summary changed, each counted once. */
+  substanceChanged: number;
+  /** Existing rows where only non-substance fields changed (subset of `updated`). */
+  metadataOnly: number;
+  /** Existing rows that were identical to the parse: no write issued. */
+  unchanged: number;
+  /**
+   * cuid ids of existing amendments whose substance (content OR summary) really
+   * changed this batch. The read-only signal a later stage (PR B) will consume to
+   * flag the linked ScrutinPolicyTitle rows for regeneration. PR A only produces it.
+   */
+  changedSubstanceAmendmentIds: string[];
   dossiersResolved: number;
   dossiersUnresolved: number;
 }
@@ -82,34 +100,94 @@ export async function writeAmendmentBatch(batch: NormalizedAmendment[]): Promise
     });
   }
 
-  if (rows.length === 0) return { created: 0, updated: 0, dossiersResolved, dossiersUnresolved };
+  if (rows.length === 0)
+    return {
+      created: 0,
+      updated: 0,
+      contentChanged: 0,
+      summaryChanged: 0,
+      substanceChanged: 0,
+      metadataOnly: 0,
+      unchanged: 0,
+      changedSubstanceAmendmentIds: [],
+      dossiersResolved,
+      dossiersUnresolved,
+    };
 
-  // 1. Bulk-fetch which externalIds already exist in the batch's externalId set.
+  // 1. Bulk-fetch the existing rows for this batch with the fields we compare,
+  //    so we can decide per-row whether anything actually changed.
   const externalIds = rows.map((r) => r.externalId);
   const existing = await db.amendment.findMany({
     where: { externalId: { in: externalIds } },
-    select: { externalId: true },
+    select: {
+      id: true,
+      externalId: true,
+      number: true,
+      texteRef: true,
+      article: true,
+      content: true,
+      summary: true,
+      status: true,
+      authorType: true,
+      authorName: true,
+      legislature: true,
+      chamber: true,
+      dossierId: true,
+    },
   });
-  const existingSet = new Set(existing.map((e) => e.externalId));
+  const existingByExternalId = new Map(existing.map((e) => [e.externalId, e]));
 
   // 2. Partition.
-  const newRows = rows.filter((r) => !existingSet.has(r.externalId));
-  const updateRows = rows.filter((r) => existingSet.has(r.externalId));
+  const newRows = rows.filter((r) => !existingByExternalId.has(r.externalId));
+  const updateRows = rows.filter((r) => existingByExternalId.has(r.externalId));
 
   // 3a. Bulk insert all new rows in a single createMany.
   if (newRows.length > 0) {
     await db.amendment.createMany({ data: newRows });
   }
 
-  // 3b. Per-row update for the (usually small) existing set.
+  // 3b. Per-row diff + conditional update for the existing set. We only write the
+  //     fields that really changed (no blind overwrite), and record which rows had
+  //     a genuine substance change (content OR summary) as the regeneration signal
+  //     for a later stage.
+  let contentChanged = 0;
+  let summaryChanged = 0;
+  let substanceChanged = 0;
+  let metadataOnly = 0;
+  let unchanged = 0;
+  const changedSubstanceAmendmentIds: string[] = [];
+
   for (const r of updateRows) {
-    const { externalId, ...data } = r;
-    await db.amendment.update({ where: { externalId }, data });
+    const prev = existingByExternalId.get(r.externalId);
+    if (!prev) continue; // unreachable: filtered above, narrows the type
+    const { externalId, ...incoming } = r;
+    const diff = diffAmendmentRow(prev, incoming);
+
+    if (diff.contentChanged) contentChanged++;
+    if (diff.summaryChanged) summaryChanged++;
+
+    if (diff.substanceChanged) {
+      substanceChanged++;
+      changedSubstanceAmendmentIds.push(prev.id);
+    } else if (diff.metadataChanged) {
+      metadataOnly++;
+    } else {
+      unchanged++;
+      continue; // nothing to write
+    }
+
+    await db.amendment.update({ where: { externalId }, data: diff.data });
   }
 
   return {
     created: newRows.length,
-    updated: updateRows.length,
+    updated: substanceChanged + metadataOnly,
+    contentChanged,
+    summaryChanged,
+    substanceChanged,
+    metadataOnly,
+    unchanged,
+    changedSubstanceAmendmentIds,
     dossiersResolved,
     dossiersUnresolved,
   };


### PR DESCRIPTION
## Problème

À chaque sync AN, `writeAmendmentBatch` réécrivait **inconditionnellement** le `content` (et tous les champs) de chaque amendement existant du batch, sans aucun diff. Quand le ZIP officiel change (quotidien en session : dépôts, statuts, rectifications), tout le lot est re-traité et chaque ligne existante est réécrite à l'aveugle (« updated 2000 » par run).

Conséquence en aval : le `dispositif` (et l'exposé sommaire) de certains amendements évolue réellement côté AN, et comme la réécriture est aveugle, les `evidenceQuotes` des titres de vote (`ScrutinPolicyTitle`), figées au moment de la génération, sont invalidées (`EVIDENCE_DRIFT`). Cela bloque l'approbation de titres pourtant souvent encore valides, et noie le vrai changement dans du churn.

## Correction

Détection de changement **réel** par champ dans le writer :

- **Diff champ par champ** entre la ligne stockée et la ligne entrante ; on ne `update` que les champs qui ont réellement changé (fin du blind overwrite).
- **Normalisation NFC + espaces** pour les comparaisons de texte (`content`, `summary`, et les champs courts). Un ré-import qui ne fait que ré-encoder le même texte (accents précomposés vs décomposés, whitespace) n'est **pas** compté comme un changement : le contenu stocké garde son encodage d'origine tant que le texte officiel n'évolue pas vraiment, ce qui supprime à la fois le churn et la fausse dérive d'evidence.
- **Garde-fou `dossierId`** : un run qui échoue à résoudre le ref ne met jamais à `null` un lien existant.

La logique pure vit dans un module db-free `amendments-an/change-detection.ts` (testable sans base, même pattern que `normalize.ts`) ; elle est invoquée dans la boucle d'update de `writer.ts`.

## Nouveau signal

`changedSubstanceAmendmentIds` : les cuids des amendements existants dont la **substance** a réellement changé, c'est-à-dire `contentChanged` **OU** `summaryChanged` (le dispositif comme l'exposé sommaire alimentent les evidenceQuotes). Le cuid est poussé **une seule fois** même si les deux champs changent. Le signal est aussi accumulé sur tout le sync dans `SyncAmendmentsANStats`.

## Compteurs

`BatchResult` / `SyncAmendmentsANStats` distinguent désormais :

- `created`
- `updated` (= `substanceChanged` + `metadataOnly`)
- `contentChanged` (dispositif ; peut chevaucher `summaryChanged`)
- `summaryChanged` (exposé sommaire ; peut chevaucher `contentChanged`)
- `substanceChanged` (content OU summary, compté une fois)
- `metadataOnly` (un champ non-substance a changé, pas la substance)
- `unchanged` (identique à la parse : aucune écriture)

## Hors périmètre (explicite)

Cette PR **produit** le signal, elle ne le consomme pas. Ne sont **pas** inclus ici :

- pas de marquage `ScrutinPolicyTitle` en `STALE` ;
- pas de régénération de titres ;
- pas de modification du cron (`sync-daily.ts` inchangé) ;
- pas de migration ;
- pas de `db push` ;
- pas de reprise du backlog de jugement.

## Tests

- **`change-detection.test.ts`** (19, db-free) : identique, NFC/NFD non flaggé, whitespace non flaggé, null↔non-null pour content et summary, content seul / summary seul / les deux → `substanceChanged` une seule fois, metadata-only sans signal substance, garde-fou dossier.
- **`writer.test.ts`** (DB-gated) : 2e run identique = no-op (`unchanged`), batch mixte 6 lignes (created / unchanged / metadata-only / content / summary / both) vérifiant `contentChanged:2`, `summaryChanged:2`, `substanceChanged:3`, `updated:4`, et un `changedSubstanceAmendmentIds` de longueur 3 (la ligne « both » n'apparaît qu'une fois).

Commandes : `tsc --noEmit --incremental false` clean, `eslint` clean sur les fichiers modifiés, `vitest` pure 19/19, `vitest` writer 7/7.

## Risque connu : tests DB-gated contre `.env` prod

En local, `.env` pointe la base de production, donc le test writer DB-gated écrit réellement en base. Mitigations en place :

- écritures **strictement** préfixées `TEST_AMW_*` (jamais en collision avec les UID AN réels) ;
- `afterAll` de cleanup obligatoire ;
- vérification post-run : **0** ligne `TEST_AMW_*` restante ;
- aucun test destructif (pas de `deleteMany` large, pas de truncate) ;
- les tests sont `describeIfDb` : skippés sans `DATABASE_URL`.

**Follow-up proposé** : isoler une base test/staging dédiée pour ces tests DB-gated, afin de ne plus jamais taper la prod en CI/local.

## Suite

PR B (sur feu vert) consommera `changedSubstanceAmendmentIds` : résoudre `cuid → ScrutinAmendment → scrutinId → ScrutinPolicyTitle`, puis marquer ces titres à régénérer (`STALE` si `APPROVED`, re-file si `NEEDS_REVIEW`), avec garde-fous.
