### PR TITLE
feat(amendments): mark linked policy titles stale on substance drift

### DIFF
--- a/src/services/sync/__tests__/mark-policy-titles-substance-drift.test.ts
+++ b/src/services/sync/__tests__/mark-policy-titles-substance-drift.test.ts
@@ -73,7 +73,7 @@ describeIfDb("markPolicyTitlesForSubstanceDrift", () => {
   it("empty signal -> no-op, all zeros", async () => {
     const r = await markPolicyTitlesForSubstanceDrift([]);
     expect(r).toEqual({
-      changedSubstanceAmendmentIds: 0,
+      changedSubstanceAmendmentCount: 0,
       linkedScrutins: 0,
       policyTitlesMarkedStale: 0,
       policyTitlesQueuedOrFlagged: 0,
@@ -84,7 +84,7 @@ describeIfDb("markPolicyTitlesForSubstanceDrift", () => {
   it("amendment with no ScrutinAmendment -> no-op", async () => {
     const a = await seedAmendment("orphan");
     const r = await markPolicyTitlesForSubstanceDrift([a.id]);
-    expect(r.changedSubstanceAmendmentIds).toBe(1);
+    expect(r.changedSubstanceAmendmentCount).toBe(1);
     expect(r.linkedScrutins).toBe(0);
     expect(r.policyTitlesMarkedStale).toBe(0);
     expect(r.policyTitlesQueuedOrFlagged).toBe(0);
@@ -113,7 +113,7 @@ describeIfDb("markPolicyTitlesForSubstanceDrift", () => {
     const t = await seedTitle(sc.id, "APPROVED");
 
     const r = await markPolicyTitlesForSubstanceDrift([a1.id, a2.id]);
-    expect(r.changedSubstanceAmendmentIds).toBe(2);
+    expect(r.changedSubstanceAmendmentCount).toBe(2);
     expect(r.linkedScrutins).toBe(1); // deduped
     expect(r.policyTitlesMarkedStale).toBe(1); // one title, one update
 

--- a/src/services/sync/__tests__/mark-policy-titles-substance-drift.test.ts
+++ b/src/services/sync/__tests__/mark-policy-titles-substance-drift.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { PolicyTitleStatus, RegenerationStatus } from "@/generated/prisma";
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+
+const PFX = "TEST_PTD_";
+
+type Mark = typeof import("@/services/sync/mark-policy-titles-substance-drift");
+let db: typeof import("@/lib/db").db;
+let markPolicyTitlesForSubstanceDrift: Mark["markPolicyTitlesForSubstanceDrift"];
+
+describeIfDb("markPolicyTitlesForSubstanceDrift", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ markPolicyTitlesForSubstanceDrift } =
+      await import("@/services/sync/mark-policy-titles-substance-drift"));
+  });
+
+  afterAll(async () => {
+    await db.scrutinAmendment.deleteMany({
+      where: { amendment: { externalId: { startsWith: PFX } } },
+    });
+    await db.scrutinPolicyTitle.deleteMany({
+      where: { scrutin: { externalId: { startsWith: PFX } } },
+    });
+    await db.amendment.deleteMany({ where: { externalId: { startsWith: PFX } } });
+    await db.scrutin.deleteMany({ where: { externalId: { startsWith: PFX } } });
+  });
+
+  const seedScrutin = (ext: string) =>
+    db.scrutin.create({
+      data: {
+        externalId: PFX + ext,
+        title: "Test scrutin " + ext,
+        votingDate: new Date("2026-01-01"),
+        legislature: 17,
+        result: "ADOPTED",
+        votesFor: 0,
+        votesAgainst: 0,
+        votesAbstain: 0,
+      },
+    });
+
+  const seedAmendment = (ext: string) =>
+    db.amendment.create({
+      data: { externalId: PFX + ext, number: "1", status: "DEPOSE", legislature: 17 },
+    });
+
+  const seedTitle = (
+    scrutinId: string,
+    status: PolicyTitleStatus,
+    regenerationStatus: RegenerationStatus = "idle"
+  ) =>
+    db.scrutinPolicyTitle.create({
+      data: {
+        scrutinId,
+        officialTitleSnapshot: "Snapshot officiel",
+        inputHash: "hash",
+        proceduralLabel: "Label procédural",
+        confidence: "HIGH",
+        qualitySignals: {},
+        generationSource: "LLM",
+        status,
+        regenerationStatus,
+      },
+    });
+
+  const link = (scrutinId: string, amendmentId: string) =>
+    db.scrutinAmendment.create({
+      data: { scrutinId, amendmentId, role: "PRINCIPAL", source: "TITLE_REGEX" },
+    });
+
+  it("empty signal -> no-op, all zeros", async () => {
+    const r = await markPolicyTitlesForSubstanceDrift([]);
+    expect(r).toEqual({
+      changedSubstanceAmendmentIds: 0,
+      linkedScrutins: 0,
+      policyTitlesMarkedStale: 0,
+      policyTitlesQueuedOrFlagged: 0,
+      policyTitlesIgnored: 0,
+    });
+  });
+
+  it("amendment with no ScrutinAmendment -> no-op", async () => {
+    const a = await seedAmendment("orphan");
+    const r = await markPolicyTitlesForSubstanceDrift([a.id]);
+    expect(r.changedSubstanceAmendmentIds).toBe(1);
+    expect(r.linkedScrutins).toBe(0);
+    expect(r.policyTitlesMarkedStale).toBe(0);
+    expect(r.policyTitlesQueuedOrFlagged).toBe(0);
+  });
+
+  it("APPROVED title -> STALE", async () => {
+    const sc = await seedScrutin("appr");
+    const a = await seedAmendment("appr_a");
+    await link(sc.id, a.id);
+    const t = await seedTitle(sc.id, "APPROVED");
+
+    const r = await markPolicyTitlesForSubstanceDrift([a.id]);
+    expect(r.linkedScrutins).toBe(1);
+    expect(r.policyTitlesMarkedStale).toBe(1);
+
+    const after = await db.scrutinPolicyTitle.findUnique({ where: { id: t.id } });
+    expect(after?.status).toBe("STALE");
+  });
+
+  it("multiple amendments of the same scrutin -> a single title update", async () => {
+    const sc = await seedScrutin("multi");
+    const a1 = await seedAmendment("multi_a1");
+    const a2 = await seedAmendment("multi_a2");
+    await link(sc.id, a1.id);
+    await link(sc.id, a2.id);
+    const t = await seedTitle(sc.id, "APPROVED");
+
+    const r = await markPolicyTitlesForSubstanceDrift([a1.id, a2.id]);
+    expect(r.changedSubstanceAmendmentIds).toBe(2);
+    expect(r.linkedScrutins).toBe(1); // deduped
+    expect(r.policyTitlesMarkedStale).toBe(1); // one title, one update
+
+    const after = await db.scrutinPolicyTitle.findUnique({ where: { id: t.id } });
+    expect(after?.status).toBe("STALE");
+  });
+
+  it("NEEDS_REVIEW -> stays NEEDS_REVIEW, queued, never approved/published", async () => {
+    const sc = await seedScrutin("nr");
+    const a = await seedAmendment("nr_a");
+    await link(sc.id, a.id);
+    const t = await seedTitle(sc.id, "NEEDS_REVIEW", "idle");
+
+    const r = await markPolicyTitlesForSubstanceDrift([a.id]);
+    expect(r.policyTitlesQueuedOrFlagged).toBe(1);
+    expect(r.policyTitlesMarkedStale).toBe(0);
+
+    const after = await db.scrutinPolicyTitle.findUnique({ where: { id: t.id } });
+    expect(after?.status).toBe("NEEDS_REVIEW"); // not approved, not published
+    expect(after?.regenerationStatus).toBe("queued");
+  });
+
+  it("already STALE -> no-op (ignored)", async () => {
+    const sc = await seedScrutin("stale");
+    const a = await seedAmendment("stale_a");
+    await link(sc.id, a.id);
+    const t = await seedTitle(sc.id, "STALE");
+
+    const r = await markPolicyTitlesForSubstanceDrift([a.id]);
+    expect(r.policyTitlesIgnored).toBe(1);
+    expect(r.policyTitlesMarkedStale).toBe(0);
+
+    const after = await db.scrutinPolicyTitle.findUnique({ where: { id: t.id } });
+    expect(after?.status).toBe("STALE");
+  });
+
+  it("REJECTED -> no-op (ignored, never reactivated)", async () => {
+    const sc = await seedScrutin("rej");
+    const a = await seedAmendment("rej_a");
+    await link(sc.id, a.id);
+    const t = await seedTitle(sc.id, "REJECTED");
+
+    const r = await markPolicyTitlesForSubstanceDrift([a.id]);
+    expect(r.policyTitlesIgnored).toBe(1);
+    expect(r.policyTitlesMarkedStale).toBe(0);
+    expect(r.policyTitlesQueuedOrFlagged).toBe(0);
+
+    const after = await db.scrutinPolicyTitle.findUnique({ where: { id: t.id } });
+    expect(after?.status).toBe("REJECTED");
+  });
+});

--- a/src/services/sync/__tests__/policy-title-substance-drift-plan.test.ts
+++ b/src/services/sync/__tests__/policy-title-substance-drift-plan.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+import {
+  classifyTitleForDrift,
+  planSubstanceDriftActions,
+  type DriftTitleRow,
+} from "@/services/sync/policy-title-substance-drift-plan";
+
+const row = (over: Partial<DriftTitleRow>): DriftTitleRow => ({
+  id: "t1",
+  status: "APPROVED",
+  regenerationStatus: "idle",
+  ...over,
+});
+
+describe("classifyTitleForDrift", () => {
+  it("APPROVED -> stale", () => expect(classifyTitleForDrift("APPROVED")).toBe("stale"));
+  it("NEEDS_REVIEW -> queue", () => expect(classifyTitleForDrift("NEEDS_REVIEW")).toBe("queue"));
+  it("DRAFT -> queue", () => expect(classifyTitleForDrift("DRAFT")).toBe("queue"));
+  it("REJECTED -> ignore (never reactivated)", () =>
+    expect(classifyTitleForDrift("REJECTED")).toBe("ignore"));
+  it("STALE -> ignore (already stale)", () =>
+    expect(classifyTitleForDrift("STALE")).toBe("ignore"));
+});
+
+describe("planSubstanceDriftActions", () => {
+  it("empty -> all zeros, no writes", () => {
+    const plan = planSubstanceDriftActions([]);
+    expect(plan).toEqual({
+      toStale: [],
+      toQueue: [],
+      markedStale: 0,
+      queuedOrFlagged: 0,
+      ignored: 0,
+    });
+  });
+
+  it("APPROVED -> toStale + markedStale", () => {
+    const plan = planSubstanceDriftActions([row({ id: "a", status: "APPROVED" })]);
+    expect(plan.toStale).toEqual(["a"]);
+    expect(plan.markedStale).toBe(1);
+    expect(plan.toQueue).toEqual([]);
+  });
+
+  it("NEEDS_REVIEW (idle) -> queued, status not touched here", () => {
+    const plan = planSubstanceDriftActions([
+      row({ id: "n", status: "NEEDS_REVIEW", regenerationStatus: "idle" }),
+    ]);
+    expect(plan.toQueue).toEqual(["n"]);
+    expect(plan.queuedOrFlagged).toBe(1);
+    expect(plan.toStale).toEqual([]); // never published/approved/stale'd
+  });
+
+  it("NEEDS_REVIEW already queued -> counted, no redundant write", () => {
+    const plan = planSubstanceDriftActions([
+      row({ id: "n", status: "NEEDS_REVIEW", regenerationStatus: "queued" }),
+    ]);
+    expect(plan.queuedOrFlagged).toBe(1);
+    expect(plan.toQueue).toEqual([]); // already queued -> skip the write
+  });
+
+  it("DRAFT -> queued", () => {
+    const plan = planSubstanceDriftActions([row({ id: "d", status: "DRAFT" })]);
+    expect(plan.toQueue).toEqual(["d"]);
+    expect(plan.queuedOrFlagged).toBe(1);
+  });
+
+  it("REJECTED -> ignored, no write", () => {
+    const plan = planSubstanceDriftActions([row({ id: "r", status: "REJECTED" })]);
+    expect(plan.ignored).toBe(1);
+    expect(plan.toStale).toEqual([]);
+    expect(plan.toQueue).toEqual([]);
+  });
+
+  it("STALE -> ignored, no write", () => {
+    const plan = planSubstanceDriftActions([row({ id: "s", status: "STALE" })]);
+    expect(plan.ignored).toBe(1);
+    expect(plan.toStale).toEqual([]);
+    expect(plan.toQueue).toEqual([]);
+  });
+
+  it("mixed batch -> correct per-bucket counts", () => {
+    const plan = planSubstanceDriftActions([
+      row({ id: "a", status: "APPROVED" }),
+      row({ id: "n", status: "NEEDS_REVIEW", regenerationStatus: "idle" }),
+      row({ id: "d", status: "DRAFT" }),
+      row({ id: "r", status: "REJECTED" }),
+      row({ id: "s", status: "STALE" }),
+    ]);
+    expect(plan.markedStale).toBe(1);
+    expect(plan.queuedOrFlagged).toBe(2); // n + d
+    expect(plan.ignored).toBe(2); // r + s
+    expect(plan.toStale).toEqual(["a"]);
+    expect(plan.toQueue).toEqual(["n", "d"]);
+  });
+});
+
+describe("substance-drift modules never call a model (structural guard)", () => {
+  const read = (rel: string) =>
+    readFileSync(path.join(process.cwd(), "src/services/sync", rel), "utf8");
+
+  it("plan + mark modules import no AI client", () => {
+    const sources = [
+      read("policy-title-substance-drift-plan.ts"),
+      read("mark-policy-titles-substance-drift.ts"),
+    ].join("\n");
+    expect(sources).not.toMatch(/anthropic/i);
+    expect(sources).not.toMatch(/mistral/i);
+    expect(sources).not.toMatch(/callAnthropic|callMistral/);
+    expect(sources).not.toMatch(/generateScrutinPolicyTitle/); // never triggers generation
+  });
+});

--- a/src/services/sync/amendments-an.ts
+++ b/src/services/sync/amendments-an.ts
@@ -14,6 +14,7 @@ import {
   resolveIdenticalGroups,
 } from "./amendments-an/writer";
 import { loadFeedState, saveFeedState } from "./amendments-an/feed-state";
+import { markPolicyTitlesForSubstanceDrift } from "./mark-policy-titles-substance-drift";
 import type {
   NormalizedAmendment,
   SyncAmendmentsANOptions,
@@ -149,6 +150,13 @@ export async function syncAmendmentsAN(
       stats.parentLinksDeferred = p.deferred;
       const g = await resolveIdenticalGroups(all);
       stats.identicalGroupsResolved = g.groups;
+
+      // Consume the substance-drift signal: flag policy titles linked to amendments
+      // whose content/summary really changed. Marks only (STALE / queued); never
+      // generates, approves, publishes, or calls a model.
+      stats.substanceDrift = await markPolicyTitlesForSubstanceDrift(
+        stats.changedSubstanceAmendmentIds
+      );
     }
 
     if (!usingProvidedZip && !opts.dryRun && freshEtag !== undefined) {

--- a/src/services/sync/amendments-an/types.ts
+++ b/src/services/sync/amendments-an/types.ts
@@ -38,7 +38,7 @@ export interface SyncWarning {
  * linked amendment substance changed, flagged for regeneration. No generation here.
  */
 export interface PolicyTitleSubstanceDriftResult {
-  changedSubstanceAmendmentIds: number;
+  changedSubstanceAmendmentCount: number;
   linkedScrutins: number;
   policyTitlesMarkedStale: number; // APPROVED -> STALE
   policyTitlesQueuedOrFlagged: number; // NEEDS_REVIEW / DRAFT -> regenerationStatus "queued"

--- a/src/services/sync/amendments-an/types.ts
+++ b/src/services/sync/amendments-an/types.ts
@@ -33,6 +33,18 @@ export interface SyncWarning {
   externalId?: string;
 }
 
+/**
+ * Outcome of consuming `changedSubstanceAmendmentIds` (PR B): policy titles whose
+ * linked amendment substance changed, flagged for regeneration. No generation here.
+ */
+export interface PolicyTitleSubstanceDriftResult {
+  changedSubstanceAmendmentIds: number;
+  linkedScrutins: number;
+  policyTitlesMarkedStale: number; // APPROVED -> STALE
+  policyTitlesQueuedOrFlagged: number; // NEEDS_REVIEW / DRAFT -> regenerationStatus "queued"
+  policyTitlesIgnored: number; // REJECTED / STALE -> untouched
+}
+
 export interface SyncAmendmentsANStats {
   notModified?: boolean; // true when feed-state returned 304 and the run short-circuited
   downloadedBytes?: number; // bytes written to disk this run (0 when notModified or zipPath used)
@@ -51,6 +63,7 @@ export interface SyncAmendmentsANStats {
   identicalGroupsResolved: number;
   dossiersResolved: number;
   dossiersUnresolved: number;
+  substanceDrift?: PolicyTitleSubstanceDriftResult; // PR B: set on non-dryRun runs
   warnings: SyncWarning[];
   durationMs: number;
 }

--- a/src/services/sync/mark-policy-titles-substance-drift.ts
+++ b/src/services/sync/mark-policy-titles-substance-drift.ts
@@ -1,0 +1,64 @@
+import { db } from "@/lib/db";
+import type { PolicyTitleSubstanceDriftResult } from "./amendments-an/types";
+import { planSubstanceDriftActions } from "./policy-title-substance-drift-plan";
+
+/**
+ * Consume the substance-drift signal produced by the AN sync writer
+ * (`changedSubstanceAmendmentIds`): flag the policy titles linked to those
+ * amendments for regeneration.
+ *
+ * Read-mostly: resolves amendmentId -> ScrutinAmendment -> scrutinId (deduped),
+ * loads the unique policy title per scrutin, and applies STALE / queued markers via
+ * two bulk updateMany calls. It NEVER generates, approves, publishes, or creates a
+ * ScrutinPolicyTitle, and never calls a model. Returns explicit per-bucket stats.
+ *
+ * APPROVED -> STALE; NEEDS_REVIEW / DRAFT -> regenerationStatus "queued" (status
+ * unchanged); REJECTED / STALE -> untouched.
+ */
+export async function markPolicyTitlesForSubstanceDrift(
+  changedSubstanceAmendmentIds: string[]
+): Promise<PolicyTitleSubstanceDriftResult> {
+  const result: PolicyTitleSubstanceDriftResult = {
+    changedSubstanceAmendmentIds: changedSubstanceAmendmentIds.length,
+    linkedScrutins: 0,
+    policyTitlesMarkedStale: 0,
+    policyTitlesQueuedOrFlagged: 0,
+    policyTitlesIgnored: 0,
+  };
+  if (changedSubstanceAmendmentIds.length === 0) return result; // no-op
+
+  // amendmentId -> scrutinId, deduplicated.
+  const links = await db.scrutinAmendment.findMany({
+    where: { amendmentId: { in: changedSubstanceAmendmentIds } },
+    select: { scrutinId: true },
+  });
+  const scrutinIds = [...new Set(links.map((l) => l.scrutinId))];
+  result.linkedScrutins = scrutinIds.length;
+  if (scrutinIds.length === 0) return result; // amendments not linked to any scrutin
+
+  // scrutinId is @unique on ScrutinPolicyTitle, so at most one title per scrutin.
+  const titles = await db.scrutinPolicyTitle.findMany({
+    where: { scrutinId: { in: scrutinIds } },
+    select: { id: true, status: true, regenerationStatus: true },
+  });
+
+  const plan = planSubstanceDriftActions(titles);
+
+  if (plan.toStale.length > 0) {
+    await db.scrutinPolicyTitle.updateMany({
+      where: { id: { in: plan.toStale } },
+      data: { status: "STALE" },
+    });
+  }
+  if (plan.toQueue.length > 0) {
+    await db.scrutinPolicyTitle.updateMany({
+      where: { id: { in: plan.toQueue } },
+      data: { regenerationStatus: "queued" },
+    });
+  }
+
+  result.policyTitlesMarkedStale = plan.markedStale;
+  result.policyTitlesQueuedOrFlagged = plan.queuedOrFlagged;
+  result.policyTitlesIgnored = plan.ignored;
+  return result;
+}

--- a/src/services/sync/mark-policy-titles-substance-drift.ts
+++ b/src/services/sync/mark-policy-titles-substance-drift.ts
@@ -19,7 +19,7 @@ export async function markPolicyTitlesForSubstanceDrift(
   changedSubstanceAmendmentIds: string[]
 ): Promise<PolicyTitleSubstanceDriftResult> {
   const result: PolicyTitleSubstanceDriftResult = {
-    changedSubstanceAmendmentIds: changedSubstanceAmendmentIds.length,
+    changedSubstanceAmendmentCount: changedSubstanceAmendmentIds.length,
     linkedScrutins: 0,
     policyTitlesMarkedStale: 0,
     policyTitlesQueuedOrFlagged: 0,

--- a/src/services/sync/policy-title-substance-drift-plan.ts
+++ b/src/services/sync/policy-title-substance-drift-plan.ts
@@ -1,0 +1,77 @@
+import type { PolicyTitleStatus } from "@/generated/prisma";
+
+/**
+ * What to do with a single policy title whose linked amendment substance changed.
+ * Kept db-free so the decision logic is unit-testable without a live database.
+ */
+export type DriftAction = "stale" | "queue" | "ignore";
+
+/** The minimal title shape the planner reasons about. */
+export interface DriftTitleRow {
+  id: string;
+  status: PolicyTitleStatus;
+  regenerationStatus: string;
+}
+
+export interface DriftPlan {
+  /** Title ids to move APPROVED -> STALE. */
+  toStale: string[];
+  /** Title ids to flag regenerationStatus -> "queued" (already-queued rows excluded). */
+  toQueue: string[];
+  markedStale: number;
+  queuedOrFlagged: number;
+  ignored: number;
+}
+
+/**
+ * Pure decision for one policy title whose linked amendment substance changed:
+ *  - APPROVED              -> stale  (evidence no longer guaranteed in sync with the
+ *                                     official text; also drops it from public, since
+ *                                     only APPROVED is public)
+ *  - NEEDS_REVIEW / DRAFT  -> queue  (flag for regeneration, status unchanged: this
+ *                                     code never auto-publishes or auto-approves)
+ *  - REJECTED              -> ignore (never auto-reactivated)
+ *  - STALE                 -> ignore (already stale)
+ */
+export function classifyTitleForDrift(status: PolicyTitleStatus): DriftAction {
+  switch (status) {
+    case "APPROVED":
+      return "stale";
+    case "NEEDS_REVIEW":
+    case "DRAFT":
+      return "queue";
+    case "REJECTED":
+    case "STALE":
+      return "ignore";
+    default:
+      return "ignore";
+  }
+}
+
+/**
+ * Pure planner: from the loaded title rows decide which ids become STALE, which get
+ * flagged queued (rows already queued are excluded from the write but still counted
+ * as flagged), and the per-bucket counts. No DB access, no model call.
+ */
+export function planSubstanceDriftActions(titles: DriftTitleRow[]): DriftPlan {
+  const plan: DriftPlan = {
+    toStale: [],
+    toQueue: [],
+    markedStale: 0,
+    queuedOrFlagged: 0,
+    ignored: 0,
+  };
+  for (const t of titles) {
+    const action = classifyTitleForDrift(t.status);
+    if (action === "stale") {
+      plan.toStale.push(t.id);
+      plan.markedStale++;
+    } else if (action === "queue") {
+      plan.queuedOrFlagged++;
+      if (t.regenerationStatus !== "queued") plan.toQueue.push(t.id);
+    } else {
+      plan.ignored++;
+    }
+  }
+  return plan;
+}


### PR DESCRIPTION
## Contexte

PR #436 (mergée) a ajouté la détection de dérive de substance dans le sync AN et produit le signal `changedSubstanceAmendmentIds` (les amendements existants dont le `content` ou le `summary` a réellement changé), sans le consommer.

Cette PR (PR B) **consomme** ce signal : à la fin du sync amendements, les titres de vote (`ScrutinPolicyTitle`) liés aux amendements dont la substance a bougé sont marqués comme à régénérer. **Aucune génération, aucune approbation, aucun appel modèle.**

## Comportement

À la fin de `syncAmendmentsAN` (uniquement hors `dryRun`), `markPolicyTitlesForSubstanceDrift(changedSubstanceAmendmentIds)` :

1. signal vide → no-op ;
2. sinon résout `Amendment.id → ScrutinAmendment → scrutinId` (dédupliqué) ;
3. charge le titre unique par scrutin (`scrutinId @unique`) et applique, par statut :
   - **APPROVED → STALE** : les preuves ne sont plus garanties synchrones avec le texte officiel ; le titre sort aussi du public (seul `APPROVED` est public) ;
   - **NEEDS_REVIEW / DRAFT → `regenerationStatus = "queued"`** : marqué à régénérer, **statut inchangé** (jamais publié ni approuvé automatiquement). Les lignes déjà `queued` ne sont pas réécrites ;
   - **REJECTED → no-op** : jamais réactivé automatiquement ;
   - **STALE → no-op** : déjà stale.

Plusieurs amendements d'un même scrutin → un seul `scrutinId` après dédup → une seule mise à jour du titre.

## Pourquoi c'est sûr (pas de régénération automatique)

- `regenerationStatus = "queued"` est un **flag passif** : seul le flux admin / le script offline le consomme. Aucun cron ni Inngest ne le traite (vérifié).
- Le générateur (`generateScrutinPolicyTitles`, cron en `force=false`) ne sélectionne que les scrutins **sans** titre (`policyTitle: { is: null }`). Il ne re-génère jamais une ligne `STALE`/`DRAFT`/`NEEDS_REVIEW` existante. Donc `APPROVED → STALE` ne déclenche aucune régénération par effet de bord.
- Le garde-fou d'approbation traite déjà `EVIDENCE_DRIFT` et `STALE` comme bloquants durs : même si une régénération avait lieu plus tard, un titre dérivé ne serait pas auto-approuvé.

## Stats explicites

`SyncAmendmentsANStats.substanceDrift` (posé sur les runs non-dryRun) :

- `changedSubstanceAmendmentCount` (le compteur ; à ne pas confondre avec la liste d'IDs `changedSubstanceAmendmentIds` de PR A)
- `linkedScrutins`
- `policyTitlesMarkedStale`
- `policyTitlesQueuedOrFlagged`
- `policyTitlesIgnored`

## Découpage

- `policy-title-substance-drift-plan.ts` _(nouveau, db-free)_ : `classifyTitleForDrift`, `planSubstanceDriftActions` — la logique de décision pure, unit-testable sans base.
- `mark-policy-titles-substance-drift.ts` _(nouveau, db)_ : résolution + deux `updateMany` (STALE / queued) + stats.
- `amendments-an/types.ts` : `PolicyTitleSubstanceDriftResult` + champ optionnel `substanceDrift`.
- `amendments-an.ts` : branchement dans le flux du sync (bloc `!dryRun`). Le cron `sync-daily.ts` n'est pas modifié.

## Hors périmètre (explicite)

- pas de migration ; pas de `db push` ;
- pas de régénération (aucun appel au générateur ni à un modèle) ;
- pas de reprise du backlog ; pas de modification du juge ;
- pas de modification du cron au-delà du branchement strictement nécessaire dans le flux du sync amendements ;
- pas de script prod ni de backfill ;
- **jamais** de création de `ScrutinPolicyTitle` ;
- aucune réactivation automatique d'un `REJECTED`.

## Tests

- **`policy-title-substance-drift-plan.test.ts`** (14, db-free) : `classifyTitleForDrift` pour les 5 statuts ; `planSubstanceDriftActions` (vide, APPROVED→stale, NEEDS_REVIEW/DRAFT→queue, déjà-queued sans réécriture, REJECTED/STALE→ignore, batch mixte) ; **garde-fou structurel** : les deux modules n'importent aucun client IA (`anthropic`/`mistral`/`callAnthropic`/`callMistral`) ni `generateScrutinPolicyTitle`.
- **`mark-policy-titles-substance-drift.test.ts`** (7, DB-gated) : signal vide → no-op ; amendement sans `ScrutinAmendment` → no-op ; APPROVED → STALE ; plusieurs amendements même scrutin → un seul update ; NEEDS_REVIEW reste NEEDS_REVIEW + `queued` (ni approuvé ni publié) ; STALE → no-op ; REJECTED → no-op.

Commandes : `tsc --noEmit --incremental false` clean, `eslint` clean, `vitest` 63/63 sur l'ensemble concerné (plan + mark + dossier amendments-an).

## Risque connu : tests DB-gated contre `.env` prod

`.env` pointe la prod, donc le test d'intégration écrit réellement en base. Mitigations en place :

- toutes les entités seedées sont préfixées `TEST_PTD_*` (jamais en collision avec des données réelles) ;
- `afterAll` de cleanup (scrutinAmendment, scrutinPolicyTitle, amendment, scrutin) ;
- vérification post-run : **0** ligne `TEST_PTD_*` restante sur les 4 tables ;
- aucun test destructif ; tests `describeIfDb` (skippés sans `DATABASE_URL`).

**Follow-up proposé** (déjà ouvert en PR A) : isoler une base test/staging dédiée pour ces tests DB-gated.

## Confirmation

Aucune génération IA lancée. Aucune écriture prod manuelle (seuls les tests DB-gated ont seedé puis nettoyé des lignes `TEST_PTD_*`, vérifiées à 0).
