### PR TITLE
feat(themes): Mistral fallback for theme classification when Anthropic is down

### DIFF
--- a/src/services/classify-theme.test.ts
+++ b/src/services/classify-theme.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AnthropicResponse } from "@/lib/api/anthropic";
+import type { MistralResponse } from "@/lib/api/mistral";
+
+// Mock only the network calls; keep the real extract/parse helpers.
+vi.mock("@/lib/api/anthropic", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/api/anthropic")>();
+  return { ...actual, callAnthropic: vi.fn() };
+});
+vi.mock("@/lib/api/mistral", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/api/mistral")>();
+  return { ...actual, callMistral: vi.fn() };
+});
+
+import { callAnthropic } from "@/lib/api/anthropic";
+import { callMistral } from "@/lib/api/mistral";
+import { classifyTheme } from "@/services/classify-theme";
+
+const anthropicTool = (theme: string): AnthropicResponse => ({
+  content: [{ type: "tool_use", name: "classify_theme", input: { theme } }],
+});
+
+const mistralJson = (obj: unknown): MistralResponse => ({
+  choices: [
+    { message: { role: "assistant", content: JSON.stringify(obj) }, finish_reason: "stop" },
+  ],
+});
+
+describe("classifyTheme — Mistral fallback", () => {
+  beforeEach(() => {
+    vi.mocked(callAnthropic).mockReset();
+    vi.mocked(callMistral).mockReset();
+  });
+
+  it("Anthropic OK -> returns theme, Mistral NOT called", async () => {
+    vi.mocked(callAnthropic).mockResolvedValue(anthropicTool("SANTE"));
+    const res = await classifyTheme("Loi hôpital", "réforme des urgences");
+    expect(res).toBe("SANTE");
+    expect(callMistral).not.toHaveBeenCalled();
+  });
+
+  it("Anthropic throws (quota / rate-limit) -> Mistral called", async () => {
+    vi.mocked(callAnthropic).mockRejectedValue(
+      new Error("Anthropic API error 429: rate_limit_error")
+    );
+    vi.mocked(callMistral).mockResolvedValue(mistralJson({ theme: "TRANSPORTS" }));
+    const res = await classifyTheme("Loi mobilités");
+    expect(res).toBe("TRANSPORTS");
+    expect(callMistral).toHaveBeenCalledTimes(1);
+  });
+
+  it("Mistral fallback returns an alias -> normalized", async () => {
+    vi.mocked(callAnthropic).mockRejectedValue(
+      new Error("Anthropic API error 400: credit balance too low")
+    );
+    vi.mocked(callMistral).mockResolvedValue(mistralJson({ theme: "CULTURE_EDUCATION" }));
+    const res = await classifyTheme("Loi école");
+    expect(res).toBe("EDUCATION_CULTURE");
+  });
+
+  it("Mistral fallback returns an invalid theme -> null (not thrown)", async () => {
+    vi.mocked(callAnthropic).mockRejectedValue(new Error("Anthropic API error 500"));
+    vi.mocked(callMistral).mockResolvedValue(mistralJson({ theme: "PAS_UN_THEME" }));
+    const res = await classifyTheme("Texte ambigu");
+    expect(res).toBeNull();
+  });
+
+  it("both providers throw -> error propagated (not swallowed)", async () => {
+    vi.mocked(callAnthropic).mockRejectedValue(new Error("Anthropic API error 429"));
+    vi.mocked(callMistral).mockRejectedValue(
+      new Error("Mistral API error 503: service unavailable")
+    );
+    await expect(classifyTheme("X")).rejects.toThrow(/Theme classification failed/);
+  });
+
+  it("MISTRAL_API_KEY missing + Anthropic throws -> explicit error, not silent null", async () => {
+    vi.mocked(callAnthropic).mockRejectedValue(new Error("Anthropic API error 429"));
+    vi.mocked(callMistral).mockRejectedValue(
+      new Error("MISTRAL_API_KEY environment variable is not set")
+    );
+    await expect(classifyTheme("X")).rejects.toThrow(
+      /MISTRAL_API_KEY environment variable is not set/
+    );
+  });
+});

