### PR TITLE
fix(factchecks): trier la liste par date de publication

### DIFF
--- a/src/components/factchecks/FactCheckCard.tsx
+++ b/src/components/factchecks/FactCheckCard.tsx
@@ -80,7 +80,7 @@ export function FactCheckCard({
       </p>
 
       {/* Date */}
-      <p className="text-xs text-muted-foreground mt-2">{formatDate(publishedAt)}</p>
+      <p className="text-xs text-muted-foreground mt-2">Vérifié le {formatDate(publishedAt)}</p>
 
       {/* Politicians mentioned */}
       {mentions.length > 0 && (

--- a/src/lib/data/factchecks.ts
+++ b/src/lib/data/factchecks.ts
@@ -136,7 +136,10 @@ async function queryFactchecks(params: {
   const [factChecks, total] = await Promise.all([
     db.factCheck.findMany({
       where,
-      orderBy: { createdAt: "desc" },
+      // Sort by the source's publication date so visitors see the most
+      // recently published fact-checks first. createdAt is only a tie-breaker
+      // for stable pagination when several share the same publication day.
+      orderBy: [{ publishedAt: "desc" }, { createdAt: "desc" }],
       skip,
       take: limit,
       include: {


### PR DESCRIPTION
## Problème

La liste `/factchecks` était triée par date d'ingestion (`createdAt`), pas par date de publication. Or 88 % des fact-checks (724/824) sont ajoutés plus de 180 jours après leur parution, l'API Google les remontant tard. L'ordre affiché n'avait donc aucun rapport avec les dates visibles : un fact-check publié le 16 janvier 2024 mais ingéré récemment se retrouvait en tête de page.

## Changement

- Tri par `publishedAt` desc, avec `createdAt` en départage pour une pagination stable (beaucoup de fact-checks partagent la même date au jour près).
- Libellé « Vérifié le » sur la carte, pour clarifier que la date affichée est celle de la vérification, pas de la déclaration.

## Vérifications

- `publishedAt` est fiable : 0 fallback sur les 824 fact-checks publiés, chaque ligne porte une vraie `reviewDate` de sa source. Trier dessus ne fait pas remonter de dates d'ingestion déguisées.
- Périmètre limité à `/factchecks` (liste + vue filtrée par politique) ; les listes admin ont leurs propres requêtes.
- Index `@@index([publishedAt])` déjà présent, coût perf nul.
- typecheck et lint OK.
