### PR TITLE
fix(seo): sitemap filtré et noindex des surfaces fines (index bloat)

### DIFF
--- a/scripts/sync-daily.ts
+++ b/scripts/sync-daily.ts
@@ -33,6 +33,12 @@ interface SyncStep {
    * otherwise page every cron.
    */
   allowFailure?: boolean;
+  /**
+   * Extra attempts after a failure (default 0). For blocking steps that hit
+   * transient infra errors (Supabase dropping a connection mid-query, issue
+   * #442) where a plain re-run succeeds.
+   */
+  retries?: number;
 }
 
 const steps: SyncStep[] = [
@@ -110,6 +116,9 @@ const steps: SyncStep[] = [
   {
     name: "Compute participation stats",
     command: `npx tsx scripts/compute-stats.ts${dryRunFlag}`,
+    // Blocking step killed once by a transient Supabase connection drop (#442);
+    // the very next run succeeded without any change. One retry absorbs the blip.
+    retries: 1,
   },
   {
     name: "IndexNow",
@@ -155,14 +164,42 @@ async function main() {
     console.log(`  ${step.command}`);
     console.log("─".repeat(50));
 
-    try {
-      execSync(step.command, {
-        stdio: "inherit",
-        env: { ...process.env },
-        timeout: 10 * 60 * 1000, // 10 minutes max per step
-      });
+    const maxAttempts = 1 + (step.retries ?? 0);
+    // Only retry fast failures (transient blips like a dropped DB connection).
+    // A slow failure (hang killed by the 10 min timeout) would just burn
+    // another 10 min of the 30 min job budget on the same non-transient cause.
+    const retryIfFailedUnderMs = 5 * 60 * 1000;
+    let lastError: string | undefined;
+    let success = false;
 
-      const duration = (Date.now() - stepStart) / 1000;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (attempt > 1) {
+        console.log(`\n↻ ${step.name}: retry ${attempt - 1}/${maxAttempts - 1}`);
+      }
+      const attemptStart = Date.now();
+      try {
+        execSync(step.command, {
+          stdio: "inherit",
+          env: { ...process.env },
+          timeout: 10 * 60 * 1000, // 10 minutes max per step
+        });
+        success = true;
+        break;
+      } catch (err) {
+        const attemptDuration = Date.now() - attemptStart;
+        lastError = err instanceof Error ? err.message : String(err);
+        console.error(`\n✗ ${step.name} attempt ${attempt}/${maxAttempts} failed: ${lastError}`);
+        if (attempt < maxAttempts && attemptDuration >= retryIfFailedUnderMs) {
+          console.error(
+            `  skipping retry: attempt ran ${(attemptDuration / 1000).toFixed(0)}s (not a transient blip)`
+          );
+          break;
+        }
+      }
+    }
+
+    const duration = (Date.now() - stepStart) / 1000;
+    if (success) {
       results.push({
         name: step.name,
         success: true,
@@ -170,20 +207,18 @@ async function main() {
         allowFailure: step.allowFailure === true,
       });
       console.log(`\n✓ ${step.name} completed in ${duration.toFixed(1)}s`);
-    } catch (err) {
-      const duration = (Date.now() - stepStart) / 1000;
-      const errorMsg = err instanceof Error ? err.message : String(err);
+    } else {
       results.push({
         name: step.name,
         success: false,
         duration,
-        error: errorMsg,
+        error: lastError,
         allowFailure: step.allowFailure === true,
       });
       const icon = step.allowFailure ? "⚠" : "✗";
       const suffix = step.allowFailure ? " (non-blocking)" : "";
       console.error(
-        `\n${icon} ${step.name} failed after ${duration.toFixed(1)}s${suffix}: ${errorMsg}`
+        `\n${icon} ${step.name} failed after ${duration.toFixed(1)}s${suffix}: ${lastError}`
       );
       // Continue to next step even on failure
     }

--- a/src/app/declarations-et-patrimoine/page.tsx
+++ b/src/app/declarations-et-patrimoine/page.tsx
@@ -23,20 +23,9 @@ import {
 } from "@/lib/data/declarations";
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 
 export const revalidate = 300;
-
-export const metadata: Metadata = {
-  title: "Patrimoine et déclarations d'intérêts des élus — HATVP",
-  description:
-    "Explorez le patrimoine et les déclarations d'intérêts des députés, sénateurs et ministres français. Portefeuilles financiers, participations, revenus et activités — données officielles HATVP.",
-  openGraph: {
-    title: "Patrimoine et déclarations d'intérêts des élus — Poligraph",
-    description:
-      "Classement des élus par patrimoine déclaré, entreprises détenues et revenus. Source officielle : HATVP.",
-  },
-  alternates: { canonical: "/declarations-et-patrimoine" },
-};
 
 interface PageProps {
   searchParams: Promise<{
@@ -45,6 +34,23 @@ interface PageProps {
     sort?: string;
     page?: string;
   }>;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const params = await searchParams;
+  return {
+    title: "Patrimoine et déclarations d'intérêts des élus — HATVP",
+    description:
+      "Explorez le patrimoine et les déclarations d'intérêts des députés, sénateurs et ministres français. Portefeuilles financiers, participations, revenus et activités — données officielles HATVP.",
+    // Filtered/paginated variants: noindex,follow, canonical consolidates on the bare listing.
+    ...listingRobotsMetadata(hasActiveListingFilter(params, ["search", "party", "sort"])),
+    openGraph: {
+      title: "Patrimoine et déclarations d'intérêts des élus — Poligraph",
+      description:
+        "Classement des élus par patrimoine déclaré, entreprises détenues et revenus. Source officielle : HATVP.",
+    },
+    alternates: { canonical: "/declarations-et-patrimoine" },
+  };
 }
 
 // ─── Page component ───────────────────────────────────────────

--- a/src/app/elections/municipales-2026/communes/[inseeCode]/page.tsx
+++ b/src/app/elections/municipales-2026/communes/[inseeCode]/page.tsx
@@ -18,6 +18,7 @@ import { EventJsonLd } from "@/components/seo/JsonLd";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { SITE_URL } from "@/config/site";
 import { db } from "@/lib/db";
+import { communeRobotsMetadata } from "@/lib/seo/commune-robots";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
@@ -49,6 +50,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description,
+    // Panachage communes (<1000 hab) are thin candidate rosters: noindex,follow (issue #385).
+    ...communeRobotsMetadata(commune.population),
     openGraph: {
       title,
       description,

--- a/src/app/elections/municipales-2026/maires/page.tsx
+++ b/src/app/elections/municipales-2026/maires/page.tsx
@@ -8,20 +8,9 @@ import { MaireCard } from "@/components/elections/municipales/MaireCard";
 import { MairesFilterBar } from "@/components/elections/municipales/MairesFilterBar";
 import { getMaireStats, getMaires, getMaireParties } from "@/lib/data/municipales";
 import { DEPARTMENTS } from "@/config/departments";
+import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 
 export const revalidate = 300; // ISR: 5 minutes
-
-export const metadata: Metadata = {
-  title: "Maires de France — Annuaire des 35 000 maires | Poligraph",
-  description:
-    "Explorez l'annuaire des maires de France : parité, couleur politique, ancienneté. Données issues du Répertoire National des Élus.",
-  openGraph: {
-    title: "Les maires de France en un coup d'œil",
-    description:
-      "35 000 maires passés au crible : parité, étiquette politique, ancienneté dans le poste.",
-  },
-  alternates: { canonical: "/elections/municipales-2026/maires" },
-};
 
 interface PageProps {
   searchParams: Promise<{
@@ -31,6 +20,23 @@ interface PageProps {
     gender?: string;
     page?: string;
   }>;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const params = await searchParams;
+  return {
+    title: "Maires de France — Annuaire des 35 000 maires | Poligraph",
+    description:
+      "Explorez l'annuaire des maires de France : parité, couleur politique, ancienneté. Données issues du Répertoire National des Élus.",
+    // Filtered/paginated variants: noindex,follow, canonical consolidates on the bare listing.
+    ...listingRobotsMetadata(hasActiveListingFilter(params, ["search", "dept", "party", "gender"])),
+    openGraph: {
+      title: "Les maires de France en un coup d'œil",
+      description:
+        "35 000 maires passés au crible : parité, étiquette politique, ancienneté dans le poste.",
+    },
+    alternates: { canonical: "/elections/municipales-2026/maires" },
+  };
 }
 
 export default async function MairesPage({ searchParams }: PageProps) {

--- a/src/app/factchecks/page.tsx
+++ b/src/app/factchecks/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/data/factchecks";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
+import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 import type { FactCheckRating } from "@/types";
 
 export const revalidate = 300; // 5 minutes — CDN edge cache with ISR
@@ -35,13 +36,10 @@ interface PageProps {
   }>;
 }
 
+const FACTCHECK_FILTER_KEYS = ["source", "verdict", "search", "directOnly"] as const;
+
 export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
   const params = await searchParams;
-  const cp = new URLSearchParams();
-  if (params.source) cp.set("source", params.source);
-  if (params.verdict) cp.set("verdict", params.verdict);
-  if (params.politician) cp.set("politician", params.politician);
-  const qs = cp.toString();
 
   if (params.politician) {
     const name = await getPoliticianNameBySlug(params.politician);
@@ -49,6 +47,9 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
       return {
         title: `Fact-checks de ${name}`,
         description: `Vérifications des déclarations de ${name}. Fact-checks issus de sources reconnues : AFP Factuel, Les Décodeurs et autres.`,
+        // The bare ?politician= view stays indexable (nominative intent);
+        // extra facets/pagination on top of it are noindex,follow.
+        ...listingRobotsMetadata(hasActiveListingFilter(params, FACTCHECK_FILTER_KEYS)),
         alternates: { canonical: `/factchecks?politician=${params.politician}` },
       };
     }
@@ -58,7 +59,12 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
     title: "Fact-checks",
     description:
       "Vérification des déclarations des responsables politiques français. Fact-checks d'AFP Factuel, Les Décodeurs et autres sources reconnues.",
-    alternates: { canonical: `/factchecks${qs ? `?${qs}` : ""}` },
+    // Weak facets and unresolved ?politician= slugs: noindex,follow,
+    // canonical consolidates on the bare listing.
+    ...listingRobotsMetadata(
+      hasActiveListingFilter(params, [...FACTCHECK_FILTER_KEYS, "politician"])
+    ),
+    alternates: { canonical: "/factchecks" },
   };
 }
 

--- a/src/app/parlement/dossiers/page.tsx
+++ b/src/app/parlement/dossiers/page.tsx
@@ -20,15 +20,9 @@ import type { DossierStatus, ThemeCategory } from "@/generated/prisma";
 import { ExternalLink, Info } from "lucide-react";
 import { SeoIntro } from "@/components/seo/SeoIntro";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 
 export const revalidate = 300; // ISR: re-check feature flag every 5 minutes
-
-export const metadata: Metadata = {
-  title: "Dossiers législatifs suivis",
-  description:
-    "Suivez les dossiers législatifs à l'Assemblée nationale : textes déposés, en commission, en séance ou adoptés. Résumés simplifiés à partir des données publiques.",
-  alternates: { canonical: "/parlement/dossiers" },
-};
 
 interface PageProps {
   searchParams: Promise<{
@@ -37,6 +31,18 @@ interface PageProps {
     sort?: string;
     page?: string;
   }>;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const params = await searchParams;
+  return {
+    title: "Dossiers législatifs suivis",
+    description:
+      "Suivez les dossiers législatifs à l'Assemblée nationale : textes déposés, en commission, en séance ou adoptés. Résumés simplifiés à partir des données publiques.",
+    // Filtered/paginated variants: noindex,follow, canonical consolidates on the hub.
+    ...listingRobotsMetadata(hasActiveListingFilter(params, ["status", "theme", "sort"])),
+    alternates: { canonical: "/parlement/dossiers" },
+  };
 }
 
 const ITEMS_PER_PAGE = 15;

--- a/src/app/parlement/votes/themes/[theme]/page.tsx
+++ b/src/app/parlement/votes/themes/[theme]/page.tsx
@@ -11,6 +11,7 @@ import { THEME_CATEGORY_LABELS, THEME_CATEGORY_ICONS } from "@/config/labels";
 import { formatDate } from "@/lib/utils";
 import type { ScrutinType } from "@/generated/prisma";
 import type { Prisma } from "@/generated/prisma";
+import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 
 export const revalidate = 3600;
 
@@ -30,23 +31,22 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: Promise<{ theme: string }>;
-  searchParams: Promise<{ type?: string }>;
+  searchParams: Promise<{ type?: string; page?: string }>;
 }): Promise<Metadata> {
   const { theme: slug } = await params;
-  const { type: typeTab } = await searchParams;
+  const sp = await searchParams;
   const theme = themeFromSlug(slug);
   if (!theme) return { title: "Thème introuvable" };
 
   const label = THEME_CATEGORY_LABELS[theme];
-  const canonical =
-    typeTab && typeTab !== "votes"
-      ? `/parlement/votes/themes/${slug}?type=${typeTab}`
-      : `/parlement/votes/themes/${slug}`;
 
   return {
     title: `Votes ${label}`,
     description: `Tous les scrutins parlementaires sur le thème ${label}. Résultats des votes de l'Assemblée nationale et du Sénat.`,
-    alternates: { canonical },
+    // Tab/paginated variants: noindex,follow, canonical consolidates on the
+    // bare theme page (which stays indexable).
+    ...listingRobotsMetadata(hasActiveListingFilter(sp, ["type"])),
+    alternates: { canonical: `/parlement/votes/themes/${slug}` },
   };
 }
 

--- a/src/app/partis/page.tsx
+++ b/src/app/partis/page.tsx
@@ -9,17 +9,12 @@ import { SeoIntro } from "@/components/seo/SeoIntro";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { SITE_URL } from "@/config/site";
 import { getParties, getPartiesStats } from "@/lib/data/partis";
+import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 import type { SortOption, StatusFilter } from "@/lib/data/partis";
 import type { PoliticalPosition } from "@/types";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 
 export const revalidate = 300; // 5 minutes, cohérent avec l'API
-
-export const metadata: Metadata = {
-  title: "Partis politiques",
-  description: "Liste des partis politiques français avec leurs membres et historique",
-  alternates: { canonical: "/partis" },
-};
 
 interface PageProps {
   searchParams: Promise<{
@@ -28,6 +23,19 @@ interface PageProps {
     status?: string;
     sort?: string;
   }>;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const params = await searchParams;
+  return {
+    title: "Partis politiques",
+    description: "Liste des partis politiques français avec leurs membres et historique",
+    // Filtered variants: noindex,follow, canonical consolidates on the bare listing.
+    ...listingRobotsMetadata(
+      hasActiveListingFilter(params, ["search", "position", "status", "sort"])
+    ),
+    alternates: { canonical: "/partis" },
+  };
 }
 
 export default async function PartiesPage({ searchParams }: PageProps) {

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -35,6 +35,7 @@ import {
   voteStatsService,
 } from "@/services/voteStats";
 import { getPolitician } from "@/lib/data/politicians";
+import { politicianRobotsMetadata } from "@/lib/seo/politician-robots";
 import { FollowButton } from "@/components/politicians/FollowButton";
 import { CopyableId } from "@/components/politicians/CopyableId";
 import { SITE_URL } from "@/config/site";
@@ -129,9 +130,22 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const description = `${role} ${politician.currentParty ? `(${politician.currentParty.shortName})` : ""} - Consultez ses mandats, déclarations d'intérêts et affaires judiciaires.${hatvpDescription}`;
 
+  // Bare profiles (RNE-imported mayors with no content) get noindex,follow (issue #385).
+  const robots = politicianRobotsMetadata({
+    mandates: politician.mandates.map((m) => ({
+      type: m.type,
+      communePopulation: m.localData?.commune?.population ?? null,
+    })),
+    publishedAffairsCount: politician.affairs.length,
+    factCheckMentionsCount: politician.factCheckMentions.length,
+    declarationsCount: politician.declarations.length,
+    biography: politician.biography,
+  });
+
   return {
     title: politician.fullName,
     description,
+    ...robots,
     alternates: { canonical: `/politiques/${slug}` },
     openGraph: {
       title: `${politician.fullName} | Poligraph`,

--- a/src/app/presse/page.tsx
+++ b/src/app/presse/page.tsx
@@ -9,15 +9,9 @@ import { ensureContrast } from "@/lib/contrast";
 import { isFeatureEnabled } from "@/lib/feature-flags";
 import { getPress, getPressStats, getPartiesWithPressMentions } from "@/lib/data/press";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 
 export const revalidate = 300; // ISR: re-check feature flag every 5 minutes
-
-export const metadata: Metadata = {
-  title: "Revue de presse",
-  description:
-    "Suivez l'actualité politique française. Articles du Monde, Politico et Mediapart mentionnant les responsables politiques.",
-  alternates: { canonical: "/presse" },
-};
 
 interface PageProps {
   searchParams: Promise<{
@@ -27,6 +21,18 @@ interface PageProps {
     search?: string;
     sort?: string;
   }>;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const params = await searchParams;
+  return {
+    title: "Revue de presse",
+    description:
+      "Suivez l'actualité politique française. Articles du Monde, Politico et Mediapart mentionnant les responsables politiques.",
+    // Filtered/paginated variants: noindex,follow, canonical consolidates on the bare listing.
+    ...listingRobotsMetadata(hasActiveListingFilter(params, ["search", "source", "party", "sort"])),
+    alternates: { canonical: "/presse" },
+  };
 }
 
 const SOURCE_OPTIONS = [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,15 @@
 import { MetadataRoute } from "next";
+import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { DEPARTMENTS, getDepartmentSlug } from "@/config/departments";
 import { getAllThemeSlugs } from "@/lib/theme-utils";
 import { SITE_URL } from "@/config/site";
 import { getWeekStart, getISOWeekString } from "@/lib/data/recap";
+import {
+  SIGNIFICANT_MANDATE_TYPES,
+  MAIRE_MIN_COMMUNE_POPULATION,
+  MIN_BIOGRAPHY_LENGTH,
+} from "@/lib/seo/politician-robots";
 
 export async function generateSitemaps() {
   return [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
@@ -29,13 +35,47 @@ export default async function sitemap(props: {
   }
 }
 
-// Sitemap 0: Static pages + PUBLISHED politicians (priority 0.8-1.0)
+// Sitemap 0: Static pages + rich PUBLISHED politicians (priority 0.8-1.0).
+// Bare profiles (RNE-imported mayors: no significant mandate, no affair, no
+// fact-check, no declaration, no bio) are excluded to fight index bloat
+// (issue #385). This SQL mirrors isIndexablePolitician() from
+// src/lib/seo/politician-robots.ts — keep both in sync.
 async function buildStaticAndPoliticiansSitemap(): Promise<MetadataRoute.Sitemap> {
-  const politicians = await db.politician.findMany({
-    where: { publicationStatus: "PUBLISHED" },
-    select: { slug: true, updatedAt: true },
-    orderBy: { updatedAt: "desc" },
-  });
+  const politicians = await db.$queryRaw<Array<{ slug: string; updatedAt: Date }>>(Prisma.sql`
+    SELECT p."slug", p."updatedAt"
+    FROM "Politician" p
+    WHERE p."publicationStatus" = 'PUBLISHED'
+      AND (
+        EXISTS (
+          SELECT 1 FROM "Mandate" m
+          WHERE m."politicianId" = p."id"
+            AND m."type"::text IN (${Prisma.join([...SIGNIFICANT_MANDATE_TYPES])})
+        )
+        OR EXISTS (
+          -- LEFT JOINs: a MAIRE mandate without commune link (or without
+          -- population) is fail-open, like isIndexablePolitician().
+          SELECT 1 FROM "Mandate" m
+          LEFT JOIN "MandateLocal" ml ON ml."mandateId" = m."id"
+          LEFT JOIN "Commune" c ON c."id" = ml."communeId"
+          WHERE m."politicianId" = p."id"
+            AND m."type" = 'MAIRE'
+            AND (c."population" IS NULL OR c."population" >= ${MAIRE_MIN_COMMUNE_POPULATION})
+        )
+        OR EXISTS (
+          SELECT 1 FROM "Affair" a
+          WHERE a."politicianId" = p."id" AND a."publicationStatus" = 'PUBLISHED'
+        )
+        OR EXISTS (
+          SELECT 1 FROM "FactCheckMention" f WHERE f."politicianId" = p."id"
+        )
+        OR EXISTS (
+          SELECT 1 FROM "Declaration" d WHERE d."politicianId" = p."id"
+        )
+        OR (p."biography" IS NOT NULL
+            AND length(btrim(p."biography", E' \t\n\r')) >= ${MIN_BIOGRAPHY_LENGTH})
+      )
+    ORDER BY p."updatedAt" DESC
+  `);
 
   const staticPages: MetadataRoute.Sitemap = [
     {

--- a/src/lib/data/politicians.ts
+++ b/src/lib/data/politicians.ts
@@ -21,6 +21,12 @@ export const getPolitician = cache(async function getPolitician(slug: string) {
               },
             },
           },
+          // Commune population feeds the SEO richness predicate (politician-robots).
+          localData: {
+            select: {
+              commune: { select: { population: true } },
+            },
+          },
         },
       },
       affairs: {

--- a/src/lib/seo/__tests__/commune-robots.test.ts
+++ b/src/lib/seo/__tests__/commune-robots.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  isIndexableCommune,
+  communeRobotsMetadata,
+  COMMUNE_MIN_POPULATION,
+} from "../commune-robots";
+
+const NOINDEX = { robots: { index: false, follow: true } };
+
+describe("isIndexableCommune", () => {
+  it("population at threshold -> indexable", () => {
+    expect(isIndexableCommune(COMMUNE_MIN_POPULATION)).toBe(true);
+  });
+
+  it("population just below threshold -> NOT indexable", () => {
+    expect(isIndexableCommune(COMMUNE_MIN_POPULATION - 1)).toBe(false);
+  });
+
+  it("large commune -> indexable", () => {
+    expect(isIndexableCommune(150_000)).toBe(true);
+  });
+
+  it("tiny commune -> NOT indexable", () => {
+    expect(isIndexableCommune(120)).toBe(false);
+  });
+
+  it("population 0 -> NOT indexable", () => {
+    expect(isIndexableCommune(0)).toBe(false);
+  });
+
+  it("null population -> indexable (fail-open on missing data)", () => {
+    expect(isIndexableCommune(null)).toBe(true);
+  });
+
+  it("undefined population -> indexable (fail-open)", () => {
+    expect(isIndexableCommune(undefined)).toBe(true);
+  });
+});
+
+describe("communeRobotsMetadata", () => {
+  it("indexable commune -> {} (inherits index:true)", () => {
+    expect(communeRobotsMetadata(COMMUNE_MIN_POPULATION)).toEqual({});
+  });
+
+  it("thin commune -> noindex,follow", () => {
+    expect(communeRobotsMetadata(500)).toEqual(NOINDEX);
+  });
+});

--- a/src/lib/seo/__tests__/politician-robots.test.ts
+++ b/src/lib/seo/__tests__/politician-robots.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  isIndexablePolitician,
+  politicianRobotsMetadata,
+  SIGNIFICANT_MANDATE_TYPES,
+  MAIRE_MIN_COMMUNE_POPULATION,
+  MIN_BIOGRAPHY_LENGTH,
+  type PoliticianIndexSignals,
+} from "../politician-robots";
+
+const NOINDEX = { robots: { index: false, follow: true } };
+
+function signals(overrides: Partial<PoliticianIndexSignals> = {}): PoliticianIndexSignals {
+  return {
+    mandates: [],
+    publishedAffairsCount: 0,
+    factCheckMentionsCount: 0,
+    declarationsCount: 0,
+    biography: null,
+    ...overrides,
+  };
+}
+
+describe("isIndexablePolitician", () => {
+  it.each([...SIGNIFICANT_MANDATE_TYPES])(
+    "mandate '%s' alone -> indexable (even without any other signal)",
+    (type) => {
+      expect(isIndexablePolitician(signals({ mandates: [{ type }] }))).toBe(true);
+    }
+  );
+
+  it("bare RNE-imported maire (small commune, no other signal) -> NOT indexable", () => {
+    expect(
+      isIndexablePolitician(signals({ mandates: [{ type: "MAIRE", communePopulation: 800 }] }))
+    ).toBe(false);
+  });
+
+  it("maire of a large commune (>= threshold) -> indexable", () => {
+    expect(
+      isIndexablePolitician(
+        signals({
+          mandates: [{ type: "MAIRE", communePopulation: MAIRE_MIN_COMMUNE_POPULATION }],
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("maire just below the population threshold -> NOT indexable", () => {
+    expect(
+      isIndexablePolitician(
+        signals({
+          mandates: [{ type: "MAIRE", communePopulation: MAIRE_MIN_COMMUNE_POPULATION - 1 }],
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("maire with unknown commune population -> indexable (fail-open on missing data)", () => {
+    expect(
+      isIndexablePolitician(signals({ mandates: [{ type: "MAIRE", communePopulation: null }] }))
+    ).toBe(true);
+    expect(isIndexablePolitician(signals({ mandates: [{ type: "MAIRE" }] }))).toBe(true);
+  });
+
+  it.each(["ADJOINT_MAIRE", "CONSEILLER_MUNICIPAL", "CONSEILLER_DEPARTEMENTAL", "OTHER"])(
+    "non-significant mandate '%s' alone -> NOT indexable",
+    (type) => {
+      expect(isIndexablePolitician(signals({ mandates: [{ type }] }))).toBe(false);
+    }
+  );
+
+  it("published affair -> indexable", () => {
+    expect(isIndexablePolitician(signals({ publishedAffairsCount: 1 }))).toBe(true);
+  });
+
+  it("fact-check mention -> indexable", () => {
+    expect(isIndexablePolitician(signals({ factCheckMentionsCount: 1 }))).toBe(true);
+  });
+
+  it("HATVP declaration -> indexable", () => {
+    expect(isIndexablePolitician(signals({ declarationsCount: 1 }))).toBe(true);
+  });
+
+  it(`biography >= ${MIN_BIOGRAPHY_LENGTH} chars -> indexable`, () => {
+    expect(isIndexablePolitician(signals({ biography: "x".repeat(MIN_BIOGRAPHY_LENGTH) }))).toBe(
+      true
+    );
+  });
+
+  it("short biography -> NOT indexable", () => {
+    expect(
+      isIndexablePolitician(signals({ biography: "x".repeat(MIN_BIOGRAPHY_LENGTH - 1) }))
+    ).toBe(false);
+  });
+
+  it("whitespace-padded short biography -> NOT indexable (trimmed)", () => {
+    const padded = `  ${"x".repeat(MIN_BIOGRAPHY_LENGTH - 10)}  `.padEnd(
+      MIN_BIOGRAPHY_LENGTH + 20,
+      " "
+    );
+    expect(isIndexablePolitician(signals({ biography: padded }))).toBe(false);
+  });
+
+  it("zero signals -> NOT indexable", () => {
+    expect(isIndexablePolitician(signals())).toBe(false);
+  });
+
+  it("mixed: small-commune maire WITH a published affair -> indexable", () => {
+    expect(
+      isIndexablePolitician(
+        signals({
+          mandates: [{ type: "MAIRE", communePopulation: 300 }],
+          publishedAffairsCount: 1,
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe("politicianRobotsMetadata", () => {
+  it("rich profile -> {} (inherits index:true)", () => {
+    expect(politicianRobotsMetadata(signals({ mandates: [{ type: "DEPUTE" }] }))).toEqual({});
+  });
+
+  it("bare profile -> noindex,follow", () => {
+    expect(politicianRobotsMetadata(signals())).toEqual(NOINDEX);
+  });
+});

--- a/src/lib/seo/commune-robots.ts
+++ b/src/lib/seo/commune-robots.ts
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+
+const NOINDEX_FOLLOW = { index: false, follow: true } as const;
+
+/**
+ * Communes below this population get noindex,follow on their municipales-2026
+ * page: under 1000 inhabitants the ballot is panachage (no structured lists),
+ * so the page is a bare candidate roster Google refuses to index (issue #385).
+ * At 1000+ the list-based ballot produces real content (~10k communes).
+ */
+export const COMMUNE_MIN_POPULATION = 1_000;
+
+/**
+ * Unknown population stays indexable (fail-open): never deindex a real page
+ * because of missing data. Only 6 communes have a null population in prod.
+ */
+export function isIndexableCommune(population: number | null | undefined): boolean {
+  if (population == null) return true;
+  return population >= COMMUNE_MIN_POPULATION;
+}
+
+/**
+ * `robots` metadata fragment for a municipales-2026 commune page: {} for
+ * communes with list-based elections, noindex,follow for thin ones.
+ */
+export function communeRobotsMetadata(
+  population: number | null | undefined
+): Pick<Metadata, "robots"> {
+  return isIndexableCommune(population) ? {} : { robots: NOINDEX_FOLLOW };
+}

--- a/src/lib/seo/politician-robots.ts
+++ b/src/lib/seo/politician-robots.ts
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+
+const NOINDEX_FOLLOW = { index: false, follow: true } as const;
+
+/**
+ * Mandate types that make a politician profile indexable on their own:
+ * national/European/government offices and executive heads. Local mandates
+ * (MAIRE, conseillers...) are NOT sufficient by themselves: ~34k RNE-imported
+ * mayors have a bare profile (no bio, no affair, no vote) that Google refuses
+ * to index ("Explorée, actuellement non indexée", issue #385).
+ */
+export const SIGNIFICANT_MANDATE_TYPES = [
+  "DEPUTE",
+  "SENATEUR",
+  "DEPUTE_EUROPEEN",
+  "PRESIDENT_REPUBLIQUE",
+  "PREMIER_MINISTRE",
+  "MINISTRE",
+  "MINISTRE_DELEGUE",
+  "SECRETAIRE_ETAT",
+  "PRESIDENT_REGION",
+  "PRESIDENT_DEPARTEMENT",
+  "PRESIDENT_PARTI",
+] as const;
+
+/** Mayors of communes at or above this population stay indexable (real nominative search demand). */
+export const MAIRE_MIN_COMMUNE_POPULATION = 10_000;
+
+/** Minimum trimmed biography length to count as real editorial content. */
+export const MIN_BIOGRAPHY_LENGTH = 50;
+
+const SIGNIFICANT_SET: ReadonlySet<string> = new Set(SIGNIFICANT_MANDATE_TYPES);
+
+export interface PoliticianIndexSignals {
+  mandates: ReadonlyArray<{ type: string; communePopulation?: number | null }>;
+  publishedAffairsCount: number;
+  factCheckMentionsCount: number;
+  declarationsCount: number;
+  biography: string | null;
+}
+
+/**
+ * True when the profile carries at least one real content signal.
+ * Mirrors the SQL filter of the politicians sitemap (src/app/sitemap.ts,
+ * buildStaticAndPoliticiansSitemap) — keep both in sync.
+ */
+export function isIndexablePolitician(signals: PoliticianIndexSignals): boolean {
+  // MAIRE with unknown commune population (missing MandateLocal/commune link,
+  // ~36 mandates in prod) is fail-open: never deindex a real mayor because of
+  // a data gap. Same philosophy as commune-robots.
+  const hasSignificantMandate = signals.mandates.some(
+    (m) =>
+      SIGNIFICANT_SET.has(m.type) ||
+      (m.type === "MAIRE" &&
+        (m.communePopulation == null || m.communePopulation >= MAIRE_MIN_COMMUNE_POPULATION))
+  );
+  return (
+    hasSignificantMandate ||
+    signals.publishedAffairsCount > 0 ||
+    signals.factCheckMentionsCount > 0 ||
+    signals.declarationsCount > 0 ||
+    (signals.biography ?? "").trim().length >= MIN_BIOGRAPHY_LENGTH
+  );
+}
+
+/**
+ * `robots` metadata fragment for a politician profile: {} for rich profiles
+ * (inherits the site default index:true), noindex,follow for bare ones.
+ * Spread into the page's generateMetadata return.
+ */
+export function politicianRobotsMetadata(
+  signals: PoliticianIndexSignals
+): Pick<Metadata, "robots"> {
+  return isIndexablePolitician(signals) ? {} : { robots: NOINDEX_FOLLOW };
+}


### PR DESCRIPTION
## Résumé

Search Console remonte un fort index bloat : une large majorité des pages soumises restent « explorées, actuellement non indexées ». La cause principale est le sitemap, qui listait toutes les fiches politiques publiées (~35 000), dont des dizaines de milliers de fiches maires importées du RNE réduites à un nom et une commune. Google les explore puis refuse de les indexer.

Cette PR réduit les surfaces fines envoyées à Google, sans rien supprimer en base. Elle met en œuvre les étapes 1 et 2 de #385.

## Changements SEO

- **Sitemap des fiches politiques filtré par un prédicat de richesse** (~35 000 → ~2 250 fiches). Un helper pur (`src/lib/seo/politician-robots.ts`) et la requête du sitemap partagent exactement le même critère.
- **`noindex,follow` sur les fiches politiques pauvres** (maires importés sans autre contenu).
- **`noindex,follow` sur les pages communes municipales 2026 de moins de 1 000 habitants**.
- **`noindex,follow` sur 7 listings filtrés ou paginés** qui n'avaient pas encore de directive robots : dossiers, partis, presse, déclarations, maires, fact-checks, thèmes de votes.
- Un retry sur une étape du sync quotidien qui échouait ponctuellement sur une erreur transitoire (#442).

## Risque SEO accepté

Environ 33 000 fiches politiques sortent du sitemap et passent en `noindex`. Ce sont des fiches sans contenu réel, que Google refusait déjà d'indexer. Rien n'est supprimé : le comportement est piloté par les métadonnées `robots` et par deux constantes de seuil, et reste réversible sans perte de ranking.

**Une fiche politique est indexable si elle a au moins un signal :**

- un mandat national ou exécutif (député, sénateur, député européen, membre du gouvernement, président de région ou de département, président de parti) ;
- ou maire d'une commune de 10 000 habitants ou plus ;
- ou une affaire judiciaire publiée, un fact-check, ou une déclaration HATVP ;
- ou une biographie d'au moins 50 caractères.

Fail-open : si une donnée manque (lien commune absent, population inconnue), la page reste indexable.

**Communes municipales 2026** : `noindex` sous 1 000 habitants (scrutin au panachage, page réduite à une liste de candidats), indexable au-dessus.

**Surfaces préservées** (restent indexables) : `/statistiques`, `/affaires/condamnations` et ses facettes, `/affaires` et `/affaires/parti/[slug]`, `/politiques`, `/factchecks?politician=` résolu, les hubs de listing, et toute fiche politique riche.

**Canonical** : les fiches individuelles passées en `noindex` conservent un canonical self, ce qui est conforme à la convention déjà en place pour les pages fines (un self-canonical combiné à un noindex n'est pas contradictoire). Seuls les listings filtrés consolident sur leur version nue.

## Tests

- tests unitaires sur les helpers (seuils, fail-open, cas limites) ;
- suite complète verte ;
- typecheck, lint et build OK ;
- cas limites couverts : slug `?politician=` non résolu, cohérence du critère entre le sitemap et le robots des fiches.

## Issues

Addresses #385
Fixes #442