--- a/src/services/classify-theme.ts
+++ b/src/services/classify-theme.ts
@@ -1,14 +1,22 @@
 /**
  * Theme classification for legislative dossiers and scrutins.
  *
- * Uses Claude Haiku to categorize legislative texts into one of 13
- * controlled theme values. This is taxonomic classification over
- * existing text, not content generation.
+ * Taxonomic classification over existing text (not content generation) into one
+ * of 13 controlled theme values. Anthropic (Claude Haiku, tool-use) is the
+ * primary provider; when it fails (quota/rate-limit/server/network), the call
+ * falls back to Mistral so a single-provider outage doesn't break the daily sync.
+ * The returned theme is always validated against THEME_VALUES, so a bad answer
+ * from either provider degrades to null rather than corrupting data.
+ *
+ * NOTE: this is the only call site using a Mistral fallback for now. A shadow
+ * eval on a sample is planned before deciding whether Mistral becomes primary.
  */
 
 import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
+import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
 
-const MODEL = "claude-haiku-4-5-20251001";
+const ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
+const MISTRAL_MODEL = "mistral-small-latest";
 
 const THEME_VALUES = [
   "ECONOMIE_BUDGET",
@@ -28,23 +36,21 @@ const THEME_VALUES = [
 
 export type ThemeCategoryValue = (typeof THEME_VALUES)[number];
 
-/**
- * Classify a legislative text or scrutin into a theme category using AI
- */
-export async function classifyTheme(
-  title: string,
-  summary?: string | null,
-  context?: string | null
-): Promise<ThemeCategoryValue | null> {
-  let input = `Titre : ${title}`;
-  if (summary) input += `\nRésumé : ${summary}`;
-  if (context) input += `\nContexte : ${context}`;
+// AI may still rarely return inverted names despite the enum constraint.
+const THEME_ALIASES: Record<string, ThemeCategoryValue> = {
+  CULTURE_EDUCATION: "EDUCATION_CULTURE",
+  JUSTICE_SECURITE: "SECURITE_JUSTICE",
+  CULTURE_PATRIMOINE: "EDUCATION_CULTURE",
+  BUDGET_ECONOMIE: "ECONOMIE_BUDGET",
+  TRAVAIL_SOCIAL: "SOCIAL_TRAVAIL",
+  ENERGIE_ENVIRONNEMENT: "ENVIRONNEMENT_ENERGIE",
+  DEFENSE_AFFAIRES_ETRANGERES: "AFFAIRES_ETRANGERES_DEFENSE",
+  TECH_NUMERIQUE: "NUMERIQUE_TECH",
+  ALIMENTATION_AGRICULTURE: "AGRICULTURE_ALIMENTATION",
+  URBANISME_LOGEMENT: "LOGEMENT_URBANISME",
+};
 
-  const prompt = `Tu es un classificateur thématique pour des textes législatifs français. Classe le texte suivant dans une catégorie en utilisant l'outil classify_theme.
-
-${input}
-
-Guide des catégories :
+const CATEGORY_GUIDE = `Guide des catégories :
 - ECONOMIE_BUDGET : fiscalité, budget de l'État, finances publiques, commerce, entreprises
 - SOCIAL_TRAVAIL : emploi, droit du travail, retraites, protection sociale, handicap
 - SECURITE_JUSTICE : police, justice, pénal, prisons, terrorisme, ordre public
@@ -58,6 +64,43 @@ Guide des catégories :
 - AGRICULTURE_ALIMENTATION : agriculture, pêche, alimentation, ruralité
 - LOGEMENT_URBANISME : logement, urbanisme, construction, copropriété
 - TRANSPORTS : transports, mobilité, routes, ferroviaire, aérien, maritime`;
+
+function buildInput(title: string, summary?: string | null, context?: string | null): string {
+  let input = `Titre : ${title}`;
+  if (summary) input += `\nRésumé : ${summary}`;
+  if (context) input += `\nContexte : ${context}`;
+  return input;
+}
+
+/**
+ * Normalize a raw theme string (from either provider) into a controlled value:
+ * apply known aliases, then validate against THEME_VALUES. Returns null (never
+ * throws) for an unknown value, logging the raw answer and its source.
+ */
+function normalizeTheme(
+  raw: string | undefined,
+  source: "anthropic" | "mistral"
+): ThemeCategoryValue | null {
+  if (!raw) {
+    console.warn(`[classify-theme] no theme returned from ${source}`);
+    return null;
+  }
+  const theme = THEME_ALIASES[raw] ?? raw;
+  if (THEME_VALUES.includes(theme as ThemeCategoryValue)) {
+    return theme as ThemeCategoryValue;
+  }
+  console.warn(`[classify-theme] invalid theme from ${source} (raw="${raw}")`);
+  return null;
+}
+
+/** Primary path: Claude Haiku with a forced tool call. Throws on API failure or
+ *  an empty (no tool_use) response, so the caller can fall back. */
+async function classifyViaAnthropic(input: string): Promise<string> {
+  const prompt = `Tu es un classificateur thématique pour des textes législatifs français. Classe le texte suivant dans une catégorie en utilisant l'outil classify_theme.
+
+${input}
+
+${CATEGORY_GUIDE}`;
 
   const tools = [
     {
@@ -78,7 +121,7 @@ Guide des catégories :
   ];
 
   const data = await callAnthropic([{ role: "user", content: prompt }], {
-    model: MODEL,
+    model: ANTHROPIC_MODEL,
     maxTokens: 100,
     tools,
     toolChoice: { type: "tool", name: "classify_theme" },
@@ -86,33 +129,71 @@ Guide des catégories :
 
   const toolInput = extractToolUse(data) as { theme?: string } | null;
   if (!toolInput?.theme) {
-    throw new Error("No tool_use content in API response");
+    throw new Error("No tool_use content in Anthropic response");
+  }
+  return toolInput.theme;
+}
+
+/** Fallback path: Mistral JSON mode. Returns the raw theme string (validated by
+ *  the caller). Throws on API/parse failure.
+ *  TODO: upgrade to response_format json_schema with a strict enum on
+ *  THEME_VALUES once verified against mistral-small-latest. json_object is used
+ *  here because it's robust and the output is validated downstream (null-safe). */
+async function classifyViaMistral(input: string): Promise<string | undefined> {
+  const prompt = `Tu es un classificateur thématique pour des textes législatifs français. Classe le texte suivant dans une seule catégorie.
+
+${input}
+
+${CATEGORY_GUIDE}
+
+Réponds UNIQUEMENT avec un objet JSON de la forme {"theme": "<CATEGORIE>"} où <CATEGORIE> est exactement l'une de ces valeurs : ${THEME_VALUES.join(", ")}.`;
+
+  const res = await callMistral([{ role: "user", content: prompt }], {
+    model: MISTRAL_MODEL,
+    maxTokens: 100,
+    responseFormat: { type: "json_object" },
+  });
+
+  const parsed = parseMistralJSON<{ theme?: string }>(extractMistralText(res));
+  return parsed?.theme;
+}
+
+/**
+ * Classify a legislative text or scrutin into a theme category.
+ * Anthropic primary, Mistral fallback. Returns null when neither produces a
+ * valid theme value; throws only when BOTH providers fail outright.
+ */
+export async function classifyTheme(
+  title: string,
+  summary?: string | null,
+  context?: string | null
+): Promise<ThemeCategoryValue | null> {
+  const input = buildInput(title, summary, context);
+
+  let anthropicError: string;
+  try {
+    const raw = await classifyViaAnthropic(input);
+    return normalizeTheme(raw, "anthropic");
+  } catch (err) {
+    anthropicError = err instanceof Error ? err.message : String(err);
+    // Fall back on ANY Anthropic error. Detecting provider/quota/rate-limit vs.
+    // a genuine bad request precisely is brittle and the output is validated
+    // (degrades to null), so for this single, low-stakes classifier we accept a
+    // broad fallback rather than masking an outage. The error is logged loudly.
+    console.warn(
+      `[classify-theme] primary=anthropic failed (${anthropicError}); falling back to provider=mistral`
+    );
   }
 
-  let theme = toolInput.theme;
-
-  // Fallback: AI may still rarely return inverted names despite enum constraint
-  const THEME_ALIASES: Record<string, ThemeCategoryValue> = {
-    CULTURE_EDUCATION: "EDUCATION_CULTURE",
-    JUSTICE_SECURITE: "SECURITE_JUSTICE",
-    CULTURE_PATRIMOINE: "EDUCATION_CULTURE",
-    BUDGET_ECONOMIE: "ECONOMIE_BUDGET",
-    TRAVAIL_SOCIAL: "SOCIAL_TRAVAIL",
-    ENERGIE_ENVIRONNEMENT: "ENVIRONNEMENT_ENERGIE",
-    DEFENSE_AFFAIRES_ETRANGERES: "AFFAIRES_ETRANGERES_DEFENSE",
-    TECH_NUMERIQUE: "NUMERIQUE_TECH",
-    ALIMENTATION_AGRICULTURE: "AGRICULTURE_ALIMENTATION",
-    URBANISME_LOGEMENT: "LOGEMENT_URBANISME",
-  };
-
-  if (theme && THEME_ALIASES[theme]) {
-    theme = THEME_ALIASES[theme]!;
+  try {
+    const raw = await classifyViaMistral(input);
+    return normalizeTheme(raw, "mistral");
+  } catch (err) {
+    const mistralError = err instanceof Error ? err.message : String(err);
+    // Both providers failed: surface an explicit error (never swallow silently),
+    // including the missing-MISTRAL_API_KEY case which throws here.
+    throw new Error(
+      `Theme classification failed — anthropic: ${anthropicError}; mistral fallback: ${mistralError}`
+    );
   }
-
-  if (THEME_VALUES.includes(theme as ThemeCategoryValue)) {
-    return theme as ThemeCategoryValue;
-  }
-
-  console.warn(`Invalid theme value: ${theme}`);
-  return null;
 }


### PR DESCRIPTION
## Problème

Le Daily Sync passe au rouge dès que l'API Anthropic est indisponible (crédit épuisé, quota, panne). L'étape `Classification thématique` (`classify-themes.ts` → `classifyTheme`) appelle Anthropic ; quand chaque appel échoue, tous les items sont en erreur et le script sort en exit 1. C'est le cas **depuis le 25/06** (vérifié : HTTP 400 « Your credit balance is too low »), indépendamment des merges récents.

## Correction

`classifyTheme` garde **Anthropic en primaire** (tool-use, `claude-haiku-4-5-20251001`, inchangé fonctionnellement) et bascule sur **Mistral** (`mistral-small-latest`, `response_format: json_object`) en repli quand Anthropic échoue.

- La sortie est **toujours validée** contre `THEME_VALUES` (alias connus normalisés, sinon `null`) : une mauvaise réponse de l'un ou l'autre provider dégrade en `null`, elle ne corrompt jamais la donnée.
- Si **les deux** providers échouent → **erreur explicite** (jamais silencieuse), incluant le cas `MISTRAL_API_KEY` absente.
- **Logs** : provider primaire/fallback, message d'erreur Anthropic à la bascule, et thème brut + source quand la normalisation échoue.

**Détection** : repli sur **toute** erreur Anthropic. Distinguer précisément provider-down / quota / rate-limit / network d'un vrai bad-request est fragile ; comme la sortie est validée (dégrade en `null`) et que c'est un classifieur unique à faible enjeu, on accepte un repli large plutôt que de masquer une panne. L'erreur est loguée fortement. **TODO** dans le code : passer à `response_format: json_schema` (enum stricte sur `THEME_VALUES`) une fois vérifié contre `mistral-small-latest`.

## Périmètre (volontairement étroit)

- **Seul** `classifyTheme` est touché. Aucun helper LLM générique, aucun autre site d'appel Anthropic migré.
- Pas de cron, pas de migration, pas de db push.
- Anthropic n'est **pas** remplacé ailleurs. Un **shadow eval** sur un échantillon d'articles/dossiers est prévu avant de décider si Mistral devient primaire pour les classifications.

## Refactor (même fichier)

`CATEGORY_GUIDE`, `THEME_ALIASES`, `THEME_VALUES` au scope module ; `buildInput()` partagé ; `normalizeTheme(raw, source)` = validation finale partagée (null-safe, loggue les valeurs invalides).

## Tests (db-free, mock des deux wrappers)

6/6 :

- Anthropic OK → Mistral **non appelé** ;
- Anthropic throw (429) → Mistral appelé ;
- alias Mistral (ex. `CULTURE_EDUCATION`) → normalisé ;
- thème Mistral invalide → `null` ;
- les deux providers throw → erreur propagée ;
- `MISTRAL_API_KEY` absente + Anthropic throw → erreur explicite (pas de `null` silencieux).

Commandes : `tsc --noEmit --incremental false` clean ; `eslint` clean ; `vitest` **6/6**.
